### PR TITLE
Use encoding supplied to --encoding by default while running commands

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -392,7 +392,7 @@ class Commands:
         combined_output = None
         try:
             result = subprocess.run(
-                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True, encoding='utf-8', errors='replace'
             )
             combined_output = result.stdout
         except Exception as e:
@@ -412,7 +412,7 @@ class Commands:
                 output=combined_output,
             )
             return msg
-
+        
     def cmd_exit(self, args):
         "Exit the application"
         sys.exit()

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -392,7 +392,7 @@ class Commands:
         combined_output = None
         try:
             result = subprocess.run(
-                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True, encoding='utf-8', errors='replace'
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True, encoding=self.io.encoding, errors='replace'
             )
             combined_output = result.stdout
         except Exception as e:
@@ -412,7 +412,7 @@ class Commands:
                 output=combined_output,
             )
             return msg
-        
+
     def cmd_exit(self, args):
         "Exit the application"
         sys.exit()


### PR DESCRIPTION
This fixes issues with /run on Windows which usually manifested as encoding errors.

Sample: Error running command: 'charmap' codec can't decode byte 0x9d in position 298: character maps to <undefined>
