### PR TITLE
Add Line numbers

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -239,9 +239,14 @@ class Coder:
 
         return True
 
+    def get_code_view(self, code):
+        """override this method to customize the code before sending to assistant"""
+        return code
+
     def get_abs_fnames_content(self):
         for fname in list(self.abs_fnames):
             content = self.io.read_text(fname)
+            content = self.get_code_view(content)
 
             if content is None:
                 relative_fname = self.get_rel_fname(fname)

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -22,17 +22,17 @@ Once you understand the request you MUST:
 {fence[0]}python
 some/dir/example.py
 <<<<<<< SEARCH
-    # Multiplication function
-    def multiply(a,b)
-        "multiply 2 numbers"
-
-        return a*b
+   1|# Multiplication function
+   2|def multiply(a,b)
+   3|    "multiply 2 numbers"
+   4|
+   5|    return a*b
 =======
-    # Addition function
-    def add(a,b):
-        "add 2 numbers"
-
-        return a+b
+   1|# Addition function
+   2|def add(a,b):
+   3|    "add 2 numbers"
+   4|
+   5|    return a+b
 >>>>>>> REPLACE
 {fence[1]}
 

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -19,20 +19,37 @@ Once you understand the request you MUST:
 
     system_reminder = """You MUST use a *SEARCH/REPLACE block* to modify the source file:
 
+For example, when changing some/dir/example.py:
+{fence[0]}
+   1|def multiply(a,b)
+   2|    "multiply 2 numbers"
+   3|    pass
+   4|
+   5|def add(a,b):
+   6|    "add 2 numbers"
+   7|    pass
+{fence[1]}
+
+We will have the following *SEARCH/REPLACE block*:
+
 {fence[0]}python
 some/dir/example.py
 <<<<<<< SEARCH
-   1|# Multiplication function
-   2|def multiply(a,b)
-   3|    "multiply 2 numbers"
+   1|def multiply(a,b)
+   2|    "multiply 2 numbers"
+   3|    pass
    4|
-   5|    return a*b
+   5|def add(a,b):
+   6|    "add 2 numbers"
+   7|    pass
 =======
-   1|# Addition function
-   2|def add(a,b):
-   3|    "add 2 numbers"
+   1|def multiply(a,b)
+   2|    "multiply 2 numbers"
+   3|    return a * b
    4|
-   5|    return a+b
+   5|def add(a,b):
+   6|    "add 2 numbers"
+   7|    return a + b
 >>>>>>> REPLACE
 {fence[1]}
 


### PR DESCRIPTION
I this pair of patches, I added line numbers both to files and to code in the prompt.
When creating SEARCH/REPLACE blocks aider write code with line numbers as well, and I chanegd the parser to handle it. When parsing I ignore the numbers and use existing SEARCH/REPLACE.

When benchmarking, it gives a small positive performance difference, and additional small improvement in the cases of "Malformed response".

This change allow me to tell aider things like this.

```
You can use the following commands to get information from files outside the chat:
\\GetDefinition of <symboll> used in <file>,<line>
```
I am writing a vscode extension that will be able to perform this kind of commands, soon I will make it public and open source.