### PR TITLE
Add program argument for syntax highlighting theme.

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -111,6 +111,7 @@ class Coder:
         map_tokens=1024,
         verbose=False,
         assistant_output_color="blue",
+        code_theme="default",
         stream=True,
         use_git=True,
     ):
@@ -135,6 +136,7 @@ class Coder:
         self.auto_commits = auto_commits
         self.dirty_commits = dirty_commits
         self.assistant_output_color = assistant_output_color
+        self.code_theme = code_theme
 
         self.dry_run = dry_run
         self.pretty = pretty
@@ -679,7 +681,7 @@ class Coder:
 
         show_resp = self.render_incremental_response(True)
         if self.pretty:
-            show_resp = Markdown(show_resp, style=self.assistant_output_color, code_theme="default")
+            show_resp = Markdown(show_resp, style=self.assistant_output_color, code_theme=self.code_theme)
         else:
             show_resp = Text(show_resp or "<no response>")
 
@@ -735,7 +737,7 @@ class Coder:
         if not show_resp:
             return
 
-        md = Markdown(show_resp, style=self.assistant_output_color, code_theme="default")
+        md = Markdown(show_resp, style=self.assistant_output_color, code_theme=self.code_theme)
         live.update(md)
 
     def render_incremental_response(self, final):

--- a/aider/main.py
+++ b/aider/main.py
@@ -146,6 +146,11 @@ def main(args=None, input=None, output=None):
         help="Set the color for assistant output (default: blue)",
     )
     parser.add_argument(
+        "--code-theme",
+        default="default",
+        help="Set the markdown code theme (default: default, other options include monokai, solarized-dark, solarized-light)",
+    )
+    parser.add_argument(
         "--apply",
         metavar="FILE",
         help="Apply the changes from the given file instead of running the chat (debug)",
@@ -272,6 +277,7 @@ def main(args=None, input=None, output=None):
         map_tokens=args.map_tokens,
         verbose=args.verbose,
         assistant_output_color=args.assistant_output_color,
+        code_theme=args.code_theme,
         stream=args.stream,
         use_git=args.git,
     )


### PR DESCRIPTION
The source code output in the chat will be colored in the given color scheme.

![image](https://github.com/paul-gauthier/aider/assets/6737928/3a8084c1-a4b2-4b24-8337-0db333ffa0c9)


Syntax highlighting is powered by pygments, which supports many styles out of the box. For example:

- default (the default)
- dracula
- emacs
- github-dark
- monokai
- vim
- solarized-dark
- solarized-light

See https://pygments.org/styles/