### PR TITLE
feature: added new argument --commit-template-file

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -91,6 +91,7 @@ class Coder:
         client,
         main_model,
         io,
+        commit_template,
         fnames=None,
         git_dname=None,
         pretty=True,
@@ -134,6 +135,7 @@ class Coder:
         self.dirty_commits = dirty_commits
         self.assistant_output_color = assistant_output_color
         self.code_theme = code_theme
+        self.commit_template = commit_template
 
         self.dry_run = dry_run
         self.pretty = pretty
@@ -924,7 +926,7 @@ class Coder:
 
     def auto_commit(self, edited):
         context = self.get_context_from_history(self.cur_messages)
-        res = self.repo.commit(fnames=edited, context=context, prefix="aider: ")
+        res = self.repo.commit(fnames=edited, context=context, template=self.commit_template)
         if res:
             commit_hash, commit_message = res
             self.last_aider_commit_hash = commit_hash
@@ -945,7 +947,7 @@ class Coder:
         if not self.repo:
             return
 
-        self.repo.commit(fnames=self.need_commit_before_edits)
+        self.repo.commit(fnames=self.need_commit_before_edits, template=self.commit_template)
 
         # files changed, move cur messages back behind the files messages
         self.move_back_cur_messages(self.gpt_prompts.files_content_local_edits)

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -57,7 +57,7 @@ class GitRepo:
         if aider_ignore_file:
             self.aider_ignore_file = Path(aider_ignore_file)
 
-    def commit(self, fnames=None, context=None, prefix=None, message=None):
+    def commit(self, template, fnames=None, context=None, prefix="aider", message=None):
         if not fnames and not self.repo.is_dirty():
             return
 
@@ -73,12 +73,14 @@ class GitRepo:
         if not commit_message:
             commit_message = "(no commit message provided)"
 
-        if prefix:
-            commit_message = prefix + commit_message
+        full_commit_message = template.replace("{aider.prefix}", prefix).replace("{aider.commit_message}", commit_message)
 
-        full_commit_message = commit_message
         if context:
-            full_commit_message += "\n\n# Aider chat conversation:\n\n" + context
+            context = "\n\n# Aider chat conversation:\n\n" + context
+        else:    
+            context = "(No context provided)"
+        
+        full_commit_message = full_commit_message.replace("{aider.context}", context)
 
         cmd = ["-m", full_commit_message, "--no-verify"]
         if fnames:


### PR DESCRIPTION
Addresses https://github.com/paul-gauthier/aider/issues/352

This PR adds a new argument
```
--commit-template-file
```
Use this argument to specify the path to a template file.

If argument is not provided the it will default to the following template:
```
{aider.prefix}: {aider.commit_message}

{aider.context}
```
The default behavior is unchanged as far as the structure of commit messages when the template file is not provided.

The 3 "tags" shown in the default template are dynamically replaced with their actual contents based on the outputs of aider. These can be omitted but it's recommended to at minimum include the ```{aider.commit_message}``` tag.

In addition to these default tags the template supports any number of ```{user.**}``` tags. For example I can replace the default prefix like so:

```
{user.myprefix}: {aider.commit_message}

{aider.context}
```

When you introduce a ```{user.**}``` tag to the template aider will ask you for the values to inject into the template on startup.
<img width="510" alt="Screenshot 2023-12-07 at 10 24 23 PM" src="https://github.com/paul-gauthier/aider/assets/46545517/367e66b1-653f-4246-b755-3a92d2d6c023">

The provided template file is not allowed to be empty and it must exists or aider will exit with an error.
