### PR TITLE
feat: add `/rg` command (ripgrep for `/add` files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Aider supports commands from within the chat, which all start with `/`. Here are
 * `/drop <file>`: Remove matching files from the chat session.
 * `/undo`: Undo the last git commit if it was done by aider.
 * `/diff`: Display the diff of the last aider commit.
+* `/rg <pattern>`: Run ripgrep with the given pattern and add the matching files to the chat.
 * `/run <command>`: Run a shell command and optionally add the output to the chat.
 * `/voice`: Speak to aider to [request code changes with your voice](https://aider.chat/docs/voice.html).
 * `/help`: Show help about all commands.

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -495,6 +495,34 @@ class Commands:
             )
             return msg
 
+    # Add cmd_rg for calling ripgrep with -l and the user-provided arguments. Then call cmd_add with the returned file names.
+    def cmd_rg(self, args):
+        "Run ripgrep and add the matching files to the chat"
+        output = None
+        try:
+            args = "rg -l " + args
+            result = subprocess.run(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                shell=True,
+                encoding=self.io.encoding,
+                errors="replace",
+            )
+            output = result.stdout
+        except Exception as e:
+            self.io.tool_error(f"Error running ripgrep: {e}")
+
+        # Split the output into an array that can be passed into cmd_add
+        if output is None:
+            self.io.tool_error("No files found")
+            return
+
+        # Quote each line then replace each line break with a space.
+        output = " ".join(map(self.quote_fname, output.splitlines()))
+        self.cmd_add(output)
+
     def cmd_exit(self, args):
         "Exit the application"
         sys.exit()

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@
 - `/undo`: Undo the last git commit if it was done by aider
 - `/diff`: Display the diff of the last aider commit
 - `/commit <message>`: Commit edits to the repo made outside the chat (commit message optional)
+- `/rg <pattern>`: Run ripgrep with the given pattern and add the matching files to the chat
 - `/git <command>`: Run a git command
 
 ## other


### PR DESCRIPTION
**NOTE:** Using this command requires [ripgrep](https://github.com/BurntSushi/ripgrep) installed on your machine.

### How it works

It calls `rg` through a subprocess with the `-l` flag to return a list of filenames. These filenames are then fed into the `/add` command. Anything you pass after `/rg` is forwarded to the ripgrep tool.