### PR TITLE
RFC - Allow adding a github issue to chat context

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -103,6 +103,7 @@ class Coder:
         use_git=True,
         voice_language=None,
         aider_ignore_file=None,
+        github_repo=None,
     ):
         if not fnames:
             fnames = []
@@ -203,6 +204,8 @@ class Coder:
             if self.verbose:
                 self.io.tool_output("JSON Schema:")
                 self.io.tool_output(json.dumps(self.functions, indent=4))
+
+        self.github_repo = github_repo
 
     def find_common_root(self):
         if len(self.abs_fnames) == 1:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -438,7 +438,7 @@ class Coder:
     def run_loop(self):
         inp = self.io.get_input(
             self.root,
-            self.get_inchat_relative_files(),
+            self.get_inchat_relative_files() + list(self.additional_context.keys()),
             self.get_addable_relative_files(),
             self.commands,
         )

--- a/aider/coders/base_prompts.py
+++ b/aider/coders/base_prompts.py
@@ -6,3 +6,5 @@ class CoderPrompts:
     files_content_gpt_no_edits = "I didn't see any properly formatted edits in your reply?!"
 
     files_content_local_edits = "I edited the files myself."
+
+    additional_context_prefix = "Here is some context for our conversation."

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -136,6 +136,11 @@ class Commands:
             content = f"{relative_fname}\n```\n" + content + "```\n"
             tokens = len(self.tokenizer.encode(content))
             res.append((tokens, f"{relative_fname}", "use /drop to drop from chat"))
+            
+        # additional context
+        for key, value in self.coder.additional_context.items():
+            tokens = len(self.tokenizer.encode(value))
+            res.append((tokens, f"{key}", "use /drop to drop from chat"))
 
         self.io.tool_output("Approximate context window usage, in tokens:")
         self.io.tool_output()

--- a/aider/github.py
+++ b/aider/github.py
@@ -1,0 +1,39 @@
+from github import Github
+
+
+class GithubRepo:
+    """A class for interacting with a github repository."""
+
+    def __init__(self, token, repo_name) -> None:
+        self.github = Github(token)
+        self.repo = self.github.get_repo(repo_name)
+        self.issue_numbers = []
+
+    def get_issue_numbers(self) -> list:
+        if not self.issue_numbers:
+            self.issue_numbers = [issue.number for issue in self.repo.get_issues()]
+        return self.issue_numbers
+
+    def get_issue_content(self, issue_number: int) -> str:
+        "Get the content of an issue"
+
+        try:
+            issue = self.repo.get_issue(number=issue_number)
+        except:
+            return ""
+
+        issue_content = ""
+        if issue.title:
+            issue_content += f"Title: {issue.title}\n\n"
+        if issue.body:
+            issue_content += f"Body:\n{issue.body}\n\n"
+
+        comments = issue.get_comments()
+        if comments.totalCount > 0:
+            issue_content += "Comments:\n"
+            for comment in issue.get_comments():
+                issue_content += f"{comment.user.login}: {comment.body}\n"
+
+            issue_content += "\n"
+
+        return issue_content

--- a/aider/main.py
+++ b/aider/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import configargparse
 import git
 import openai
+from aider.github import GithubRepo
 
 from aider import __version__, models
 from aider.coders import Coder
@@ -342,6 +343,27 @@ def main(argv=None, input=None, output=None, force_git_root=None):
     )
 
     ##########
+    github_group = parser.add_argument_group("Github Settings")
+    github_group.add_argument(
+        "--github",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable/disable getting information from github (default: False))",
+    )
+    github_group.add_argument(
+        "--github-token",
+        metavar="TOKEN",
+        help="Specify the Github API token",
+        env_var="GITHUB_TOKEN",
+    )
+    github_group.add_argument(
+        "--github-repo",
+        metavar="GITHUB_REPO",
+        help="Specify the Github repo to use",
+        env_var="GITHUB_REPO",
+    )
+
+    ##########
     other_group = parser.add_argument_group("Other Settings")
     other_group.add_argument(
         "--version",
@@ -468,6 +490,24 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         if args.gitignore:
             check_gitignore(git_root, io)
 
+    github_repo = None
+    if args.github:
+        if not args.github_token:
+            io.tool_error(
+                "No Github token provided. Use --github-token or setx GITHUB_TOKEN (or export"
+                " GITHUB_TOKEN)."
+            )
+            return 1
+
+        if not args.github_repo:
+            io.tool_error(
+                "No Github repo provided. Use --github-repo or setx GITHUB_REPO (or export"
+                " GITHUB_REPO)."
+            )
+            return 1
+                
+        github_repo = GithubRepo(args.github_token, args.github_repo)
+
     def scrub_sensitive_info(text):
         # Replace sensitive information with placeholder
         return text.replace(args.openai_api_key, "***")
@@ -525,6 +565,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             use_git=args.git,
             voice_language=args.voice_language,
             aider_ignore_file=args.aiderignore,
+            github_repo=github_repo,
         )
     except ValueError as err:
         io.tool_error(str(err))

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,3 +117,4 @@ wcwidth==0.2.9
     # via prompt-toolkit
 yarl==1.9.2
     # via aiohttp
+PyGithub==2.1.1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,6 +6,7 @@ import tempfile
 from io import StringIO
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 import git
 
@@ -485,3 +486,18 @@ class TestCommands(TestCase):
 
         commands.cmd_add("file.txt")
         self.assertEqual(coder.abs_fnames, set())
+
+    def test_cmd_add_issue(self):
+        with ChdirTemporaryDirectory():
+            io = InputOutput(pretty=False, yes=False)
+            from aider.coders import Coder
+
+            coder = Coder.create(models.GPT35, None, io)
+            coder.github_repo = MagicMock()
+            coder.github_repo.get_issue_numbers.return_value = [1]
+            coder.github_repo.get_issue_content.return_value = "Issue content"
+            commands = Commands(io, coder)
+
+            commands.cmd_add(R"\issue-1")
+            self.assertIn(R"\issue-1", coder.additional_context.keys())
+            self.assertEqual("Issue content", coder.additional_context[R"\issue-1"])


### PR DESCRIPTION
Hi, would you like to take a look on this feature?

In the first commit I changed Coder to allow adding arbitrary additional context in the begining of the chat.
In the second commit I used this infra to add github issues to the chat.

I didn't add a new command, instead I extended `/add` to allow `/add \issue-3`.
The feature is disabled by default and enabled with a flag. If enabled, the user need to supply github repository name and authentication token.

Thanks
Omri