### PR TITLE
repomap.get_tags_raw doesn't crash on UTF-16 files

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -143,8 +143,11 @@ class RepoMap:
             return
         query_scm = query_scm.read_text()
 
-        code = Path(fname).read_text(encoding=self.io.encoding)
-        tree = parser.parse(bytes(code, "utf-8"))
+        try:
+            code = Path(fname).read_text(encoding=self.io.encoding)
+            tree = parser.parse(bytes(code, "utf-8"))
+        except UnicodeDecodeError:
+            return
 
         # Run the tags queries
         query = language.query(query_scm)


### PR DESCRIPTION
Related to #305, Aider would crash while building a repomap when attempting to load a file with non UTF-16 content. This commit adds a try/except block that returns nothing back to the caller, allowing repomap to skip the file and continue.

Future considerations might be to use the read_file function in `io.py`

I've not run any tests other than ensuring that `/tokens` does not crash when a non UTF-8 file is present in the Git repo.