### PR TITLE
(Docs) Add support for Anthropic, Huggingface TGI, Palm, Cohere, Replicate, etc.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -154,6 +154,11 @@ and
 [SimpleAI](https://github.com/lhenault/simpleAI)
 look like relevant tools to serve local models via a compatible API.
 
+### Other Hosted LLMs ( Anthropic,Huggingface,Palm,Ollama, etc.[Full List](https://docs.litellm.ai/docs/providers))
+
+[LiteLLM](https://github.com/BerriAI/litellm) has a tutorial for using creating a local OpenAI-compatible API, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+[Tutorial](https://docs.litellm.ai/docs/proxy_server#tutorial-use-with-aiderautogencontinue-devlangroidetc)
 
 ### Azure
 


### PR DESCRIPTION
Hey @paul-gauthier,

Based on your feedback on a few previous PRs - https://github.com/paul-gauthier/aider/pull/251, 

My PR shows users how to call their custom LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing the api base to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation with Aider.

This makes **no code changes** to Aider.

Happy to add additional tests/documentation if the initial PR looks good.

I have been testing this with aider for the past week (primarily with claude-2 and codellama). 