### PR TITLE
Add `--message-file` flag and unit test

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -381,6 +381,12 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         help="Specify a single message to send GPT, process reply then exit (disables chat mode)",
     )
     other_group.add_argument(
+        "--message-file",
+        "-mf",
+        metavar="MESSAGE_FILE",
+        help="Specify a file containing the message to send GPT, process reply, then exit (disables chat mode)",
+    )
+    other_group.add_argument(
         "--encoding",
         default="utf-8",
         help="Specify the encoding for input and output (default: utf-8)",
@@ -563,6 +569,18 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         io.add_to_input_history(args.message)
         io.tool_output()
         coder.run(with_message=args.message)
+    elif args.message_file:
+        try:
+            with open(args.message_file, 'r', encoding='utf-8') as file:
+                message_from_file = file.read()
+            io.tool_output()
+            coder.run(with_message=message_from_file)
+        except FileNotFoundError:
+            io.tool_error(f"Message file not found: {args.message_file}")
+            return 1
+        except IOError as e:
+            io.tool_error(f"Error reading message file: {e}")
+            return 1
     else:
         coder.run()
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -382,7 +382,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
     )
     other_group.add_argument(
         "--message-file",
-        "-mf",
+        "-f",
         metavar="MESSAGE_FILE",
         help="Specify a file containing the message to send GPT, process reply, then exit (disables chat mode)",
     )
@@ -571,8 +571,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         coder.run(with_message=args.message)
     elif args.message_file:
         try:
-            with open(args.message_file, 'r', encoding='utf-8') as file:
-                message_from_file = file.read()
+            message_from_file = io.read_text(args.message_file)
             io.tool_output()
             coder.run(with_message=message_from_file)
         except FileNotFoundError:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -182,6 +182,20 @@ class TestMain(TestCase):
             _, kwargs = MockCoder.call_args
             assert kwargs["dirty_commits"] is True
 
+    @patch('aider.main.InputOutput.confirm_ask', return_value=True)
+    def test_message_file_flag(self, mock_confirm):
+        message_file_content = "This is a test message from a file."
+        message_file_path = "test_message.txt"
+        with open(message_file_path, 'w', encoding='utf-8') as message_file:
+            message_file.write(message_file_content)
+
+        with patch("aider.main.Coder.create") as MockCoder:
+            MockCoder.return_value.run = MagicMock()
+            main(["--message-file", message_file_path], input=DummyInput(), output=DummyOutput())
+            MockCoder.return_value.run.assert_called_once_with(with_message=message_file_content)
+
+        os.remove(message_file_path)
+
     def test_encodings_arg(self):
         fname = "foo.py"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -182,16 +182,15 @@ class TestMain(TestCase):
             _, kwargs = MockCoder.call_args
             assert kwargs["dirty_commits"] is True
 
-    @patch('aider.main.InputOutput.confirm_ask', return_value=True)
-    def test_message_file_flag(self, mock_confirm):
+    def test_message_file_flag(self):
         message_file_content = "This is a test message from a file."
-        message_file_path = "test_message.txt"
+        message_file_path = tempfile.mktemp()
         with open(message_file_path, 'w', encoding='utf-8') as message_file:
             message_file.write(message_file_content)
 
         with patch("aider.main.Coder.create") as MockCoder:
             MockCoder.return_value.run = MagicMock()
-            main(["--message-file", message_file_path], input=DummyInput(), output=DummyOutput())
+            main(["--yes", "--message-file", message_file_path], input=DummyInput(), output=DummyOutput())
             MockCoder.return_value.run.assert_called_once_with(with_message=message_file_content)
 
         os.remove(message_file_path)


### PR DESCRIPTION
This commit introduces the `--message-file` flag to the `aider` tool, allowing users to specify a file containing the message to send to GPT. This feature processes the reply and then exits, disabling the chat mode. The implementation includes reading the content of the specified file and using it as the prompt message.

Additionally, a unit test has been added to `tests/test_main.py` to ensure the correct functionality of the `--message-file` flag. The test includes necessary mocks to handle non-interactive environments and verifies that the tool behaves as expected when a message file is provided.

This enhancement improves the usability of the `aider` tool for users who prefer or require non-interactive execution, such as in scripting or automated workflows.

Tested using:

```
# https://github.com/paul-gauthier/aider or when working on a patch on fork:
docker build --file docker/Dockerfile -t aider-image .
# to launch pytest:
docker run -it --volume $(pwd):/app --entrypoint /bin/bash aider-image -c "pip install pytest && pytest tests/test_main.py"
```

like in :
https://github.com/paul-gauthier/aider/pull/377 and https://gist.github.com/gwpl/8faa1b314c7d5905dd23ce041d65dc79 .