### PR TITLE
Add fzf file selection via pyfzf

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -18,6 +18,7 @@ from rich.text import Text
 
 from .utils import is_image_file
 from .dump import dump  # noqa: F401
+from pyfzf.pyfzf import FzfPrompt
 
 
 class AutoCompleter(Completer):
@@ -360,3 +361,16 @@ class InputOutput:
         if self.chat_history_file is not None:
             with self.chat_history_file.open("a", encoding=self.encoding) as f:
                 f.write(text)
+
+    def fzf_select_files(self, directory='.', prompt='Select files:'):
+        """
+        Presents a file selection dialog using pyfzf for multiple files.
+
+        :param directory: The directory to search for files. Defaults to the current directory.
+        :param prompt: The prompt to display to the user. Defaults to 'Select a file:'.
+        :return: The list of selected file paths or an empty list if no files were selected.
+        """
+        fzf = FzfPrompt()
+        files = [os.path.join(dp, f) for dp, dn, filenames in os.walk(directory) for f in filenames]
+        selected = fzf.prompt(files, '--multi')
+        return selected if selected else []

--- a/aider/main.py
+++ b/aider/main.py
@@ -392,6 +392,12 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         help="Apply the changes from the given file instead of running the chat (debug)",
     )
     other_group.add_argument(
+        "--fzf",
+        action="store_true",
+        help="Invoke file selection using FZF",
+        default=False,
+    )
+    other_group.add_argument(
         "--yes",
         action="store_true",
         help="Always say yes to every confirmation",
@@ -470,7 +476,14 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         encoding=args.encoding,
     )
 
-    fnames = [str(Path(fn).resolve()) for fn in args.files]
+    if args.fzf:
+        selected_files = io.fzf_select_files()
+        if not selected_files:
+            io.tool_error("No files selected.")
+            return
+        fnames = selected_files
+    else:
+        fnames = [str(Path(fn).resolve()) for fn in args.files]
     if len(args.files) > 1:
         good = True
         for fname in args.files:

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,6 +90,8 @@ pydantic==2.5.3
     # via openai
 pydantic-core==2.14.6
     # via pydantic
+pyfzf==0.3.1 
+    # via pyfzf
 pyee==11.0.1
     # via playwright
 pygments==2.17.2


### PR DESCRIPTION
This implements the workflow of https://github.com/paul-gauthier/aider/issues/492 using pyfzf. What it doesn't do it yet is respect .aiderignore entries, but I first wanted to check if there's general interest in implementing something along those lines.