### PR TITLE
Don't try to add ignored files to git.

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -56,6 +56,8 @@ class GitRepo:
                 continue
             if not Path(fname).exists():
                 continue
+            if self.repo.ignored(Path(fname).resolve()):
+                continue
             self.io.tool_output(f"Adding {fname} to git")
             self.repo.git.add(fname)
 


### PR DESCRIPTION
If I start aider with a file that is in .gitignore and should be ignored by git, aider tries nonetheless to `git add` the file. I think this is an obvious bug.

Old behaviour:

Let's say files aa and bb are in `.gitignore`:

```
$ cat .gitignore
aa
bb
.aider*
```

Now let's say the user starts aider and gives aa and bb as file parameters:

```
appuser@73ab230c4d0a:/src$ aider aa bb
```

The old behaviour is that aider will immediateley try to `git add` both files. And this results in a python exception:

```
Aider v0.12.1-dev
Model: gpt-4
Git repo: .git
Repo-map: universal-ctags using 1024 tokens
Added aa to the chat.
Added bb to the chat.
Adding /src/aa to git
Traceback (most recent call last):
  File "/opt/venv/bin/aider", line 33, in <module>
    sys.exit(load_entry_point('aider-chat', 'console_scripts', 'aider')())
  File "/src/aider/main.py", line 479, in main
    coder = Coder.create(
  File "/src/aider/coders/base_coder.py", line 84, in create
    return EditBlockCoder(main_model, io, **kwargs)
  File "/src/aider/coders/editblock_coder.py", line 14, in __init__
    super().__init__(*args, **kwargs)
  File "/src/aider/coders/base_coder.py", line 206, in __init__
    self.repo.add_new_files(fname for fname in fnames if not Path(fname).is_dir())
  File "/src/aider/repo.py", line 60, in add_new_files
    self.repo.git.add(fname)
  File "/opt/venv/lib/python3.10/site-packages/git/cmd.py", line 741, in <lambda>
    return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/git/cmd.py", line 1315, in _call_process
    return self.execute(call, **exec_kwargs)
  File "/opt/venv/lib/python3.10/site-packages/git/cmd.py", line 1109, in execute
    raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git add /src/aa
  stderr: 'The following paths are ignored by one of your .gitignore files:
aa
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"'
```

In the other case, if a file is not git-ignored and it is also not part of the git index, aider will correctly add it to git:


Example for untracked file (not ignored):

```
$ touch cc
appuser@73ab230c4d0a:/src$ aider cc
Aider v0.12.1-dev
Model: gpt-4
Git repo: .git
Repo-map: universal-ctags using 1024 tokens
Added cc to the chat.
Adding /src/cc to git
Use /help to see in-chat commands, run with --help to see cmd line args
Git repo has uncommitted changes.
diff --git a/cc b/cc
new file mode 100644
index 0000000..e69de29
Commit before the chat proceeds [y/n/commit message]? y
Commit f143e86 Added new file cc.
────
cc>
```

--------

In the proposed fix, before `git adding` a file, the code would use the `repo.ignored()` check and if the file is ignored it would not try to add the file to git:


```
$ aider aa bb
Aider v0.12.1-dev
Model: gpt-4
Git repo: .git
Repo-map: universal-ctags using 1024 tokens
Added aa to the chat.
Added bb to the chat.
Use /help to see in-chat commands, run with --help to see cmd line args
────────
aa bb>
```

But there is a small issue with this solution: `/ls` does not list aa and bb. I could not find out why. So while my proposed change fixeds one obvious thing, it introduces another problem. 





