### PR TITLE
/add and /drop problems when cwd != git_root #139 #95

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -328,7 +328,7 @@ class Commands:
                 self.io.tool_error(f"No files matched '{word}'")
 
             for matched_file in matched_files:
-                abs_fname = str(Path(matched_file).resolve())
+                abs_fname = self.coder.abs_root_path(matched_file)
                 if abs_fname in self.coder.abs_fnames:
                     self.coder.abs_fnames.remove(abs_fname)
                     self.io.tool_output(f"Removed {matched_file} from the chat")

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -232,7 +232,9 @@ class Commands:
 
         matched_files = []
         for fn in raw_matched_files:
-            matched_files += expand_subdir(fn.relative_to(self.coder.root))
+            matched_files += expand_subdir(fn)
+
+        matched_files = [str(Path(fn).relative_to(self.coder.root)) for fn in matched_files]
 
         # if repo, filter against it
         if self.coder.repo:
@@ -426,6 +428,7 @@ def expand_subdir(file_path):
         yield file_path
         return
 
-    for file in file_path.rglob("*"):
-        if file.is_file():
-            yield str(file)
+    if file_path.is_dir():
+        for file in file_path.rglob("*"):
+            if file.is_file():
+                yield str(file)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -90,14 +90,14 @@ class TestCommands(TestCase):
         coder = Coder.create(models.GPT35, None, io)
         commands = Commands(io, coder)
 
-        # Create a directory and add files to it
-        os.mkdir("test_dir")
-        os.mkdir("test_dir/another_dir")
-        with open("test_dir/test_file1.txt", "w") as f:
+        # Create a directory and add files to it using pathlib
+        Path("test_dir").mkdir()
+        Path("test_dir/another_dir").mkdir()
+        with open(Path("test_dir/test_file1.txt"), "w") as f:
             f.write("Test file 1")
-        with open("test_dir/test_file2.txt", "w") as f:
+        with open(Path("test_dir/test_file2.txt"), "w") as f:
             f.write("Test file 2")
-        with open("test_dir/another_dir/test_file.txt", "w") as f:
+        with open(Path("test_dir/another_dir/test_file.txt"), "w") as f:
             f.write("Test file 3")
 
         # Call the cmd_add method with a directory

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -93,12 +93,9 @@ class TestCommands(TestCase):
         # Create a directory and add files to it using pathlib
         Path("test_dir").mkdir()
         Path("test_dir/another_dir").mkdir()
-        with open(Path("test_dir/test_file1.txt"), "w") as f:
-            f.write("Test file 1")
-        with open(Path("test_dir/test_file2.txt"), "w") as f:
-            f.write("Test file 2")
-        with open(Path("test_dir/another_dir/test_file.txt"), "w") as f:
-            f.write("Test file 3")
+        Path("test_dir/test_file1.txt").write_text("Test file 1")
+        Path("test_dir/test_file2.txt").write_text("Test file 2")
+        Path("test_dir/another_dir/test_file.txt").write_text("Test file 3")
 
         # Call the cmd_add method with a directory
         commands.cmd_add("test_dir test_dir/test_file2.txt")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -84,7 +84,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_drop_directory(self):
         # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        io = InputOutput(pretty=False, yes=False)
         from aider.coders import Coder
 
         coder = Coder.create(models.GPT35, None, io)
@@ -111,6 +111,21 @@ class TestCommands(TestCase):
         self.assertNotIn(
             str(Path("test_dir/another_dir/test_file.txt").resolve()), coder.abs_fnames
         )
+
+        # Issue #139 /add problems when cwd != git_root
+
+        # remember the proper abs path to this file
+        abs_fname = str(Path("test_dir/another_dir/test_file.txt").resolve())
+
+        # chdir to someplace other than git_root
+        Path("side_dir").mkdir()
+        os.chdir("side_dir")
+
+        # add it via it's git_root referenced name
+        commands.cmd_add("test_dir/another_dir/test_file.txt")
+
+        # it should be there, but was not in v0.10.0
+        self.assertIn(abs_fname, coder.abs_fnames)
 
     def test_cmd_drop_with_glob_patterns(self):
         # Initialize the Commands and InputOutput objects

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -127,6 +127,12 @@ class TestCommands(TestCase):
         # it should be there, but was not in v0.10.0
         self.assertIn(abs_fname, coder.abs_fnames)
 
+        # drop it via it's git_root referenced name
+        commands.cmd_drop("test_dir/another_dir/test_file.txt")
+
+        # it should be there, but was not in v0.10.0
+        self.assertNotIn(abs_fname, coder.abs_fnames)
+
     def test_cmd_drop_with_glob_patterns(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, yes=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -25,7 +25,10 @@ class TestCommands(TestCase):
 
     def tearDown(self):
         os.chdir(self.original_cwd)
-        shutil.rmtree(self.tempdir)
+        try:
+            shutil.rmtree(self.tempdir)
+        except OSError:
+            pass  # Ignore errors (Windows)
 
     def test_cmd_add(self):
         # Initialize the Commands and InputOutput objects
@@ -254,7 +257,3 @@ class TestCommands(TestCase):
         self.assertIn(filenames[0], coder.abs_fnames)
         self.assertNotIn(filenames[1], coder.abs_fnames)
         self.assertIn(filenames[2], coder.abs_fnames)
-
-        del commands
-        del coder
-        del io


### PR DESCRIPTION
Per #139 and #95, the `/add` command was failing if the cwd was not the same as the git root.