### PR TITLE
More complete docs for prompt commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Aider also has many
 additional command-line options, environment variables or configuration file
 to set many options. See `aider --help` for details.
 
+
 ## In-chat commands
 
 Aider supports commands from within the chat, which all start with `/`. Here are some of the most useful in-chat commands:
@@ -107,6 +108,8 @@ Aider supports commands from within the chat, which all start with `/`. Here are
 * `/diff`: Display the diff of the last aider commit.
 * `/run <command>`: Run a shell command and optionally add the output to the chat.
 * `/help`: Show help about all commands.
+
+See the [full command docs](https://aider.chat/docs/commands.html) for more information.
 
 
 ## Tips

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Commands
 
-- `/help <command>`: Show help about all commands
+- `/help`: Show help about all commands
 - `/exit`: Exit the application
 
 ## token/context management

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,37 @@
+# Commands
+
+- `/help <command>`: Show help about all commands
+- `/exit`: Exit the application
+
+## token/context management
+- `/add <file>`: Add matching files to the chat session using glob patterns
+- `/drop <file>`: Remove matching files from the chat session
+- `/clear`: Clear the chat history
+- `/ls`: List all known files and those included in the chat session
+- `/tokens`: Report on the number of tokens used by the current chat context
+- `/run <command>`: Run a shell command and optionally add the output to the chat
+
+## git
+- `/undo`: Undo the last git commit if it was done by aider
+- `/diff`: Display the diff of the last aider commit
+- `/commit <message>`: Commit edits to the repo made outside the chat (commit message optional)
+- `/git <command>`: Run a git command
+
+# Prompt Toolkit defaults
+
+The interactive prompt is built with [prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) which provides a lot of Emacs and Vi-style keyboard. Some emacs bindings you may find useful are
+
+- `Ctrl-A` : Move cursor to the start of the line.
+- `Ctrl-B` : Move cursor back one character.
+- `Ctrl-D` : Delete the character under the cursor.
+- `Ctrl-E` : Move cursor to the end of the line.
+- `Ctrl-F` : Move cursor forward one character.
+- `Ctrl-K` : Delete from the cursor to the end of the line.
+- `Ctrl-L` : Clear the screen.
+- `Ctrl-N` : Move down to the next history entry.
+- `Ctrl-P` : Move up to the previous history entry.
+- `Ctrl-R` : Reverse search in command history.
+
+Note: aider currently exits vi normal mode after a single command, (maybe something to do with the esc keybinding?). Feel free to investigate and make a PR if you would like to see it fully supported.
+
+Prompt toolkit also does not provide clear documentation on the bindings they support - maybe you can take aider and help them out with that and we can then link to the authoritative docs.


### PR DESCRIPTION
Added a section about the prompt-toolkit defaults. Note that the link in the README is to docs/commands.html which will be a dead link until aider.chat is rebuilt
