### PR TITLE
Add litellm - Add support for gpt 3.5, gpt-4, azure, anthropic, cohere, replicate 

### DIFF
--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -11,7 +11,7 @@ from openai.error import (
     ServiceUnavailableError,
     Timeout,
 )
-
+from litellm import completion
 
 @backoff.on_exception(
     backoff.expo,
@@ -47,7 +47,8 @@ def send_with_retries(model, messages, functions, stream):
     # Generate SHA1 hash of kwargs and append it to chat_completion_call_hashes
     hash_object = hashlib.sha1(json.dumps(kwargs, sort_keys=True).encode())
 
-    res = openai.ChatCompletion.create(**kwargs)
+    # adding support for gpt3.5, gpt-4, azure, anthropic, cohere
+    res = completion(**kwargs)
     return hash_object, res
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ diskcache==5.6.1
 numpy==1.24.3
 scipy==1.10.1
 jsonschema==4.17.3
+litellm==0.1.213


### PR DESCRIPTION
Hi i'm the maintainer of https://github.com/BerriAI/litellm, 

litellm allows you to add support for Azure, OpenAI, Cohere, Anthropic, Replicate, and more coming and I'd love to include it into aider. 

Here's a code snippet of how it works: 
```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# azure openai call
response = completion("chatgpt-test", messages, azure=True)

# openrouter call
response = completion("google/palm-2-codechat-bison", messages)
```

