### PR TITLE
Remove azure_deployment argument from main

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -499,7 +499,6 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             api_key=args.openai_api_key,
             azure_endpoint=args.openai_api_base,
             api_version=args.openai_api_version,
-            azure_deployment=args.openai_api_deployment_id,
         )
     else:
         kwargs = dict()


### PR DESCRIPTION
The new openai package version has a different API call when using Azure. You do not need args.azure_deployment anymore in AzureOpenAI