### PR TITLE
skip docker github action if credentials not present

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      if: ${{ secrets.DOCKERHUB_USERNAME }} && ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Build Docker image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
Haven't been able to test this in my fork but maybe this will stop the docker action errors that seem omnipresent?

Maybe we could also just delete the docker action?
