### PR TITLE
Reduce "Malformed Responses" by a minor change in the prompt

### DIFF
--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -22,17 +22,17 @@ Once you understand the request you MUST:
 {fence[0]}python
 some/dir/example.py
 <<<<<<< SEARCH
-    # Multiplication function
-    def multiply(a,b)
-        "multiply 2 numbers"
+# Multiplication function
+def multiply(a,b)
+    "multiply 2 numbers"
 
-        return a*b
+    return a*b
 =======
-    # Addition function
-    def add(a,b):
-        "add 2 numbers"
+# Addition function
+def add(a,b):
+    "add 2 numbers"
 
-        return a+b
+    return a+b
 >>>>>>> REPLACE
 {fence[1]}
 


### PR DESCRIPTION
This change has positive effect on ratio of malformed response.
I discovered it while testing another change, in which I add line numbers to code.

I run the Exercism python benchmarks, consisting of 135 tests, using gpt-4-turbo.
- The number of chats with malformed response went down from 14 to 9
- The total number of malformed responses went down from 21 to 15

Does this difference justifies a change?
Do you want additional benchmarking?

About performance, I saw minor improvment.
community -> community+change:
- 1st try 50.04% -> 51.1%
- 2nd try 61.5% -> 63%

I know it doesn't reproduce your results, I guess difference comes from chatgpt randomness.
I counted malformed responses from the chat history, using excel and this script:
https://gist.github.com/omri123/6c0f4a07e3c25ac059e04ddeeaf7f62c
