### PR TITLE
Only commit dirty files if GPT tries to edit them #200

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ### main branch
 
+- [Only git commit dirty files that GPT tries to edit](https://aider.chat/docs/faq.html#how-does-aider-use-git)
 - Send chat history as prompt/context for Whisper voice transcription
 - Added `--voice-language` switch to constrain `/voice` to transcribe to a specific language
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -190,9 +190,6 @@ class Coder:
         for fname in self.get_inchat_relative_files():
             self.io.tool_output(f"Added {fname} to the chat.")
 
-        if self.repo:
-            self.repo.add_new_files(fname for fname in fnames if not Path(fname).is_dir())
-
         self.summarizer = ChatSummary()
         self.summarizer_thread = None
         self.summarized_done_messages = None

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -801,13 +801,17 @@ class Coder:
 
         return res
 
+    def update_files(self):
+        edits = self.get_edits()
+        edits = self.prepare_to_edit(edits)
+        self.apply_edits(edits)
+        return set(edit[0] for edit in edits)
+
     def apply_updates(self):
         max_apply_update_errors = 3
 
         try:
-            edits = self.get_edits()
-            edits = self.prepare_to_edit(edits)
-            self.apply_edits(edits)
+            edited = self.update_files()
         except ValueError as err:
             err = err.args[0]
             self.apply_update_errors += 1
@@ -833,11 +837,7 @@ class Coder:
 
         self.apply_update_errors = 0
 
-        # TODO FIXME: make sure
-        edited = set()
-        for edit in sorted(edits):
-            path = edit[0]
-            edited.add(path)
+        for path in edited:
             if self.dry_run:
                 self.io.tool_output(f"Did not apply edit to {path} (--dry-run)")
             else:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -726,7 +726,8 @@ class Coder:
 
     def allowed_to_edit(self, path):
         full_path = self.abs_root_path(path)
-        is_in_repo = self.repo.path_in_repo(path)
+        if self.repo:
+            is_in_repo = self.repo.path_in_repo(path)
 
         if full_path in self.abs_fnames:
             self.check_for_dirty_commit(path)

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -409,11 +409,6 @@ class Coder:
             self.commands,
         )
 
-        if self.should_dirty_commit(inp) and self.dirty_commit():
-            if inp.strip():
-                self.io.tool_output("Use up-arrow to retry previous command:", inp)
-            return
-
         if not inp:
             return
 
@@ -899,20 +894,6 @@ class Coder:
 
         self.io.tool_output("No changes made to git tracked files.")
         return self.gpt_prompts.files_content_gpt_no_edits
-
-    def should_dirty_commit(self, inp):
-        return
-        cmds = self.commands.matching_commands(inp)
-        if cmds:
-            matching_commands, _, _ = cmds
-            if len(matching_commands) == 1:
-                cmd = matching_commands[0][1:]
-                if cmd in "add clear commit diff drop exit help ls tokens".split():
-                    return
-
-        if self.last_asked_for_commit_time >= self.get_last_modified():
-            return
-        return True
 
     def dirty_commit(self):
         if not self.need_commit_before_edits:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -739,8 +739,9 @@ class Coder:
 
     def allowed_to_edit(self, path):
         full_path = self.abs_root_path(path)
-        tracked_files = set(self.repo.get_tracked_files())
-        is_in_repo = path in tracked_files
+        if self.repo:
+            tracked_files = set(self.repo.get_tracked_files())
+            is_in_repo = path in tracked_files
 
         if full_path in self.abs_fnames:
             if self.check_for_dirty_commit(path):

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -745,7 +745,7 @@ class Coder:
 
                 # Seems unlikely that we needed to create the file, but it was
                 # actually already part of the repo.
-                # But let's handle this obscure corner case anyway.
+                # But let's only add if we need to, just to be safe.
                 if need_to_add:
                     self.repo.repo.git.add(full_path)
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -58,13 +58,7 @@ class Coder:
         io,
         **kwargs,
     ):
-        from . import (
-            EditBlockCoder,
-            EditBlockFunctionCoder,
-            SingleWholeFileFunctionCoder,
-            WholeFileCoder,
-            WholeFileFunctionCoder,
-        )
+        from . import EditBlockCoder, WholeFileCoder
 
         if not main_model:
             main_model = models.GPT35_16k
@@ -85,14 +79,6 @@ class Coder:
             return EditBlockCoder(main_model, io, **kwargs)
         elif edit_format == "whole":
             return WholeFileCoder(main_model, io, **kwargs)
-        elif edit_format == "whole-func":
-            return WholeFileFunctionCoder(main_model, io, **kwargs)
-        elif edit_format == "single-whole-func":
-            return SingleWholeFileFunctionCoder(main_model, io, **kwargs)
-        elif edit_format == "diff-func-list":
-            return EditBlockFunctionCoder("list", main_model, io, **kwargs)
-        elif edit_format in ("diff-func", "diff-func-string"):
-            return EditBlockFunctionCoder("string", main_model, io, **kwargs)
         else:
             raise ValueError(f"Unknown edit format {edit_format}")
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -479,7 +479,7 @@ class Coder:
 
         if edited:
             if self.repo and self.auto_commits and not self.dry_run:
-                saved_message = self.auto_commit(fnames=edited)
+                saved_message = self.auto_commit(edited)
             elif hasattr(self.gpt_prompts, "files_content_gpt_edits_no_repo"):
                 saved_message = self.gpt_prompts.files_content_gpt_edits_no_repo
             else:

--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -22,7 +22,8 @@ class EditBlockCoder(Coder):
         return edits
 
     def apply_edits(self, edits):
-        for path, full_path, original, updated in edits:
+        for path, original, updated in edits:
+            full_path = self.abs_root_path(path)
             content = self.io.read_text(full_path)
             content = do_replace(full_path, content, original, updated)
             if content:

--- a/aider/coders/editblock_func_coder.py
+++ b/aider/coders/editblock_func_coder.py
@@ -58,6 +58,7 @@ class EditBlockFunctionCoder(Coder):
     ]
 
     def __init__(self, code_format, *args, **kwargs):
+        raise RuntimeError("Deprecated, needs to be refactored to support get_edits/apply_edits")
         self.code_format = code_format
 
         if code_format == "string":
@@ -91,7 +92,7 @@ class EditBlockFunctionCoder(Coder):
         res = json.dumps(args, indent=4)
         return res
 
-    def update_files(self):
+    def _update_files(self):
         name = self.partial_response_function_call.get("name")
 
         if name and name != "replace_lines":

--- a/aider/coders/single_wholefile_func_coder.py
+++ b/aider/coders/single_wholefile_func_coder.py
@@ -31,6 +31,7 @@ class SingleWholeFileFunctionCoder(Coder):
     ]
 
     def __init__(self, *args, **kwargs):
+        raise RuntimeError("Deprecated, needs to be refactored to support get_edits/apply_edits")
         self.gpt_prompts = SingleWholeFileFunctionPrompts()
         super().__init__(*args, **kwargs)
 
@@ -94,7 +95,7 @@ class SingleWholeFileFunctionCoder(Coder):
 
         return "\n".join(show_diff)
 
-    def update_files(self):
+    def _update_files(self):
         name = self.partial_response_function_call.get("name")
         if name and name != "write_file":
             raise ValueError(f'Unknown function_call name="{name}", use name="write_file"')

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -46,7 +46,7 @@ class WholeFileCoder(Coder):
                     # ending an existing block
                     saw_fname = None
 
-                    full_path = (Path(self.root) / fname).absolute()
+                    full_path = self.abs_root_path(fname)
 
                     if mode == "diff":
                         output += self.do_live_diff(full_path, new_lines, True)
@@ -121,12 +121,13 @@ class WholeFileCoder(Coder):
         return refined_edits
 
     def apply_edits(self, edits):
-        for path, full_path, fname_source, new_lines in edits:
+        for path, fname_source, new_lines in edits:
+            full_path = self.abs_root_path(path)
             new_lines = "".join(new_lines)
             self.io.write_text(full_path, new_lines)
 
     def do_live_diff(self, full_path, new_lines, final):
-        if full_path.exists():
+        if Path(full_path).exists():
             orig_lines = self.io.read_text(full_path).splitlines(keepends=True)
 
             show_diff = diffs.diff_partial_update(

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -22,11 +22,11 @@ class WholeFileCoder(Coder):
 
     def render_incremental_response(self, final):
         try:
-            return self.update_files(mode="diff")
+            return self.get_edits(mode="diff")
         except ValueError:
             return self.partial_response_content
 
-    def update_files(self, mode="update"):
+    def get_edits(self, mode="update"):
         content = self.partial_response_content
 
         chat_files = self.get_inchat_relative_files()
@@ -104,22 +104,26 @@ class WholeFileCoder(Coder):
         if fname:
             edits.append((fname, fname_source, new_lines))
 
-        edited = set()
+        seen = set()
+        refined_edits = []
         # process from most reliable filename, to least reliable
         for source in ("block", "saw", "chat"):
             for fname, fname_source, new_lines in edits:
                 if fname_source != source:
                     continue
                 # if a higher priority source already edited the file, skip
-                if fname in edited:
+                if fname in seen:
                     continue
 
-                # we have a winner
-                new_lines = "".join(new_lines)
-                if self.allowed_to_edit(fname, new_lines):
-                    edited.add(fname)
+                seen.add(fname)
+                refined_edits.append((fname, fname_source, new_lines))
 
-        return edited
+        return refined_edits
+
+    def apply_edits(self, edits):
+        for path, full_path, fname_source, new_lines in edits:
+            new_lines = "".join(new_lines)
+            self.io.write_text(full_path, new_lines)
 
     def do_live_diff(self, full_path, new_lines, final):
         if full_path.exists():

--- a/aider/coders/wholefile_func_coder.py
+++ b/aider/coders/wholefile_func_coder.py
@@ -44,6 +44,8 @@ class WholeFileFunctionCoder(Coder):
     ]
 
     def __init__(self, *args, **kwargs):
+        raise RuntimeError("Deprecated, needs to be refactored to support get_edits/apply_edits")
+
         self.gpt_prompts = WholeFileFunctionPrompts()
         super().__init__(*args, **kwargs)
 
@@ -105,7 +107,7 @@ class WholeFileFunctionCoder(Coder):
 
         return "\n".join(show_diff)
 
-    def update_files(self):
+    def _update_files(self):
         name = self.partial_response_function_call.get("name")
         if name and name != "write_file":
             raise ValueError(f'Unknown function_call name="{name}", use name="write_file"')

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -230,7 +230,7 @@ class Commands:
             return
 
         commits = f"{self.coder.last_aider_commit_hash}~1"
-        diff = self.coder.repo.get_diffs(
+        diff = self.coder.repo.diff_commits(
             self.coder.pretty,
             commits,
             self.coder.last_aider_commit_hash,

--- a/aider/main.py
+++ b/aider/main.py
@@ -522,7 +522,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
 
     io.tool_output("Use /help to see in-chat commands, run with --help to see cmd line args")
 
-    coder.dirty_commit()
+    # coder.dirty_commit()
 
     if args.message:
         io.tool_output()

--- a/aider/main.py
+++ b/aider/main.py
@@ -522,8 +522,6 @@ def main(argv=None, input=None, output=None, force_git_root=None):
 
     io.tool_output("Use /help to see in-chat commands, run with --help to see cmd line args")
 
-    # coder.dirty_commit()
-
     if args.message:
         io.tool_output()
         coder.run(with_message=args.message)

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -56,7 +56,10 @@ class GitRepo:
         if message:
             commit_message = message
         else:
-            diffs = self.get_diffs(False)
+            diff_args = []
+            if fnames:
+                diff_args += ["--"] + list(fnames)
+            diffs = self.get_diffs(False, *diff_args)
             commit_message = self.get_commit_message(diffs, context)
 
         if not commit_message:

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -190,5 +190,5 @@ class GitRepo:
 
         return res
 
-    def is_dirty(self):
-        return self.repo.is_dirty()
+    def is_dirty(self, path=None):
+        return self.repo.is_dirty(path=path)

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -59,7 +59,9 @@ class GitRepo:
             diff_args = []
             if fnames:
                 diff_args += ["--"] + list(fnames)
+            dump(diff_args)
             diffs = self.get_diffs(False, *diff_args)
+            dump(diffs)
             commit_message = self.get_commit_message(diffs, context)
 
         if not commit_message:
@@ -134,6 +136,7 @@ class GitRepo:
         if args:
             if pretty:
                 args = ["--color"] + args
+            dump(args)
             return self.repo.git.diff(*args)
 
         # otherwise, we always want diffs of index and working dir

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -49,16 +49,6 @@ class GitRepo:
         self.repo = git.Repo(repo_paths.pop(), odbt=git.GitDB)
         self.root = utils.safe_abs_path(self.repo.working_tree_dir)
 
-    def add_new_files(self, fnames):
-        cur_files = [str(Path(fn).resolve()) for fn in self.get_tracked_files()]
-        for fname in fnames:
-            if str(Path(fname).resolve()) in cur_files:
-                continue
-            if not Path(fname).exists():
-                continue
-            self.io.tool_output(f"Adding {fname} to git")
-            self.repo.git.add(fname)
-
     def commit(self, context=None, prefix=None, message=None):
         if not self.repo.is_dirty():
             return

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -74,7 +74,7 @@ class GitRepo:
 
         cmd = ["-m", full_commit_message, "--no-verify"]
         if fnames:
-            fnames = [str(self.full_path(fn)) for fn in fnames]
+            fnames = [str(self.abs_root_path(fn)) for fn in fnames]
             for fname in fnames:
                 self.repo.git.add(fname)
             cmd += ["--"] + fnames
@@ -199,8 +199,9 @@ class GitRepo:
         tracked_files = set(self.get_tracked_files())
         return path in tracked_files
 
-    def full_path(self, path):
-        return (Path(self.root) / path).resolve()
+    def abs_root_path(self, path):
+        res = Path(self.root) / path
+        return utils.safe_abs_path(res)
 
     def is_dirty(self, path=None):
         if path and not self.path_in_repo(path):

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,29 +13,29 @@
 It is recommended that you use aider with code that is part of a git repo.
 This allows aider to maintain the safety of your code. Using git makes it easy to:
 
-  - Review the changes GPT made to your code
-  - Undo changes that weren't appropriate
+  - Undo any changes that weren't appropriate
+  - Go back later to review the changes GPT made to your code
   - Manage a series of GPT's changes on a git branch
-  - etc
 
-Working without git means that GPT might drastically change your code without an easy way to undo the changes.
+Working without git means that GPT might drastically change your code
+without an easy way to undo the changes.
 
 Aider tries to provide safety using git in a few ways:
 
   - It asks to create a git repo if you launch it in a directory without one.
-  - When you add a file to the chat, aider asks permission to add it to the git repo if needed.
-  - At launch and before sending requests to GPT, aider checks if the repo is dirty and offers to commit those changes for you. This way, the GPT changes will be applied to a clean repo and won't be intermingled with your own changes.
-  - After GPT changes your code, aider commits those changes with a descriptive commit message.
-
+  - Whenever GPT edits a file, those changes are committed with a descriptive commit message. This makes it easy to revert or review GPT's changes.
+  - If GPT tries to edit files that already have uncommitted changes (dirty files), aider will first commit those existing changes with a descriptive commit message. This makes sure you never lose your work if GPT makes an inappropriate change to uncommitted code.  
+  
 Aider also allows you to use in-chat commands to `/diff` or `/undo` the last change made by GPT.
-To do more complex management of your git history, you should use `git` on the command line outside of aider.
+To do more complex management of your git history, you cat use raw `git` commands,
+either by using `/git` or with git tools outside of aider.
 You can start a branch before using aider to make a sequence of changes.
 Or you can `git reset` a longer series of aider changes that didn't pan out. Etc.
 
 While it is not recommended, you can disable aider's use of git in a few ways:
 
   - `--no-auto-commits` will stop aider from git committing each of GPT's changes.
-  - `--no-dirty-commits` will stop aider from ensuring your repo is clean before sending requests to GPT.
+  - `--no-dirty-commits` will stop aider from committing dirty files before applying GPT's edits.
   - `--no-git` will completely stop aider from using git on your files. You should ensure you are keeping sensible backups of the files you are working with.
 
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -94,26 +94,6 @@ class TestCoder(unittest.TestCase):
             fname.unlink()
             self.assertEqual(coder.get_last_modified(), 0)
 
-    def test_should_dirty_commit(self):
-        # Mock the IO object
-        mock_io = MagicMock()
-
-        with GitTemporaryDirectory():
-            repo = git.Repo(Path.cwd())
-            fname = Path("new.txt")
-            fname.touch()
-            repo.git.add(str(fname))
-            repo.git.commit("-m", "new")
-
-            # Initialize the Coder object with the mocked IO and mocked repo
-            coder = Coder.create(models.GPT4, None, mock_io)
-
-            fname.write_text("hi")
-            self.assertTrue(coder.should_dirty_commit("hi"))
-
-            self.assertFalse(coder.should_dirty_commit("/exit"))
-            self.assertFalse(coder.should_dirty_commit("/help"))
-
     def test_check_for_file_mentions(self):
         # Mock the IO object
         mock_io = MagicMock()

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -512,10 +512,6 @@ three
 
             coder.run(with_message="hi")
 
-            print("=" * 20)
-            print(repo.git.log(["-p"]))
-            print("=" * 20)
-
             content = fname.read_text()
             self.assertEqual(content, "three\n")
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -382,8 +382,9 @@ class TestCoder(unittest.TestCase):
 
             self.assertTrue(fname.exists())
 
+            # make sure it was not committed
             with self.assertRaises(git.exc.GitCommandError):
-                repo.iter_commits(repo.active_branch.name)
+                list(repo.iter_commits(repo.active_branch.name))
 
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -227,7 +227,6 @@ class TestCoder(unittest.TestCase):
             mock.return_value = set([str(fname)])
             coder.repo.get_tracked_files = mock
 
-            dump(fname)
             # Call the check_for_file_mentions method
             coder.check_for_file_mentions(f"Please check `{fname}`")
 
@@ -524,14 +523,12 @@ three
             self.assertEqual(num_commits, 3)
 
             diff = repo.git.diff(["HEAD~2", "HEAD~1"])
-            dump(diff)
             self.assertIn("one", diff)
             self.assertIn("two", diff)
             self.assertNotIn("three", diff)
             self.assertNotIn("other", diff)
             self.assertNotIn("OTHER", diff)
 
-            dump(saved_diffs)
             diff = saved_diffs[0]
             self.assertIn("one", diff)
             self.assertIn("two", diff)
@@ -553,7 +550,6 @@ three
             self.assertNotIn("other", diff)
             self.assertNotIn("OTHER", diff)
 
-            dump(saved_diffs)
             self.assertEqual(len(saved_diffs), 2)
 
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -406,7 +406,10 @@ new
             self.assertEqual(num_commits, 1)
 
     def test_only_commit_gpt_edited_file(self):
-        """Only commit file that gpt edits, not other dirty files"""
+        """
+        Only commit file that gpt edits, not other dirty files.
+        Also ensure commit msg only depends on diffs from the GPT edited file.
+        """
 
         with GitTemporaryDirectory():
             repo = git.Repo()
@@ -441,9 +444,13 @@ TWO
 """
                 coder.partial_response_function_call = dict()
 
+            def mock_get_commit_message(diffs, context):
+                self.assertNotIn("one", diffs)
+                self.assertNotIn("ONE", diffs)
+                return "commit message"
+
             coder.send = MagicMock(side_effect=mock_send)
-            coder.repo.get_commit_message = MagicMock()
-            coder.repo.get_commit_message.return_value = "commit message"
+            coder.repo.get_commit_message = MagicMock(side_effect=mock_get_commit_message)
 
             coder.run(with_message="hi")
 

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -42,33 +42,47 @@ class TestCoder(unittest.TestCase):
 
     def test_allowed_to_edit(self):
         with GitTemporaryDirectory():
-            repo = git.Repo(Path.cwd())
-            fname = Path("foo.txt")
+            repo = git.Repo()
+
+            fname = Path("added.txt")
             fname.touch()
             repo.git.add(str(fname))
+
+            fname = Path("repo.txt")
+            fname.touch()
+            repo.git.add(str(fname))
+
             repo.git.commit("-m", "init")
 
+            # YES!
             io = InputOutput(yes=True)
-            # Initialize the Coder object with the mocked IO and mocked repo
-            coder = Coder.create(models.GPT4, None, io, fnames=["foo.txt"])
+            coder = Coder.create(models.GPT4, None, io, fnames=["added.txt"])
 
-            self.assertTrue(coder.allowed_to_edit("foo.txt"))
+            self.assertTrue(coder.allowed_to_edit("added.txt"))
+            self.assertTrue(coder.allowed_to_edit("repo.txt"))
             self.assertTrue(coder.allowed_to_edit("new.txt"))
 
     def test_allowed_to_edit_no(self):
         with GitTemporaryDirectory():
-            repo = git.Repo(Path.cwd())
-            fname = Path("foo.txt")
+            repo = git.Repo()
+
+            fname = Path("added.txt")
             fname.touch()
             repo.git.add(str(fname))
+
+            fname = Path("repo.txt")
+            fname.touch()
+            repo.git.add(str(fname))
+
             repo.git.commit("-m", "init")
 
             # say NO
             io = InputOutput(yes=False)
 
-            coder = Coder.create(models.GPT4, None, io, fnames=["foo.txt"])
+            coder = Coder.create(models.GPT4, None, io, fnames=["added.txt"])
 
-            self.assertTrue(coder.allowed_to_edit("foo.txt"))
+            self.assertTrue(coder.allowed_to_edit("added.txt"))
+            self.assertFalse(coder.allowed_to_edit("repo.txt"))
             self.assertFalse(coder.allowed_to_edit("new.txt"))
 
     def test_get_last_modified(self):

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -380,6 +380,11 @@ class TestCoder(unittest.TestCase):
             io = InputOutput(yes=True)
             coder = Coder.create(models.GPT4, "diff", io=io, fnames=[str(fname)])
 
+            self.assertTrue(fname.exists())
+
+            ### TODO: assert that the next line raises git.exc.GitCommandError
+            repo.iter_commits(repo.active_branch.name)
+
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""
 Do this:

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -382,8 +382,8 @@ class TestCoder(unittest.TestCase):
 
             self.assertTrue(fname.exists())
 
-            ### TODO: assert that the next line raises git.exc.GitCommandError
-            repo.iter_commits(repo.active_branch.name)
+            with self.assertRaises(git.exc.GitCommandError):
+                repo.iter_commits(repo.active_branch.name)
 
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -26,7 +26,7 @@ class TestRepo(unittest.TestCase):
             fname.write_text("workingdir\n")
 
             git_repo = GitRepo(InputOutput(), None, ".")
-            diffs = git_repo.get_diffs(False)
+            diffs = git_repo.get_diffs()
             self.assertIn("index", diffs)
             self.assertIn("workingdir", diffs)
 
@@ -49,7 +49,7 @@ class TestRepo(unittest.TestCase):
             fname2.write_text("workingdir\n")
 
             git_repo = GitRepo(InputOutput(), None, ".")
-            diffs = git_repo.get_diffs(False)
+            diffs = git_repo.get_diffs()
             self.assertIn("index", diffs)
             self.assertIn("workingdir", diffs)
 
@@ -67,7 +67,7 @@ class TestRepo(unittest.TestCase):
             repo.git.commit("-m", "second")
 
             git_repo = GitRepo(InputOutput(), None, ".")
-            diffs = git_repo.get_diffs(False, ["HEAD~1", "HEAD"])
+            diffs = git_repo.diff_commits(False, "HEAD~1", "HEAD")
             dump(diffs)
             self.assertIn("two", diffs)
 

--- a/tests/test_wholefile.py
+++ b/tests/test_wholefile.py
@@ -90,7 +90,7 @@ class TestWholeFileCoder(unittest.TestCase):
         # Set the partial response content with the updated content
         coder.partial_response_content = f"{sample_file}\n```\n0\n\1\n2\n"
 
-        lines = coder.update_files(mode="diff").splitlines()
+        lines = coder.get_edits(mode="diff").splitlines()
 
         # the live diff should be concise, since we haven't changed anything yet
         self.assertLess(len(lines), 20)


### PR DESCRIPTION

Discussed in #200

If GPT tries to edit a dirty file, aider will just commit the dirty changes (with a nice message) before applying and committing GPT's edits.

You now never get interrupted and asked about pending dirty changes. Aider just commits them for you to keep them distinct from GPT's edits and preserve the ability to cleanly undo GPT's changes. And dirty changes are only ever committed by aider if the file is about to get modified by GPT.

As always, aider still respects the --no-dirty-commits flag. If set, it will apply GPT's edits without first committing dirty files.
