### PR TITLE
Openrouter compatibility

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -190,7 +190,7 @@ class Coder:
         for fname in self.get_inchat_relative_files():
             self.io.tool_output(f"Added {fname} to the chat.")
 
-        self.summarizer = ChatSummary()
+        self.summarizer = ChatSummary(models.Model.weak_model())
         self.summarizer_thread = None
         self.summarized_done_messages = None
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -901,6 +901,5 @@ class Coder:
 
 def check_model_availability(main_model):
     available_models = openai.Model.list()
-    print(available_models)
     model_ids = [model.id for model in available_models["data"]]
     return main_model.name in model_ids

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -636,7 +636,7 @@ class Coder:
                 if len(chunk.choices) == 0:
                     continue
 
-                if chunk.choices[0].finish_reason == "length":
+                if hasattr(chunk.choices[0], "finish_reason") and chunk.choices[0].finish_reason == "length":
                     raise ExhaustedContextWindow()
 
                 try:
@@ -901,5 +901,6 @@ class Coder:
 
 def check_model_availability(main_model):
     available_models = openai.Model.list()
+    print(available_models)
     model_ids = [model.id for model in available_models["data"]]
     return main_model.name in model_ids

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 import git
-import tiktoken
 from prompt_toolkit.completion import Completion
 
 from aider import prompts, voice
@@ -24,7 +23,7 @@ class Commands:
             voice_language = None
 
         self.voice_language = voice_language
-        self.tokenizer = tiktoken.encoding_for_model(coder.main_model.name)
+        self.tokenizer = coder.main_model.tokenizer
 
     def is_command(self, inp):
         if inp[0] == "/":

--- a/aider/history.py
+++ b/aider/history.py
@@ -9,8 +9,8 @@ from aider.sendchat import simple_send_with_retries
 
 
 class ChatSummary:
-    def __init__(self, model=models.GPT35.name, max_tokens=1024):
-        self.tokenizer = tiktoken.encoding_for_model(model)
+    def __init__(self, model=models.Model.weak_model(), max_tokens=1024):
+        self.tokenizer = model.tokenizer
         self.max_tokens = max_tokens
         self.model = model
 
@@ -86,7 +86,7 @@ class ChatSummary:
             dict(role="user", content=content),
         ]
 
-        summary = simple_send_with_retries(model=self.model.weak_model, messages=messages)
+        summary = simple_send_with_retries(self.model.name, messages)
         summary = prompts.summary_prefix + summary
 
         return [dict(role="user", content=summary)]
@@ -124,7 +124,7 @@ def main():
 
         assistant.append(line)
 
-    summarizer = ChatSummary(models.GPT35.name)
+    summarizer = ChatSummary(models.Model.weak_model())
     summary = summarizer.summarize(messages[-40:])
     dump(summary)
 

--- a/aider/history.py
+++ b/aider/history.py
@@ -85,7 +85,7 @@ class ChatSummary:
             dict(role="user", content=content),
         ]
 
-        summary = simple_send_with_retries(model=models.GPT35.name, messages=messages)
+        summary = simple_send_with_retries(model=self.model.weak_model, messages=messages)
         summary = prompts.summary_prefix + summary
 
         return [dict(role="user", content=summary)]

--- a/aider/history.py
+++ b/aider/history.py
@@ -12,6 +12,7 @@ class ChatSummary:
     def __init__(self, model=models.GPT35.name, max_tokens=1024):
         self.tokenizer = tiktoken.encoding_for_model(model)
         self.max_tokens = max_tokens
+        self.model = model
 
     def too_big(self, messages):
         sized = self.tokenize(messages)

--- a/aider/main.py
+++ b/aider/main.py
@@ -458,7 +458,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             setattr(openai, mod_key, val)
             io.tool_output(f"Setting openai.{mod_key}={val}")
 
-    main_model = models.Model(args.model, openai)
+    main_model = models.Model.create(args.model)
 
     try:
         coder = Coder.create(

--- a/aider/main.py
+++ b/aider/main.py
@@ -449,8 +449,6 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             )
         return 1
 
-    main_model = models.Model(args.model)
-
     openai.api_key = args.openai_api_key
     for attr in ("base", "type", "version", "deployment_id", "engine"):
         arg_key = f"openai_api_{attr}"
@@ -459,6 +457,8 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             mod_key = f"api_{attr}"
             setattr(openai, mod_key, val)
             io.tool_output(f"Setting openai.{mod_key}={val}")
+
+    main_model = models.Model(args.model, openai)
 
     try:
         coder = Coder.create(

--- a/aider/models/__init__.py
+++ b/aider/models/__init__.py
@@ -2,6 +2,6 @@ from .openai import OpenAIModel
 from .openrouter import OpenRouterModel
 from .model import Model
 
-GPT4 = Model("gpt-4")
-GPT35 = Model("gpt-3.5-turbo")
-GPT35_16k = Model("gpt-3.5-turbo-16k")
+GPT4 = Model.create('gpt-4')
+GPT35 = Model.create('gpt-3.5-turbo')
+GPT35_16k = Model.create('gpt-3.5-turbo-16k')

--- a/aider/models/__init__.py
+++ b/aider/models/__init__.py
@@ -1,0 +1,7 @@
+from .openai import OpenAIModel
+from .openrouter import OpenRouterModel
+from .model import Model
+
+GPT4 = Model("gpt-4")
+GPT35 = Model("gpt-3.5-turbo")
+GPT35_16k = Model("gpt-3.5-turbo-16k")

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -1,6 +1,6 @@
 import importlib
 
-using_openrouter = False
+saved_openai = None
 
 class Model:
     name = None
@@ -16,22 +16,15 @@ class Model:
     completion_price = None
 
     def __init__(self, name, openai=None):
-        global using_openrouter
+        global saved_openai
         if (openai and "openrouter.ai" in openai.api_base):
-            using_openrouter = True
+            saved_openai = openai
 
         from .openai import OpenAIModel
         from .openrouter import OpenRouterModel
         model = None
-        if using_openrouter:
-            if name == 'gpt-4':
-                name = 'openai/gpt-4'
-            elif name == 'gpt-3.5-turbo':
-                name = 'openai/gpt-3.5-turbo'
-            elif name == 'gpt-3.5.turbo-16k':
-                name = 'openai/gpt-3.5-turbo-16k'
-
-            model = OpenRouterModel(name, openai)
+        if saved_openai:
+            model = OpenRouterModel(name, saved_openai)
         else:
             model = OpenAIModel(name)
 

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -1,0 +1,60 @@
+import importlib
+
+using_openrouter = False
+
+class Model:
+    name = None
+    edit_format = None
+    max_context_tokens = 0
+    tokenizer = None
+
+    always_available = False
+    use_repo_map = False
+    send_undo_reply = False
+
+    prompt_price = None
+    completion_price = None
+
+    def __init__(self, name, openai=None):
+        global using_openrouter
+        if (openai and "openrouter.ai" in openai.api_base):
+            using_openrouter = True
+
+        from .openai import OpenAIModel
+        from .openrouter import OpenRouterModel
+        model = None
+        if using_openrouter:
+            if name == 'gpt-4':
+                name = 'openai/gpt-4'
+            elif name == 'gpt-3.5-turbo':
+                name = 'openai/gpt-3.5-turbo'
+            elif name == 'gpt-3.5.turbo-16k':
+                name = 'openai/gpt-3.5-turbo-16k'
+
+            model = OpenRouterModel(name, openai)
+        else:
+            model = OpenAIModel(name)
+
+        self.name = model.name
+        self.edit_format = model.edit_format
+        self.max_context_tokens = model.max_context_tokens
+        self.tokenizer = model.tokenizer
+        self.prompt_price = model.prompt_price
+        self.completion_price = model.completion_price
+        self.always_available = model.always_available
+        self.use_repo_map = model.use_repo_map
+
+    def __str__(self):
+        return self.name
+
+    @staticmethod
+    def strong_model():
+        return Model('gpt-4')
+
+    @staticmethod
+    def weak_model():
+        return Model('gpt-3.5-turbo')
+
+    @staticmethod
+    def commit_message_models():
+        return [Model('gpt-3.5-turbo'), Model('gpt-3.5-turbo-16k')]

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -1,6 +1,4 @@
-saved_openai = None
-
-
+import openai 
 class Model:
     name = None
     edit_format = None
@@ -13,40 +11,27 @@ class Model:
 
     prompt_price = None
     completion_price = None
+    openai=None
 
-    def __init__(self, name, openai=None):
-        global saved_openai
-        if (openai and "openrouter.ai" in openai.api_base):
-            saved_openai = openai
-
+    @classmethod
+    def create(cls, name, **kwargs):
         from .openai import OpenAIModel
         from .openrouter import OpenRouterModel
-        model = None
-        if saved_openai:
-            model = OpenRouterModel(name, saved_openai)
-        else:
-            model = OpenAIModel(name)
-
-        self.name = model.name
-        self.edit_format = model.edit_format
-        self.max_context_tokens = model.max_context_tokens
-        self.tokenizer = model.tokenizer
-        self.prompt_price = model.prompt_price
-        self.completion_price = model.completion_price
-        self.always_available = model.always_available
-        self.use_repo_map = model.use_repo_map
+        if ("openrouter.ai" in openai.api_base):
+            return OpenRouterModel(name, **kwargs)
+        return OpenAIModel(name, **kwargs)
 
     def __str__(self):
         return self.name
 
     @staticmethod
     def strong_model():
-        return Model('gpt-4')
+        return Model.create('gpt-4')
 
     @staticmethod
     def weak_model():
-        return Model('gpt-3.5-turbo')
+        return Model.create('gpt-3.5-turbo')
 
     @staticmethod
     def commit_message_models():
-        return [Model('gpt-3.5-turbo'), Model('gpt-3.5-turbo-16k')]
+        return [Model.create('gpt-3.5-turbo'), Model.create('gpt-3.5-turbo-16k')]

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -11,15 +11,14 @@ class Model:
 
     prompt_price = None
     completion_price = None
-    openai=None
 
     @classmethod
-    def create(cls, name, **kwargs):
+    def create(cls, name):
         from .openai import OpenAIModel
         from .openrouter import OpenRouterModel
         if ("openrouter.ai" in openai.api_base):
-            return OpenRouterModel(name, **kwargs)
-        return OpenAIModel(name, **kwargs)
+            return OpenRouterModel(name)
+        return OpenAIModel(name)
 
     def __str__(self):
         return self.name

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -1,6 +1,5 @@
-import importlib
-
 saved_openai = None
+
 
 class Model:
     name = None

--- a/aider/models/openai.py
+++ b/aider/models/openai.py
@@ -1,4 +1,6 @@
+import tiktoken
 import re
+from .model import Model
 
 known_tokens = {
     "gpt-3.5-turbo": 4,
@@ -6,14 +8,7 @@ known_tokens = {
 }
 
 
-class Model:
-    always_available = False
-    use_repo_map = False
-    send_undo_reply = False
-
-    prompt_price = None
-    completion_price = None
-
+class OpenAIModel(Model):
     def __init__(self, name):
         self.name = name
 
@@ -31,6 +26,7 @@ class Model:
             raise ValueError(f"Unknown context window size for model: {name}")
 
         self.max_context_tokens = tokens * 1024
+        self.tokenizer = tiktoken.encoding_for_model(name)
 
         if self.is_gpt4():
             self.edit_format = "diff"
@@ -66,11 +62,3 @@ class Model:
 
     def is_gpt35(self):
         return self.name.startswith("gpt-3.5-turbo")
-
-    def __str__(self):
-        return self.name
-
-
-GPT4 = Model("gpt-4")
-GPT35 = Model("gpt-3.5-turbo")
-GPT35_16k = Model("gpt-3.5-turbo-16k")

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -28,9 +28,9 @@ class OpenRouterModel(Model):
         found = next((details for details in cached_model_details if details.get('id') == name), None)
 
         if found:
-            self.max_context_tokens = int(found.context_length)
-            self.prompt_price = float(found.get('pricing').get('prompt')) * 1000
-            self.completion_price = float(found.get('pricing').get('completion')) * 1000
+            self.max_context_tokens = int(found.get('context_length'))
+            self.prompt_price = round(float(found.get('pricing').get('prompt')) * 1000,6)
+            self.completion_price = round(float(found.get('pricing').get('completion')) * 1000,6)
 
         else:
             raise ValueError(f'invalid openrouter model: {name}')

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -4,9 +4,16 @@ from .model import Model
 
 class OpenRouterModel(Model):
     def __init__(self, name, openai):
+        if name == 'gpt-4':
+            name = 'openai/gpt-4'
+        elif name == 'gpt-3.5-turbo':
+            name = 'openai/gpt-3.5-turbo'
+        elif name == 'gpt-3.5-turbo-16k':
+            name = 'openai/gpt-3.5-turbo-16k'
+
         self.name = name
-        self.edit_format = "diff"
-        self.use_repo_map = True
+        self.edit_format = edit_format_for_model(name)
+        self.use_repo_map = self.edit_format == "diff"
 
         # TODO: figure out proper encodings for non openai models
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
@@ -20,4 +27,11 @@ class OpenRouterModel(Model):
             self.completion_price = float(found.get('pricing').get('completion')) * 1000
 
         else:
-            raise ValueError('invalid openrouter model for {name}')
+            raise ValueError(f'invalid openrouter model: {name}')
+
+
+def edit_format_for_model(name):
+    if any(str in name for str in ['gpt-4', 'claude-2']):
+        return "diff"
+
+    return "whole"

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -1,6 +1,8 @@
 import tiktoken
 from .model import Model
 
+cached_model_details = None
+
 
 class OpenRouterModel(Model):
     def __init__(self, name, openai):
@@ -19,8 +21,10 @@ class OpenRouterModel(Model):
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
         # TODO cache the model list data to speed up using multiple models
-        available_models = openai.Model.list().data
-        found = next((details for details in available_models if details.get('id') == name), None)
+        global cached_model_details
+        if cached_model_details == None:
+            cached_model_details = openai.Model.list().data
+        found = next((details for details in cached_model_details if details.get('id') == name), None)
 
         if found:
             self.max_context_tokens = int(found.context_length)

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -7,7 +7,17 @@ class OpenRouterModel(Model):
         self.name = name
         self.edit_format = "diff"
         self.use_repo_map = True
-        self.max_context_tokens = 1024 * 8
 
         # TODO: figure out proper encodings for non openai models
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
+
+        available_models = openai.Model.list().data
+        found = next((details for details in available_models if details.get('id') == name), None)
+
+        if found:
+            self.max_context_tokens = int(found.context_length)
+            self.prompt_price = float(found.get('pricing').get('prompt')) * 1000
+            self.completion_price = float(found.get('pricing').get('completion')) * 1000
+
+        else:
+            raise ValueError('invalid openrouter model for {name}')

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -1,0 +1,13 @@
+import tiktoken
+from .model import Model
+
+
+class OpenRouterModel(Model):
+    def __init__(self, name, openai):
+        self.name = name
+        self.edit_format = "diff"
+        self.use_repo_map = True
+        self.max_context_tokens = 1024 * 8
+
+        # TODO: figure out proper encodings for non openai models
+        self.tokenizer = tiktoken.get_encoding("cl100k_base")

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -1,3 +1,4 @@
+import openai
 import tiktoken
 from .model import Model
 
@@ -5,7 +6,7 @@ cached_model_details = None
 
 
 class OpenRouterModel(Model):
-    def __init__(self, name, openai):
+    def __init__(self, name):
         if name == 'gpt-4':
             name = 'openai/gpt-4'
         elif name == 'gpt-3.5-turbo':

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -18,6 +18,7 @@ class OpenRouterModel(Model):
         # TODO: figure out proper encodings for non openai models
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
+        # TODO cache the model list data to speed up using multiple models
         available_models = openai.Model.list().data
         found = next((details for details in available_models if details.get('id') == name), None)
 
@@ -30,6 +31,7 @@ class OpenRouterModel(Model):
             raise ValueError(f'invalid openrouter model: {name}')
 
 
+# TODO run benchmarks and figure out which models support which edit-formats
 def edit_format_for_model(name):
     if any(str in name for str in ['gpt-4', 'claude-2']):
         return "diff"

--- a/aider/models/openrouter.py
+++ b/aider/models/openrouter.py
@@ -21,7 +21,6 @@ class OpenRouterModel(Model):
         # TODO: figure out proper encodings for non openai models
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
 
-        # TODO cache the model list data to speed up using multiple models
         global cached_model_details
         if cached_model_details == None:
             cached_model_details = openai.Model.list().data

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -109,8 +109,8 @@ class GitRepo:
             dict(role="user", content=content),
         ]
 
-        for model in [models.GPT35.name, models.GPT35_16k.name]:
-            commit_message = simple_send_with_retries(model, messages)
+        for model in models.Model.commit_message_models():
+            commit_message = simple_send_with_retries(model.name, messages)
             if commit_message:
                 break
 

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -9,7 +9,6 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 import networkx as nx
-import tiktoken
 from diskcache import Cache
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Token
@@ -104,7 +103,7 @@ class RepoMap:
         else:
             self.use_ctags = False
 
-        self.tokenizer = tiktoken.encoding_for_model(main_model.name)
+        self.tokenizer = main_model.tokenizer
         self.repo_content_prefix = repo_content_prefix
 
     def get_repo_map(self, chat_files, other_files):

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -80,7 +80,7 @@ class RepoMap:
         self,
         map_tokens=1024,
         root=None,
-        main_model=models.GPT4,
+        main_model=models.Model.strong_model(),
         io=None,
         repo_content_prefix=None,
         verbose=False,

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -50,6 +50,12 @@ def send_with_retries(model, messages, functions, stream):
     if hasattr(openai, "api_engine"):
         kwargs["engine"] = openai.api_engine
 
+    if "openrouter.ai" in openai.api_base:
+        kwargs["headers"] = {
+            "HTTP-Referer": "http://aider.chat",
+            "X-Title": "Aider"
+        }
+
     key = json.dumps(kwargs, sort_keys=True).encode()
 
     # Generate SHA1 hash of kwargs and append it to chat_completion_call_hashes

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -34,9 +34,9 @@ CACHE = None
         f"{details.get('exception','Exception')}\nRetry in {details['wait']:.1f} seconds."
     ),
 )
-def send_with_retries(model, messages, functions, stream):
+def send_with_retries(model_name, messages, functions, stream):
     kwargs = dict(
-        model=model,
+        model=model_name,
         messages=messages,
         temperature=0,
         stream=stream,
@@ -72,10 +72,10 @@ def send_with_retries(model, messages, functions, stream):
     return hash_object, res
 
 
-def simple_send_with_retries(model, messages):
+def simple_send_with_retries(model_name, messages):
     try:
         _hash, response = send_with_retries(
-            model=model,
+            model_name=model_name,
             messages=messages,
             functions=None,
             stream=False,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,6 +4,7 @@
 - [How does aider use git?](#how-does-aider-use-git)
 - [GPT-4 vs GPT-3.5](#gpt-4-vs-gpt-35)
 - [Aider isn't editing my files?](#aider-isnt-editing-my-files)
+- [Accessing other LLMs with OpenRouter](#accessing-other-llms-with-openrouter)
 - [Can I use aider with other LLMs, local LLMs, etc?](#can-i-use-aider-with-other-llms-local-llms-etc)
 - [Can I change the system prompts that aider uses?](#can-i-change-the-system-prompts-that-aider-uses)
 - [Can I run aider in Google Colab?](#can-i-run-aider-in-google-colab)
@@ -111,6 +112,19 @@ In these cases, here are some things you might try:
     - Etc...
   - Use `/drop` to remove files from the chat session which aren't needed for the task at hand. This will reduce distractions and may help GPT produce properly formatted edits.
   - Use `/clear` to remove the conversation history, again to help GPT focus.
+
+## Accessing other LLMs with OpenRouter
+
+[OpenRouter](https://openrouter.ai) provide an interface to [many models](https://openrouter.ai/docs) which are not widely accessible, in particular gpt-4-32k and claude-2.
+
+To access the openrouter models simply
+
+- register for an account, purchase some credits and generate an api key
+- set --openai-api-base to https://openrouter.ai/api/v1
+- set --openai-api-key to your openrouter key
+- set --model to the model of your choice (openai/gpt-4-32k, anthropic/claude-2 etc.)
+
+Some of the models weren't very functional and each llm has its own quirks. The anthropic models work ok, but the llama-2 ones in particular will need more work to play friendly with aider.
 
 ## Can I use aider with other LLMs, local LLMs, etc?
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,6 +28,7 @@ class TestModels(unittest.TestCase):
     @patch('openai.Model.list')
     def test_openrouter_model_properties(self, mock_model_list):
         import openai
+        old_base = openai.api_base
         openai.api_base = 'https://openrouter.ai/api/v1'
         mock_model_list.return_value = {
             'data': [
@@ -49,6 +50,7 @@ class TestModels(unittest.TestCase):
         self.assertEqual(model.max_context_tokens, 8192)
         self.assertEqual(model.prompt_price, 0.06)
         self.assertEqual(model.completion_price, 0.12)
+        openai.api_base = old_base
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,12 @@ class TestModels(unittest.TestCase):
         model = Model.create("gpt-4-32k-2123")
         self.assertEqual(model.max_context_tokens, 32 * 1024)
 
+    def test_openrouter_models(self):
+        import openai
+        openai.api_base = 'https://openrouter.ai/api/v1'
+        model = Model.create("gpt-3.5-turbo")
+        self.assertEqual(model.name, 'openai/gpt-3.5-turbo')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,22 +5,22 @@ from aider.models import Model
 
 class TestModels(unittest.TestCase):
     def test_max_context_tokens(self):
-        model = Model("gpt-3.5-turbo")
+        model = Model.create("gpt-3.5-turbo")
         self.assertEqual(model.max_context_tokens, 4 * 1024)
 
-        model = Model("gpt-3.5-turbo-16k")
+        model = Model.create("gpt-3.5-turbo-16k")
         self.assertEqual(model.max_context_tokens, 16 * 1024)
 
-        model = Model("gpt-4")
+        model = Model.create("gpt-4")
         self.assertEqual(model.max_context_tokens, 8 * 1024)
 
-        model = Model("gpt-4-32k")
+        model = Model.create("gpt-4-32k")
         self.assertEqual(model.max_context_tokens, 32 * 1024)
 
-        model = Model("gpt-4-0101")
+        model = Model.create("gpt-4-0101")
         self.assertEqual(model.max_context_tokens, 8 * 1024)
 
-        model = Model("gpt-4-32k-2123")
+        model = Model.create("gpt-4-32k-2123")
         self.assertEqual(model.max_context_tokens, 32 * 1024)
 
 


### PR DESCRIPTION
Enabling aider to work with openrouter.ai as per #170 

If openai-api-base has openrouter.ai in it then it will use a different model class to instantiate and dynamically load the costs and max_tokens from the model list.

It works for all the manual testing I did but needs unit tests and more thorough testing, particularly of the chat summary feature and the finish_reason change (which openrouter api doesn't support).

Keen for feedback from @paul-gauthier on the approach taken before doing more work on tests and polish.