### PR TITLE
Use an explicit encoding to read/write text files, utf-8 by default

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -290,9 +290,10 @@ class Coder:
     def get_abs_fnames_content(self):
         for fname in list(self.abs_fnames):
             content = self.io.read_text(fname)
+            dump(fname, content)
             if content is None:
                 relative_fname = self.get_rel_fname(fname)
-                self.tool_error(f"Dropping {relative_fname} from the chat.")
+                self.io.tool_error(f"Dropping {relative_fname} from the chat.")
                 self.abs_fnames.remove(fname)
             else:
                 yield fname, content

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -924,7 +924,7 @@ class Coder:
 
         if full_path in self.abs_fnames:
             if not self.dry_run and write_content:
-                Path(full_path).write_text(write_content)
+                self.io.write_text(full_path, write_content)
             return full_path
 
         if not Path(full_path).exists():
@@ -950,7 +950,7 @@ class Coder:
                     self.repo.git.add(full_path)
 
         if not self.dry_run and write_content:
-            Path(full_path).write_text(write_content)
+            self.io.write_text(full_path, write_content)
 
         return full_path
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -167,13 +167,13 @@ class Coder:
             self.find_common_root()
 
         if main_model.use_repo_map and self.repo and self.gpt_prompts.repo_content_prefix:
-            rm_io = io if self.verbose else None
             self.repo_map = RepoMap(
                 map_tokens,
                 self.root,
                 self.main_model,
-                rm_io,
+                io,
                 self.gpt_prompts.repo_content_prefix,
+                self.verbose,
             )
 
             if self.repo_map.use_ctags:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -290,7 +290,7 @@ class Coder:
     def get_abs_fnames_content(self):
         for fname in list(self.abs_fnames):
             content = self.io.read_text(fname)
-            dump(fname, content)
+
             if content is None:
                 relative_fname = self.get_rel_fname(fname)
                 self.io.tool_error(f"Dropping {relative_fname} from the chat.")
@@ -302,8 +302,6 @@ class Coder:
         all_content = ""
         for _fname, content in self.get_abs_fnames_content():
             all_content += content + "\n"
-
-        all_content = all_content.splitlines()
 
         good = False
         for fence_open, fence_close in self.fences:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -923,7 +923,7 @@ class Coder:
         full_path = os.path.abspath(os.path.join(self.root, path))
 
         if full_path in self.abs_fnames:
-            if not self.dry_run and write_content:
+            if write_content:
                 self.io.write_text(full_path, write_content)
             return full_path
 
@@ -949,7 +949,7 @@ class Coder:
                 if not self.dry_run:
                     self.repo.git.add(full_path)
 
-        if not self.dry_run and write_content:
+        if write_content:
             self.io.write_text(full_path, write_content)
 
         return full_path

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -337,11 +337,6 @@ class Coder:
 
         return prompt
 
-    def recheck_abs_fnames(self):
-        self.abs_fnames = set(
-            fname for fname in self.abs_fnames if Path(fname).exists() and Path(fname).is_file()
-        )
-
     def get_files_messages(self):
         all_content = ""
         if self.abs_fnames:
@@ -469,10 +464,6 @@ class Coder:
         ]
 
         messages += self.done_messages
-
-        # notice if files disappear
-        self.recheck_abs_fnames()
-
         messages += self.get_files_messages()
         messages += self.cur_messages
 

--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -27,7 +27,10 @@ class EditBlockCoder(Coder):
             if not full_path:
                 continue
             content = self.io.read_text(full_path)
-            if do_replace(full_path, content, original, updated, self.dry_run):
+            content = do_replace(full_path, content, original, updated)
+            if content:
+                if not self.dry_run:
+                    self.io.write_text(full_path, content)
                 edited.add(path)
                 continue
             self.io.tool_error(f"Failed to apply edit to {path}")
@@ -212,7 +215,7 @@ def strip_quoted_wrapping(res, fname=None):
     return res
 
 
-def do_replace(fname, content, before_text, after_text, dry_run=False):
+def do_replace(fname, content, before_text, after_text):
     before_text = strip_quoted_wrapping(before_text, fname)
     after_text = strip_quoted_wrapping(after_text, fname)
     fname = Path(fname)
@@ -230,13 +233,8 @@ def do_replace(fname, content, before_text, after_text, dry_run=False):
         new_content = content + after_text
     else:
         new_content = replace_most_similar_chunk(content, before_text, after_text)
-        if not new_content:
-            return
 
-    if not dry_run:
-        fname.write_text(new_content)
-
-    return True
+    return new_content
 
 
 ORIGINAL = "<<<<<<< ORIGINAL"

--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -35,33 +35,6 @@ class EditBlockCoder(Coder):
         return edited
 
 
-def do_replace(fname, content, before_text, after_text, dry_run=False):
-    before_text = strip_quoted_wrapping(before_text, fname)
-    after_text = strip_quoted_wrapping(after_text, fname)
-    fname = Path(fname)
-
-    # does it want to make a new file?
-    if not fname.exists() and not before_text.strip():
-        fname.touch()
-        content = ""
-
-    if content is None:
-        return
-
-    if not before_text.strip():
-        # append to existing file, or start a new file
-        new_content = content + after_text
-    else:
-        new_content = replace_most_similar_chunk(content, before_text, after_text)
-        if not new_content:
-            return
-
-    if not dry_run:
-        fname.write_text(new_content)
-
-    return True
-
-
 def try_dotdotdots(whole, part, replace):
     """
     See if the edit block has ... lines.
@@ -237,6 +210,33 @@ def strip_quoted_wrapping(res, fname=None):
         res += "\n"
 
     return res
+
+
+def do_replace(fname, content, before_text, after_text, dry_run=False):
+    before_text = strip_quoted_wrapping(before_text, fname)
+    after_text = strip_quoted_wrapping(after_text, fname)
+    fname = Path(fname)
+
+    # does it want to make a new file?
+    if not fname.exists() and not before_text.strip():
+        fname.touch()
+        content = ""
+
+    if content is None:
+        return
+
+    if not before_text.strip():
+        # append to existing file, or start a new file
+        new_content = content + after_text
+    else:
+        new_content = replace_most_similar_chunk(content, before_text, after_text)
+        if not new_content:
+            return
+
+    if not dry_run:
+        fname.write_text(new_content)
+
+    return True
 
 
 ORIGINAL = "<<<<<<< ORIGINAL"

--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -29,8 +29,7 @@ class EditBlockCoder(Coder):
             content = self.io.read_text(full_path)
             content = do_replace(full_path, content, original, updated)
             if content:
-                if not self.dry_run:
-                    self.io.write_text(full_path, content)
+                self.io.write_text(full_path, content)
                 edited.add(path)
                 continue
             self.io.tool_error(f"Failed to apply edit to {path}")

--- a/aider/coders/editblock_func_coder.py
+++ b/aider/coders/editblock_func_coder.py
@@ -136,7 +136,10 @@ class EditBlockFunctionCoder(Coder):
             if not full_path:
                 continue
             content = self.io.read_text(full_path)
-            if do_replace(full_path, content, original, updated, self.dry_run):
+            content = do_replace(full_path, content, original, updated)
+            if content:
+                if not self.dry_run:
+                    self.io.write_text(full_path, content)
                 edited.add(path)
                 continue
             self.io.tool_error(f"Failed to apply edit to {path}")

--- a/aider/coders/editblock_func_coder.py
+++ b/aider/coders/editblock_func_coder.py
@@ -135,7 +135,8 @@ class EditBlockFunctionCoder(Coder):
             full_path = self.allowed_to_edit(path)
             if not full_path:
                 continue
-            if do_replace(full_path, original, updated, self.dry_run):
+            content = self.io.read_text(full_path)
+            if do_replace(full_path, content, original, updated, self.dry_run):
                 edited.add(path)
                 continue
             self.io.tool_error(f"Failed to apply edit to {path}")

--- a/aider/coders/editblock_func_coder.py
+++ b/aider/coders/editblock_func_coder.py
@@ -138,8 +138,7 @@ class EditBlockFunctionCoder(Coder):
             content = self.io.read_text(full_path)
             content = do_replace(full_path, content, original, updated)
             if content:
-                if not self.dry_run:
-                    self.io.write_text(full_path, content)
+                self.io.write_text(full_path, content)
                 edited.add(path)
                 continue
             self.io.tool_error(f"Failed to apply edit to {path}")

--- a/aider/coders/single_wholefile_func_coder.py
+++ b/aider/coders/single_wholefile_func_coder.py
@@ -90,8 +90,11 @@ class SingleWholeFileFunctionCoder(Coder):
         # ending an existing block
         full_path = os.path.abspath(os.path.join(self.root, fname))
 
-        with open(full_path, "r") as f:
-            orig_lines = f.readlines()
+        content = self.io.read_text(full_path)
+        if content is None:
+            orig_lines = []
+        else:
+            orig_lines = content.splitlines()
 
         show_diff = diffs.diff_partial_update(
             orig_lines,

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -66,7 +66,7 @@ class WholeFileCoder(Coder):
                             edited.add(fname)
                             if not self.dry_run:
                                 new_lines = "".join(new_lines)
-                                full_path.write_text(new_lines)
+                                self.io.write_text(full_path, new_lines)
 
                     fname = None
                     new_lines = []
@@ -125,6 +125,6 @@ class WholeFileCoder(Coder):
                 edited.add(fname)
                 if not self.dry_run:
                     new_lines = "".join(new_lines)
-                    Path(full_path).write_text(new_lines)
+                    self.io.write_text(full_path, new_lines)
 
         return edited

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -64,9 +64,8 @@ class WholeFileCoder(Coder):
                     else:
                         if self.allowed_to_edit(fname):
                             edited.add(fname)
-                            if not self.dry_run:
-                                new_lines = "".join(new_lines)
-                                self.io.write_text(full_path, new_lines)
+                            new_lines = "".join(new_lines)
+                            self.io.write_text(full_path, new_lines)
 
                     fname = None
                     new_lines = []
@@ -123,8 +122,7 @@ class WholeFileCoder(Coder):
             full_path = self.allowed_to_edit(fname)
             if full_path:
                 edited.add(fname)
-                if not self.dry_run:
-                    new_lines = "".join(new_lines)
-                    self.io.write_text(full_path, new_lines)
+                new_lines = "".join(new_lines)
+                self.io.write_text(full_path, new_lines)
 
         return edited

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -53,7 +53,7 @@ class WholeFileCoder(Coder):
                     full_path = (Path(self.root) / fname).absolute()
 
                     if mode == "diff" and full_path.exists():
-                        orig_lines = full_path.read_text().splitlines(keepends=True)
+                        orig_lines = self.io.read_text(full_path).splitlines(keepends=True)
 
                         show_diff = diffs.diff_partial_update(
                             orig_lines,
@@ -109,7 +109,7 @@ class WholeFileCoder(Coder):
                 full_path = (Path(self.root) / fname).absolute()
 
                 if mode == "diff" and full_path.exists():
-                    orig_lines = full_path.read_text().splitlines(keepends=True)
+                    orig_lines = self.io.read_text(full_path).splitlines(keepends=True)
 
                     show_diff = diffs.diff_partial_update(
                         orig_lines,

--- a/aider/coders/wholefile_func_coder.py
+++ b/aider/coders/wholefile_func_coder.py
@@ -101,8 +101,11 @@ class WholeFileFunctionCoder(Coder):
         # ending an existing block
         full_path = os.path.abspath(os.path.join(self.root, fname))
 
-        with open(full_path, "r") as f:
-            orig_lines = f.readlines()
+        content = self.io.read_text(full_path)
+        if content is None:
+            orig_lines = []
+        else:
+            orig_lines = content.splitlines()
 
         show_diff = diffs.diff_partial_update(
             orig_lines,

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 
 import git
 import tiktoken
@@ -238,8 +239,8 @@ class Commands:
                     )
 
                 if create_file:
-                    with open(os.path.join(self.coder.root, word), "w"):
-                        pass
+                    (Path(self.coder.root) / word).touch()
+
                     matched_files = [word]
                     if self.coder.repo is not None:
                         self.coder.repo.git.add(os.path.join(self.coder.root, word))

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -9,7 +9,7 @@ import git
 import tiktoken
 from prompt_toolkit.completion import Completion
 
-from aider import prompts, utils
+from aider import prompts
 
 
 class Commands:
@@ -117,8 +117,10 @@ class Commands:
         # files
         for fname in self.coder.abs_fnames:
             relative_fname = self.coder.get_rel_fname(fname)
-            quoted = utils.quoted_file(fname, relative_fname)
-            tokens = len(self.tokenizer.encode(quoted))
+            content = self.io.read_text(fname)
+            # approximate
+            content = "```\n" + content + "```\n"
+            tokens = len(self.tokenizer.encode(content))
             res.append((tokens, f"{relative_fname}", "use /drop to drop from chat"))
 
         self.io.tool_output("Approximate context window usage, in tokens:")

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -119,7 +119,7 @@ class Commands:
             relative_fname = self.coder.get_rel_fname(fname)
             content = self.io.read_text(fname)
             # approximate
-            content = "```\n" + content + "```\n"
+            content = f"{relative_fname}\n```\n" + content + "```\n"
             tokens = len(self.tokenizer.encode(content))
             res.append((tokens, f"{relative_fname}", "use /drop to drop from chat"))
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -252,9 +252,11 @@ class Commands:
             for matched_file in matched_files:
                 abs_file_path = os.path.abspath(os.path.join(self.coder.root, matched_file))
                 if abs_file_path not in self.coder.abs_fnames:
-                    self.coder.abs_fnames.add(abs_file_path)
-                    self.io.tool_output(f"Added {matched_file} to the chat")
-                    added_fnames.append(matched_file)
+                    content = self.io.read_text(abs_file_path)
+                    if content is not None:
+                        self.coder.abs_fnames.add(abs_file_path)
+                        self.io.tool_output(f"Added {matched_file} to the chat")
+                        added_fnames.append(matched_file)
                 else:
                     self.io.tool_error(f"{matched_file} is already in the chat")
 

--- a/aider/diffs.py
+++ b/aider/diffs.py
@@ -11,10 +11,10 @@ def main():
 
     file_orig, file_updated = sys.argv[1], sys.argv[2]
 
-    with open(file_orig, "r") as f:
+    with open(file_orig, "r", encoding="utf-8") as f:
         lines_orig = f.readlines()
 
-    with open(file_updated, "r") as f:
+    with open(file_updated, "r", encoding="utf-8") as f:
         lines_updated = f.readlines()
 
     for i in range(len(file_updated)):

--- a/aider/io.py
+++ b/aider/io.py
@@ -141,7 +141,7 @@ class InputOutput:
                 return f.read()
         except (FileNotFoundError, UnicodeError) as e:
             self.tool_error(str(e))
-            return None
+            return
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
         if self.pretty:

--- a/aider/io.py
+++ b/aider/io.py
@@ -140,7 +140,7 @@ class InputOutput:
             with open(filename, "r", encoding=self.encoding) as f:
                 return f.read()
         except (FileNotFoundError, UnicodeError) as e:
-            self.tool_error(str(e))
+            self.tool_error(f"{filename}: {e}")
             return
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):

--- a/aider/io.py
+++ b/aider/io.py
@@ -134,11 +134,19 @@ class InputOutput:
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.append_chat_history(f"\n# aider chat started at {current_time}\n\n")
-
+    
     def read_text(self, filename):
         try:
             with open(filename, "r", encoding=self.encoding) as f:
                 return f.read()
+        except (FileNotFoundError, UnicodeError) as e:
+            self.tool_error(f"{filename}: {e}")
+            return
+
+    def write_text(self, filename, content):
+        try:
+            with open(filename, "w", encoding=self.encoding) as f:
+                f.write(content)
         except (FileNotFoundError, UnicodeError) as e:
             self.tool_error(f"{filename}: {e}")
             return

--- a/aider/io.py
+++ b/aider/io.py
@@ -127,6 +127,7 @@ class InputOutput:
             self.chat_history_file = None
 
         self.encoding = encoding
+        self.dry_run = dry_run
 
         if pretty:
             self.console = Console()

--- a/aider/io.py
+++ b/aider/io.py
@@ -101,6 +101,7 @@ class InputOutput:
         tool_output_color=None,
         tool_error_color="red",
         encoding="utf-8",
+        dry_run=False,
     ):
         no_color = os.environ.get("NO_COLOR")
         if no_color is not None and no_color != "":
@@ -144,6 +145,8 @@ class InputOutput:
             return
 
     def write_text(self, filename, content):
+        if self.dry_run:
+            return
         with open(str(filename), "w", encoding=self.encoding) as f:
             f.write(content)
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -134,7 +134,7 @@ class InputOutput:
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.append_chat_history(f"\n# aider chat started at {current_time}\n\n")
-    
+
     def read_text(self, filename):
         try:
             with open(filename, "r", encoding=self.encoding) as f:
@@ -144,12 +144,8 @@ class InputOutput:
             return
 
     def write_text(self, filename, content):
-        try:
-            with open(filename, "w", encoding=self.encoding) as f:
-                f.write(content)
-        except (FileNotFoundError, UnicodeError) as e:
-            self.tool_error(f"{filename}: {e}")
-            return
+        with open(filename, "w", encoding=self.encoding) as f:
+            f.write(content)
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
         if self.pretty:

--- a/aider/io.py
+++ b/aider/io.py
@@ -137,14 +137,14 @@ class InputOutput:
 
     def read_text(self, filename):
         try:
-            with open(filename, "r", encoding=self.encoding) as f:
+            with open(str(filename), "r", encoding=self.encoding) as f:
                 return f.read()
         except (FileNotFoundError, UnicodeError) as e:
             self.tool_error(f"{filename}: {e}")
             return
 
     def write_text(self, filename, content):
-        with open(filename, "w", encoding=self.encoding) as f:
+        with open(str(filename), "w", encoding=self.encoding) as f:
             f.write(content)
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):

--- a/aider/io.py
+++ b/aider/io.py
@@ -141,7 +141,10 @@ class InputOutput:
         try:
             with open(str(filename), "r", encoding=self.encoding) as f:
                 return f.read()
-        except (FileNotFoundError, UnicodeError) as e:
+        except FileNotFoundError:
+            self.tool_error(f"{filename}: file not found error")
+            return
+        except UnicodeError as e:
             self.tool_error(f"{filename}: {e}")
             return
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -100,6 +100,7 @@ class InputOutput:
         user_input_color="blue",
         tool_output_color=None,
         tool_error_color="red",
+        encoding="utf-8",
     ):
         no_color = os.environ.get("NO_COLOR")
         if no_color is not None and no_color != "":
@@ -124,6 +125,8 @@ class InputOutput:
         else:
             self.chat_history_file = None
 
+        self.encoding = encoding
+
         if pretty:
             self.console = Console()
         else:
@@ -131,6 +134,14 @@ class InputOutput:
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.append_chat_history(f"\n# aider chat started at {current_time}\n\n")
+
+    def read_text(self, filename):
+        try:
+            with open(filename, "r", encoding=self.encoding) as f:
+                return f.read()
+        except (FileNotFoundError, UnicodeError) as e:
+            self.tool_error(str(e))
+            return None
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
         if self.pretty:

--- a/aider/main.py
+++ b/aider/main.py
@@ -186,6 +186,11 @@ def main(args=None, input=None, output=None):
         help="Disable commits when repo is found dirty",
     )
     parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Specify the encoding to use when reading files (default: utf-8)",
+    )
+    parser.add_argument(
         "--openai-api-key",
         metavar="OPENAI_API_KEY",
         help="Specify the OpenAI API key",

--- a/aider/main.py
+++ b/aider/main.py
@@ -299,8 +299,9 @@ def main(args=None, input=None, output=None):
         coder.commit(ask=True, which="repo_files")
 
     if args.apply:
-        with open(args.apply, "r") as f:
-            content = f.read()
+        content = io.read_text(args.apply)
+        if content is None:
+            return
         coder.apply_updates(content)
         return
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -252,6 +252,7 @@ def main(args=None, input=None, output=None):
         user_input_color=args.user_input_color,
         tool_output_color=args.tool_output_color,
         tool_error_color=args.tool_error_color,
+        dry_run=args.dry_run,
     )
 
     if args.verbose:

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -1,22 +1,4 @@
-from pathlib import Path
-
 from .dump import dump  # noqa: F401
-
-
-def quoted_file(fname, display_fname, fence=("```", "```"), number=False):
-    prompt = "\n"
-    prompt += display_fname
-    prompt += f"\n{fence[0]}\n"
-
-    file_content = Path(fname).read_text()
-    lines = file_content.splitlines()
-    for i, line in enumerate(lines, start=1):
-        if number:
-            prompt += f"{i:4d} "
-        prompt += line + "\n"
-
-    prompt += f"{fence[1]}\n"
-    return prompt
 
 
 def show_messages(messages, title=None, functions=None):

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -202,8 +202,11 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 2)
 
-        # Delete one of the files
-        os.remove(file1)
+        # move the file
+        # os.remove() causes PermErr on Windows!
+        # PermissionError: [WinError 32] The process cannot access the file because
+        # it is being used by another process
+        os.rename(file1, file1 + ".renamed")
 
         # Call the run method again with a message
         coder.run(with_message="hi")

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -239,5 +239,30 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 1)
 
+    def test_choose_fence(self):
+        # Create a few temporary files
+        _, file1 = tempfile.mkstemp()
+
+        with open(file1, "wb") as f:
+            f.write(b"this contains ``` backticks")
+
+        files = [file1]
+
+        # Initialize the Coder object with the mocked IO and mocked repo
+        coder = Coder.create(
+            models.GPT4, None, io=InputOutput(), openai_api_key="fake_key", fnames=files
+        )
+
+        def mock_send(*args, **kwargs):
+            coder.partial_response_content = "ok"
+            coder.partial_response_function_call = dict()
+
+        coder.send = MagicMock(side_effect=mock_send)
+
+        # Call the run method with a message
+        coder.run(with_message="hi")
+
+        self.assertNotEqual(coder.fence[0], "```")
+
     if __name__ == "__main__":
         unittest.main()

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -265,17 +265,22 @@ class TestCoder(unittest.TestCase):
         self.assertNotEqual(coder.fence[0], "```")
 
     def test_run_with_file_utf_unicode_error(self):
+        "make sure that we honor InputOutput(encoding) and don't just assume utf-8"
         # Create a few temporary files
         _, file1 = tempfile.mkstemp()
         _, file2 = tempfile.mkstemp()
 
         files = [file1, file2]
 
-        encoding = 'latin-1'
+        encoding = "utf-16"
 
         # Initialize the Coder object with the mocked IO and mocked repo
         coder = Coder.create(
-            models.GPT4, None, io=InputOutput(encoding=encoding), openai_api_key="fake_key", fnames=files
+            models.GPT4,
+            None,
+            io=InputOutput(encoding=encoding),
+            openai_api_key="fake_key",
+            fnames=files,
         )
 
         def mock_send(*args, **kwargs):
@@ -288,7 +293,7 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 2)
 
-        some_content_which_will_error_if_read_with_encoding_utf8 = 'ÅÍÎÏ'.encode('utf-16')
+        some_content_which_will_error_if_read_with_encoding_utf8 = "ÅÍÎÏ".encode(encoding)
         with open(file1, "wb") as f:
             f.write(some_content_which_will_error_if_read_with_encoding_utf8)
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import openai
@@ -182,8 +183,14 @@ class TestCoder(unittest.TestCase):
 
     def test_run_with_file_deletion(self):
         # Create a few temporary files
-        _, file1 = tempfile.mkstemp()
-        _, file2 = tempfile.mkstemp()
+
+        tempdir = Path(tempfile.mkdtemp())
+
+        file1 = tempdir / "file1.txt"
+        file2 = tempdir / "file2.txt"
+
+        file1.touch()
+        file2.touch()
 
         files = [file1, file2]
 
@@ -202,7 +209,7 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 2)
 
-        os.remove(file1)
+        file1.unlink()
 
         # Call the run method again with a message
         coder.run(with_message="hi")

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -209,6 +209,22 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 1)
 
+    def test_run_with_file_unicode_error(self):
+        # Create a temporary file
+        _, file = tempfile.mkstemp()
 
-if __name__ == "__main__":
-    unittest.main()
+        # Write some non-UTF8 text into the file
+        with open(file, "wb") as f:
+            f.write(b"\x80abc")
+
+        # Initialize the Coder object with the temporary file
+        coder = Coder.create(
+            models.GPT4, None, io=InputOutput(), openai_api_key="fake_key", fnames=[file]
+        )
+
+        # Expect a UnicodeDecodeError to be raised when the run method is called
+        with self.assertRaises(UnicodeDecodeError):
+            coder.run(with_message="hi")
+
+    if __name__ == "__main__":
+        unittest.main()

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -202,11 +202,7 @@ class TestCoder(unittest.TestCase):
         coder.run(with_message="hi")
         self.assertEqual(len(coder.abs_fnames), 2)
 
-        # move the file
-        # os.remove() causes PermErr on Windows!
-        # PermissionError: [WinError 32] The process cannot access the file because
-        # it is being used by another process
-        os.rename(file1, file1 + ".renamed")
+        os.remove(file1)
 
         # Call the run method again with a message
         coder.run(with_message="hi")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -49,3 +49,14 @@ class TestCommands(TestCase):
         commands.cmd_add("foo.bad")
 
         self.assertEqual(coder.abs_fnames, set())
+
+    def test_cmd_tokens(self):
+        # Initialize the Commands and InputOutput objects
+        io = InputOutput(pretty=False, yes=True)
+        from aider.coders import Coder
+
+        coder = Coder.create(models.GPT35, None, io, openai_api_key="deadbeef")
+        commands = Commands(io, coder)
+
+        commands.cmd_add("foo.txt bar.txt")
+        commands.cmd_tokens("")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,12 +1,15 @@
 import codecs
 import os
 import shutil
+import sys
 import tempfile
+from io import StringIO
 from unittest import TestCase
-import io
 
 from aider import models
+from aider.coders import Coder
 from aider.commands import Commands
+from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 
 
@@ -54,7 +57,6 @@ class TestCommands(TestCase):
     def test_cmd_tokens(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, yes=True)
-        from aider.coders import Coder
 
         coder = Coder.create(models.GPT35, None, io, openai_api_key="deadbeef")
         commands = Commands(io, coder)
@@ -62,7 +64,7 @@ class TestCommands(TestCase):
         commands.cmd_add("foo.txt bar.txt")
 
         # Redirect the standard output to an instance of io.StringIO
-        stdout = io.StringIO()
+        stdout = StringIO()
         sys.stdout = stdout
 
         commands.cmd_tokens("")
@@ -72,4 +74,6 @@ class TestCommands(TestCase):
 
         # Get the console output
         console_output = stdout.getvalue()
-        print(console_output)
+
+        self.assertIn("foo.txt", console_output)
+        self.assertIn("bar.txt", console_output)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import shutil
 import tempfile
@@ -33,7 +34,6 @@ class TestCommands(TestCase):
         self.assertTrue(os.path.exists("foo.txt"))
         self.assertTrue(os.path.exists("bar.txt"))
 
-    import codecs
     def test_cmd_add_bad_encoding(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, yes=True)
@@ -43,8 +43,8 @@ class TestCommands(TestCase):
         commands = Commands(io, coder)
 
         # Create a new file foo.bad which will fail to decode as utf-8
-        with codecs.open('foo.bad', 'w', encoding='iso-8859-15') as f:
-            f.write('ÆØÅ')  # Characters not present in utf-8
+        with codecs.open("foo.bad", "w", encoding="iso-8859-15") as f:
+            f.write("ÆØÅ")  # Characters not present in utf-8
 
         commands.cmd_add("foo.bad")
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -32,3 +32,20 @@ class TestCommands(TestCase):
         # Check if both files have been created in the temporary directory
         self.assertTrue(os.path.exists("foo.txt"))
         self.assertTrue(os.path.exists("bar.txt"))
+
+    import codecs
+    def test_cmd_add_bad_encoding(self):
+        # Initialize the Commands and InputOutput objects
+        io = InputOutput(pretty=False, yes=True)
+        from aider.coders import Coder
+
+        coder = Coder.create(models.GPT35, None, io, openai_api_key="deadbeef")
+        commands = Commands(io, coder)
+
+        # Create a new file foo.bad which will fail to decode as utf-8
+        with codecs.open('foo.bad', 'w', encoding='iso-8859-15') as f:
+            f.write('ÆØÅ')  # Characters not present in utf-8
+
+        commands.cmd_add("foo.bad")
+
+        self.assertEqual(coder.abs_fnames, set())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 from unittest import TestCase
+import io
 
 from aider import models
 from aider.commands import Commands
@@ -59,4 +60,16 @@ class TestCommands(TestCase):
         commands = Commands(io, coder)
 
         commands.cmd_add("foo.txt bar.txt")
+
+        # Redirect the standard output to an instance of io.StringIO
+        stdout = io.StringIO()
+        sys.stdout = stdout
+
         commands.cmd_tokens("")
+
+        # Reset the standard output
+        sys.stdout = sys.__stdout__
+
+        # Get the console output
+        console_output = stdout.getvalue()
+        print(console_output)

--- a/tests/test_editblock.py
+++ b/tests/test_editblock.py
@@ -271,7 +271,7 @@ new
         # Call the run method with a message
         coder.run(with_message="hi")
 
-        content = open(file1, encoding="utf-8").read()
+        content = Path(file1).read_text(encoding="utf-8")
         self.assertEqual(content, "one\nnew\nthree\n")
 
     def test_full_edit_dry_run(self):
@@ -314,7 +314,7 @@ new
         # Call the run method with a message
         coder.run(with_message="hi")
 
-        content = open(file1, encoding="utf-8").read()
+        content = Path(file1).read_text(encoding="utf-8")
         self.assertEqual(content, orig_content)
 
 

--- a/tests/test_editblock.py
+++ b/tests/test_editblock.py
@@ -1,11 +1,26 @@
 # flake8: noqa: E501
 
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+from aider import models
+from aider.coders import Coder
 from aider.coders import editblock_coder as eb
+from aider.dump import dump  # noqa: F401
+from aider.io import InputOutput
 
 
 class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.patcher = patch("aider.coders.base_coder.check_model_availability")
+        self.mock_check = self.patcher.start()
+        self.mock_check.return_value = True
+
+    def tearDown(self):
+        self.patcher.stop()
+
     def test_replace_most_similar_chunk(self):
         whole = "This is a sample text.\nAnother line of text.\nYet another line.\n"
         part = "This is a sample text"
@@ -222,6 +237,42 @@ These changes replace the `subprocess.run` patches with `subprocess.check_output
 
         result = eb.replace_part_with_missing_leading_whitespace(whole, part, replace)
         self.assertEqual(result, expected_output)
+
+    def test_choose_fence(self):
+        # Create a few temporary files
+        _, file1 = tempfile.mkstemp()
+
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write("one\ntwo\nthree\n")
+
+        files = [file1]
+
+        # Initialize the Coder object with the mocked IO and mocked repo
+        coder = Coder.create(
+            models.GPT4, "diff", io=InputOutput(), openai_api_key="fake_key", fnames=files
+        )
+
+        def mock_send(*args, **kwargs):
+            coder.partial_response_content = f"""
+Do this:
+
+{Path(file1).name}
+<<<<<<< ORIGINAL
+two
+=======
+new
+>>>>>>> UPDATED
+
+"""
+            coder.partial_response_function_call = dict()
+
+        coder.send = MagicMock(side_effect=mock_send)
+
+        # Call the run method with a message
+        coder.run(with_message="hi")
+
+        content = open(file1, encoding="utf-8").read()
+        self.assertEqual(content, "one\nnew\nthree\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_repomap.py
+++ b/tests/test_repomap.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from aider.io import InputOutput
 from aider.repomap import RepoMap
 
 
@@ -21,7 +22,8 @@ class TestRepoMap(unittest.TestCase):
                 with open(os.path.join(temp_dir, file), "w") as f:
                     f.write("")
 
-            repo_map = RepoMap(root=temp_dir)
+            io = InputOutput()
+            repo_map = RepoMap(root=temp_dir, io=io)
             other_files = [os.path.join(temp_dir, file) for file in test_files]
             result = repo_map.get_repo_map([], other_files)
 
@@ -65,7 +67,8 @@ print(my_function(3, 4))
             with open(os.path.join(temp_dir, test_file3), "w") as f:
                 f.write(file_content3)
 
-            repo_map = RepoMap(root=temp_dir)
+            io = InputOutput()
+            repo_map = RepoMap(root=temp_dir, io=io)
             other_files = [
                 os.path.join(temp_dir, test_file1),
                 os.path.join(temp_dir, test_file2),
@@ -83,7 +86,7 @@ print(my_function(3, 4))
     def test_check_for_ctags_failure(self):
         with patch("subprocess.run") as mock_run:
             mock_run.side_effect = Exception("ctags not found")
-            repo_map = RepoMap()
+            repo_map = RepoMap(io=InputOutput())
             self.assertFalse(repo_map.has_ctags)
 
     def test_check_for_ctags_success(self):
@@ -100,7 +103,7 @@ print(my_function(3, 4))
                     b' status = main()$/", "kind": "variable"}'
                 ),
             ]
-            repo_map = RepoMap()
+            repo_map = RepoMap(io=InputOutput())
             self.assertTrue(repo_map.has_ctags)
 
     def test_get_repo_map_without_ctags(self):
@@ -120,7 +123,7 @@ print(my_function(3, 4))
                 with open(os.path.join(temp_dir, file), "w") as f:
                     f.write("")
 
-            repo_map = RepoMap(root=temp_dir)
+            repo_map = RepoMap(root=temp_dir, io=InputOutput())
             repo_map.has_ctags = False  # force it off
 
             other_files = [os.path.join(temp_dir, file) for file in test_files]

--- a/tests/test_wholefile.py
+++ b/tests/test_wholefile.py
@@ -240,7 +240,7 @@ Do this:
         # Call the run method with a message
         coder.run(with_message="hi")
 
-        content = open(file1, encoding="utf-8").read()
+        content = Path(file1).read_text(encoding="utf-8")
 
         # check for one trailing newline
         self.assertEqual(content, new_content + "\n")


### PR DESCRIPTION
Added --encoding cmd line arg
Catch unicode errors and gracefully report and handle them

Resolves issues #56 and #28