### PR TITLE
Typescript repo map fix

### DIFF
--- a/aider/queries/tree-sitter-typescript-tags.scm
+++ b/aider/queries/tree-sitter-typescript-tags.scm
@@ -1,23 +1,17 @@
-(function_signature
+(function_declaration
   name: (identifier) @name.definition.function) @definition.function
 
-(method_signature
+(method_definition
   name: (property_identifier) @name.definition.method) @definition.method
 
-(abstract_method_signature
-  name: (property_identifier) @name.definition.method) @definition.method
-
-(abstract_class_declaration
+(class_declaration
   name: (type_identifier) @name.definition.class) @definition.class
 
-(module
-  name: (identifier) @name.definition.module) @definition.module
-
 (interface_declaration
-  name: (type_identifier) @name.definition.interface) @definition.interface
+  name: (type_identifier) @name.definition.class) @definition.class
 
-(type_annotation
-  (type_identifier) @name.reference.type) @reference.type
+(type_alias_declaration
+  name: (type_identifier) @name.definition.type) @definition.type
 
-(new_expression
-  constructor: (identifier) @name.reference.class) @reference.class
+(enum_declaration
+  name: (identifier) @name.definition.enum) @definition.enum

--- a/aider/queries/tree-sitter-typescript-tags.scm
+++ b/aider/queries/tree-sitter-typescript-tags.scm
@@ -1,3 +1,27 @@
+(function_signature
+  name: (identifier) @name.definition.function) @definition.function
+
+(method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(module
+  name: (identifier) @name.definition.module) @definition.module
+
+(interface_declaration
+  name: (type_identifier) @name.definition.interface) @definition.interface
+
+(type_annotation
+  (type_identifier) @name.reference.type) @reference.type
+
+(new_expression
+  constructor: (identifier) @name.reference.class) @reference.class
+
 (function_declaration
   name: (identifier) @name.definition.function) @definition.function
 

--- a/tests/test_repomap.py
+++ b/tests/test_repomap.py
@@ -1,9 +1,13 @@
+from collections import defaultdict
 import os
 import unittest
+from pathlib import Path
+import networkx as nx
 
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.repomap import RepoMap
+from aider import models
 from aider.utils import IgnorantTemporaryDirectory
 
 
@@ -149,6 +153,61 @@ print(my_function(3, 4))
             # close the open cache files, so Windows won't error
             del repo_map
 
+
+class TestRepoMapTypescript(unittest.TestCase):
+    def test_get_repo_map_typescript(self):
+        # Create a temporary directory with a sample TypeScript file
+        test_file_ts = "test_file.ts"
+        file_content_ts = """\
+interface IMyInterface {
+    someMethod(): void;
+}
+
+type ExampleType = {
+    key: string;
+    value: number;
+};
+
+enum Status {
+    New,
+    InProgress,
+    Completed,
+}
+
+export class MyClass {
+    constructor(public value: number) {}
+
+    add(input: number): number {
+        return this.value + input;
+        return this.value + input;
+    }
+}
+
+export function myFunction(input: number): number {
+    return input * 2;
+}
+"""
+
+        with IgnorantTemporaryDirectory() as temp_dir:
+            with open(os.path.join(temp_dir, test_file_ts), "w") as f:
+                f.write(file_content_ts)
+
+            io = InputOutput()
+            repo_map = RepoMap(root=temp_dir, io=io)
+            other_files = [os.path.join(temp_dir, test_file_ts)]
+            result = repo_map.get_repo_map([], other_files)
+
+            # Check if the result contains the expected tags map with TypeScript identifiers
+            self.assertIn("test_file.ts", result)
+            self.assertIn("IMyInterface", result)
+            self.assertIn("ExampleType", result)
+            self.assertIn("Status", result)
+            self.assertIn("MyClass", result)
+            self.assertIn("add", result)
+            self.assertIn("myFunction", result)
+
+            # close the open cache files, so Windows won't error
+            del repo_map
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Corrects the query syntax for Tree Sitter TypeScript. This causes correct repo maps to be created. E.g. for the [nodeadr](https://github.com/robogeek/nodeadr) project:

```text
lib/client.ts:
⋮...
│import { ADRConnection } from './oadr.js';
⋮...
│export type AddReportOptions = {
│
│    /**
│     * The quantity that is being measured (enums.MEASUREMENTS).
│     * Optional for TELEMETRY_STATUS reports.
│     */
│    measurement?: types.Measurement;
│
│    /**
│     * Whether you want the data to be collected incrementally
⋮...
│export class OpenADRClient {
│
│    /**
│     * Initializes a new OpenADR Client (Virtual End Node)
│     * 
│     * @param ven_name The name for this VEN
│     * @param ven_id The ID for this VEN. If you leave this blank,
│     *               a VEN_ID will be assigned by the VTN.
│     * @param vtn_url The URL of the VTN (Server) to connect to
│     * @param cert The path to a PEM-formatted Certificate file to use
⋮...
│    set vtn_url(nu: string) { this.#vtn_url = nu; }
│    get vtn_url() { return this.#vtn_url; }
│
⋮...
│    async VTNConnection(): Promise<ADRConnection> {
│        if (this.#vtnconnection) {
│            return this.#vtnconnection;
│        }
│        // TODO must initialize the connection
│        this.#vtnconnection = new ADRConnection(this.vtn_url);
│        return this.#vtnconnection;
⋮...
│    async start() {
│        await this.create_party_registration();
│        if (!this.vtn_requested_poll_frequency) {
│            throw new Error(`start - no polling schedule supplied`);
│        }
│
│        this.#scheduler = new ToadScheduler();
│
│        const pollTask = new AsyncTask('VTN Poll', async (): Promise<void> => {
│            await this.poll();
⋮...
│    async handle_on_event(oadrDistributeEvent) {
│        if (typeof this.#receivedEvents === 'undefined') {
│            this.#receivedEvents = [];
│        }
│
│        for (const event of oadrDistributeEvent.oadrEvent) {
│            const eventDescriptor = event.eiEvent.eventDescriptor;
│
│            /*
│             * We're supposed to remove memory of the event. 
⋮...
│    on_event(callback) {
│        this.#handle_event = callback;
⋮...
│    handle_on_update_event() {
│        throw new Error(`Do not know what handle_on_update_event should do`);
│        // this.#handlers.emit('on_update_event') // TBD add arguments
⋮...
│    add_report(callback, resource_id: string, options: AddReportOptions) {
│
│        if (options.report_name && !enums.isReportName(options.report_name)) {
│            throw new Error(`add_report: ${options.report_name} is not a valid report name`);
│        }
│        if (options.reading_type && !enums.isReadingType(options.reading_type)) {
│            throw new Error(`add_report: ${options.reading_type} is not a valid reading type`);
│        }
│        if (options.report_type && !enums.isReportType(options.report_type)) {
│            throw new Error(`add_report: ${options.report_type} is not a valid report type`);
⋮...
│    query_registration() {
│
⋮...
│    async create_party_registration(): Promise<void> {
│        const requestID = uuidv4();
│        const request = await oadr_payload(
│            await render_template('oadrCreatePartyRegistration.xml', {
│            ven_id: this.ven_id,
│            ven_name: this.ven_name,
│            request_id: requestID,
│            profile_name: (await this.VTNConnection()).oadrProfile,
│            transport_name: 'simpleHttp',
│            /*
⋮...
│    request_event() {
│
⋮...
│    created_event() {
│
⋮...
│    create_report() {
│
⋮...
│    create_single_report() {
│
⋮...
│    update_report() {
│
⋮...
│    cancel_report() {
│        
⋮...
│    async poll() {
│        const request = await oadr_payload(
│            await render_template('oadrPoll.xml', {
│                ven_id: this.ven_id
│            })
│        );
│        
│        const response = await (await this.VTNConnection())
│                        .sendRequest('OadrPoll', request);
│
⋮...
```

Without these changes, the output from aider is as following:
```text

.gitignore

LICENSE

README.md

lib/client.ts

lib/enums.ts

lib/oadr.ts

lib/templates.ts

lib/types.ts

package.json

templates/README.md

tsconfig.json
```