### PR TITLE
Add --skip-model-availability-check option

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -55,7 +55,7 @@ class Coder:
         main_model,
         edit_format,
         io,
-        skip_model_availabily_check,
+        skip_model_availabily_check=False,
         **kwargs,
     ):
         from . import EditBlockCoder, WholeFileCoder

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -55,6 +55,7 @@ class Coder:
         main_model,
         edit_format,
         io,
+        skip_model_availabily_check,
         **kwargs,
     ):
         from . import EditBlockCoder, WholeFileCoder
@@ -62,7 +63,7 @@ class Coder:
         if not main_model:
             main_model = models.GPT35_16k
 
-        if not main_model.always_available:
+        if not skip_model_availabily_check and not main_model.always_available:
             if not check_model_availability(main_model):
                 if main_model != models.GPT4:
                     io.tool_error(

--- a/aider/main.py
+++ b/aider/main.py
@@ -143,6 +143,12 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         help=f"Specify the model to use for the main chat (default: {models.GPT4.name})",
     )
     core_group.add_argument(
+        "--skip-model-availability-check",
+        metavar="SKIP_MODEL_AVAILABILITY_CHECK",
+        default=False,
+        help="Override to skip model availability check (default: False)",
+    )
+    core_group.add_argument(
         "-3",
         action="store_const",
         dest="model",
@@ -465,6 +471,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             main_model,
             args.edit_format,
             io,
+            args.skip_model_availability_check,
             ##
             fnames=fnames,
             git_dname=git_dname,


### PR DESCRIPTION
Adding a `--skip-model-availability-check` flag to skip model availability check. 

This is needed to make Aider work with our internal Azure OpenAI proxy which does not fully support model check calls. 