### PR TITLE
Fix /add to work in subdirectories

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1,3 +1,4 @@
+import os
 import json
 import shlex
 import subprocess
@@ -273,16 +274,17 @@ class Commands:
                 if any(char in word for char in "*?[]"):
                     self.io.tool_error(f"No files to add matching pattern: {word}")
                 else:
+                    subdir = os.path.relpath(os.getcwd(), self.coder.root)
                     if Path(word).exists():
                         if Path(word).is_file():
-                            matched_files = [word]
+                            matched_files = [os.path.join(subdir, word)]
                         else:
                             self.io.tool_error(f"Unable to add: {word}")
                     elif self.io.confirm_ask(
                         f"No files matched '{word}'. Do you want to create the file?"
                     ):
-                        (Path(self.coder.root) / word).touch()
-                        matched_files = [word]
+                        (Path(self.coder.root) / subdir / word).touch()
+                        matched_files = [os.path.join(subdir, word)]
 
             all_matched_files.update(matched_files)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -133,6 +133,23 @@ class TestCommands(TestCase):
         # it should be there, but was not in v0.10.0
         self.assertNotIn(abs_fname, coder.abs_fnames)
 
+    def test_cmd_add_from_sub_dir(self):
+        io = InputOutput(pretty=False, yes=False)
+        from aider.coders import Coder
+        coder = Coder.create(models.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        Path("side_dir").mkdir()
+        os.chdir("side_dir")
+
+        # add a file that is in the side_dir
+        with open('temp.txt', 'w'):
+            pass
+
+        commands.cmd_add('temp.txt')
+        tmp_abs_fname = str(Path("temp.txt").resolve())
+        self.assertIn(tmp_abs_fname, coder.abs_fnames)
+
     def test_cmd_drop_with_glob_patterns(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, yes=True)


### PR DESCRIPTION
opening aider in a subdir and using /add for a file that exists would through an error and for a file that doesn't exist it would create it relative to the root directory which could get confusing.

This fix makes the /add command aware of a subdirectory if it is in one