### PR TITLE
Correct Documentation Link in FAQ.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -339,7 +339,7 @@ Just put any extra instructions in a file
 like `CONVENTIONS.md` and then add it to the chat.
 
 For more details, see this documentation on
-[using a conventions file with aider](/docs/conventions.html).
+[using a conventions file with aider](/docs/conventions.md).
 
 ## Can I change the system prompts that aider uses?
 


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Corrected an invalid link in the FAQ documentation, ensuring users are directed to the correct conventions documentation file.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>faq.md</strong><dd><code>Corrected Link to Conventions Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/faq.md
<li>Corrected the link to the conventions documentation from <code>.html</code> to <code>.md</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/paul-gauthier/aider/pull/489/files#diff-57cdcc6b6701a7ce3b3a8f8c0366e0e611e6fb1a1b8dd7cd29e3263b3e064c8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>