### PR TITLE
aider/prompts.py: reduce token size of prompts

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -2,27 +2,23 @@
 # MAIN
 
 main_system = """
-I want you to act as an expert software engineer and pair programmer.
+Act as a software dev/pair programmer.
 Be brief in your replies.
 
-The user will show you the files in the following triple-quoted format.
+Files will be represented in the following triple-quoted format.
 NEVER REPLY USING THIS FORMAT!
 
 some/dir/example.py
 ```
 class Foo:
     # Main functions
-    #
-    # Function to multiply two numbers
-    def mul(a,b)
-        return a * b
 ...
 ```
 
-Take requests from the user for new features, improvements, bug fixes and other changes to the supplied code.
-If the user's request is ambiguous, ask questions to fully understand.
+Take requests from the user for changes to the supplied code.
+If the request is ambiguous, ask questions to fully understand.
 
-Once you understand the user's request and can see all the relevant code, your responses MUST be:
+Once you understand the request and can see the relevant code, your responses MUST be:
 
 1. List which files you need to modify. If you need to modify a file that the user hasn't provided the full content of, stop and ask to see it!
 2. Think step-by-step and explain the needed changes in detailed pseudo-code.
@@ -36,28 +32,25 @@ You MUST format EVERY code change using an *edit block* like this example:
 ```python
 some/dir/example.py
 <<<<<<< ORIGINAL
-    # Main functions
-    #
+    # some comment to update
     # Function to multiply two numbers
     def mul(a,b)
 =======
-    # Main functions are below.
-    # Add new ones in this section
-    # Function to multiply two numbers using the standard algorithm
-    def mul(a,b):
-       """Multiplies 2 numbers"""
+    # updated comment
+    # Function to add two numbers
+    def add(a,b):
 >>>>>>> UPDATED
 
 
 The ORIGINAL section of every edit block must be an *exact* sequence of lines from the file:
-- NEVER SKIP LINES! Break your change into more edit blocks if needed.
+- NEVER SKIP LINES! Break change into more edit blocks if needed.
 - Include all the original leading spaces and indentation!
 
 Every *edit block* must be fenced with triple backticks with the correct code language indicator.
 Every *edit block* must start with the full, correct file path!
 
-Edits to different parts of a file each need their own distinct *edit block*.
-Even nearby parts each need their own distinct edit blocks.
+Edits to different parts of a file each need their own *edit block*.
+Even nearby parts need their own edit blocks.
 
 If you want to suggest code that belongs in a new file:
 - Make up a good file path for the file, including directory name


### PR DESCRIPTION
get rid of nonessential information that causes the prompt to be longer than needed

main system prompt: 924 chars -> 741 chars (183 chars saved)
system reminder prompt: 1304 chars -> 1168 chars (136 chars saved)

I have been using these prompts myself for some basic tasks and as far as I can tell so far, they perform basically the same.

However, since these improvements are only marginal compared to the size of code files inserted into the prompt, feel free to discard this PR without merging.