### PR TITLE
feat: add LiteLLM support

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -73,7 +73,7 @@ class Coder:
 
         if not skip_model_availabily_check and not main_model.always_available:
             if not check_model_availability(io, client, main_model):
-                fallback_model = models.GPT35_0125
+                fallback_model = models.Model.create("gpt-3.5-turbo-0125")
                 io.tool_error(
                     f"API key does not support {main_model.name}, falling back to"
                     f" {fallback_model.name}"

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -160,7 +160,7 @@ class Coder:
         if use_git:
             try:
                 self.repo = GitRepo(
-                    self.io, fnames, git_dname, aider_ignore_file, client=self.client
+                    self.io, fnames, git_dname, main_model, aider_ignore_file, client=self.client
                 )
                 self.root = self.repo.root
             except FileNotFoundError:
@@ -224,7 +224,7 @@ class Coder:
 
         self.summarizer = ChatSummary(
             self.client,
-            models.Model.weak_model(),
+            self.main_model.get_weak_model(),
             self.main_model.max_chat_history_tokens,
         )
 
@@ -1055,6 +1055,9 @@ class Coder:
 
 
 def check_model_availability(io, client, main_model):
+    if not hasattr(client, "models"):
+        return True
+
     try:
         available_models = client.models.list()
     except openai.NotFoundError:

--- a/aider/main.py
+++ b/aider/main.py
@@ -2,7 +2,6 @@ import argparse
 import configparser
 import os
 import sys
-import importlib
 from pathlib import Path
 
 import configargparse
@@ -587,6 +586,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         args.model = default_model
 
     if args.litellm:
+        import importlib
         spec = importlib.util.find_spec("litellm")
         if spec is None:
             io.tool_error("LiteLLM is not installed. Install it with `pip install litellm`.")

--- a/aider/main.py
+++ b/aider/main.py
@@ -635,8 +635,11 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         handler.setLevel(logging.ERROR)
 
         # Support LITELLM_API_KEY, LITELLM_BASE_URL, etc.
-        import os
-        litellm_kwargs = {key.replace("LITELLM_", "").lower(): value for key, value in os.environ.items() if key.startswith("LITELLM_")}
+        litellm_kwargs = {
+            key.replace("LITELLM_", "").lower(): value
+            for key, value in os.environ.items()
+            if key.startswith("LITELLM_")
+        }
 
         from litellm import LiteLLM
         client = LiteLLM(**litellm_kwargs)

--- a/aider/main.py
+++ b/aider/main.py
@@ -634,15 +634,13 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         from litellm._logging import handler
         handler.setLevel(logging.ERROR)
 
-        # Support LITELLM_API_KEY, LITELLM_BASE_URL, etc.
-        litellm_kwargs = {
-            key.replace("LITELLM_", "").lower(): value
-            for key, value in os.environ.items()
-            if key.startswith("LITELLM_")
-        }
-
         from litellm import LiteLLM
-        client = LiteLLM(**litellm_kwargs)
+        client = LiteLLM(
+            api_key=os.environ.get("LITELLM_API_KEY"),
+            base_url=os.environ.get("LITELLM_BASE_URL"),
+            organization=os.environ.get("LITELLM_ORGANIZATION_ID"),
+            timeout=int(os.environ.get("LITELLM_TIMEOUT", 600)),
+        )
     elif args.openai_api_type == "azure":
         client = openai.AzureOpenAI(
             api_key=args.openai_api_key,

--- a/aider/main.py
+++ b/aider/main.py
@@ -634,8 +634,12 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         from litellm._logging import handler
         handler.setLevel(logging.ERROR)
 
+        # Support LITELLM_API_KEY, LITELLM_BASE_URL, etc.
+        import os
+        litellm_kwargs = {key.replace("LITELLM_", "").lower(): value for key, value in os.environ.items() if key.startswith("LITELLM_")}
+
         from litellm import LiteLLM
-        client = LiteLLM()
+        client = LiteLLM(**litellm_kwargs)
     elif args.openai_api_type == "azure":
         client = openai.AzureOpenAI(
             api_key=args.openai_api_key,

--- a/aider/main.py
+++ b/aider/main.py
@@ -191,7 +191,7 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         const=default_4_turbo_model,
         help=f"Use {default_4_turbo_model} model for the main chat",
     )
-    default_3_model = models.GPT35_0125
+    default_3_model = "gpt-3.5-turbo-0125"
     core_group.add_argument(
         "--35turbo",
         "--35-turbo",
@@ -199,8 +199,8 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         "-3",
         action="store_const",
         dest="model",
-        const=default_3_model.name,
-        help=f"Use {default_3_model.name} model for the main chat",
+        const=default_3_model,
+        help=f"Use {default_3_model} model for the main chat",
     )
     core_group.add_argument(
         "--voice-language",

--- a/aider/main.py
+++ b/aider/main.py
@@ -628,6 +628,12 @@ def main(argv=None, input=None, output=None, force_git_root=None):
                 import json
                 json.dump(model_cost, f)
 
+        # Strangely, LiteLLM has DEBUG-level logging enabled by default. This is
+        # a rather fragile solution, so we should report the issue upstream.
+        import logging
+        from litellm._logging import handler
+        handler.setLevel(logging.ERROR)
+
         from litellm import LiteLLM
         client = LiteLLM()
     elif args.openai_api_type == "azure":

--- a/aider/main.py
+++ b/aider/main.py
@@ -13,7 +13,7 @@ from aider.coders import Coder
 from aider.io import InputOutput
 from aider.repo import GitRepo
 from aider.versioncheck import check_version
-from aider.models.litellm import LITELLM_VERSION
+from aider.models.litellm import LITELLM_SPEC
 
 from .dump import dump  # noqa: F401
 
@@ -571,8 +571,8 @@ def main(argv=None, input=None, output=None, force_git_root=None):
 
     elif not (args.openai_api_key or args.openai_api_base) and \
             args.model is not None and \
-            LITELLM_VERSION is not None:
-        io.tool_output(f"OpenAI key not provided, using LiteLLM v{LITELLM_VERSION} instead.")
+            LITELLM_SPEC is not None:
+        io.tool_output(f"OpenAI key not provided, using LiteLLM instead.")
         args.litellm = True
 
     elif not args.openai_api_key:
@@ -586,15 +586,13 @@ def main(argv=None, input=None, output=None, force_git_root=None):
         args.model = default_model
 
     if args.litellm:
-        import importlib
-        spec = importlib.util.find_spec("litellm")
-        if spec is None:
+        if LITELLM_SPEC is None:
             io.tool_error("LiteLLM is not installed. Install it with `pip install litellm`.")
             return 1
 
         io.tool_output("LiteLLM is enabled.")
 
-        packageRootDir = os.path.dirname(spec.origin)
+        packageRootDir = os.path.dirname(LITELLM_SPEC.origin)
         modelPricesBackupName = "model_prices_and_context_window_backup.json"
         modelPricesPath = os.path.join(packageRootDir, modelPricesBackupName)
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -165,7 +165,6 @@ def main(argv=None, input=None, output=None, force_git_root=None):
     core_group.add_argument(
         "--model",
         metavar="MODEL",
-        default=default_model,
         help=f"Specify the model to use for the main chat (default: {default_model})",
     )
     core_group.add_argument(
@@ -577,15 +576,14 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             return 1
 
     elif not args.openai_api_key:
-        if os.name == "nt":
-            io.tool_error(
-                "No OpenAI API key provided. Use --openai-api-key or setx OPENAI_API_KEY."
-            )
-        else:
-            io.tool_error(
-                "No OpenAI API key provided. Use --openai-api-key or export OPENAI_API_KEY."
-            )
+        export_kw = "setx" if os.name == "nt" else "export"
+        io.tool_error(
+            f"No OpenAI API key provided. Use --openai-api-key or {export_kw} OPENAI_API_KEY."
+        )
         return 1
+
+    if not args.model:
+        args.model = default_model
 
     if args.litellm:
         from litellm import LiteLLM

--- a/aider/main.py
+++ b/aider/main.py
@@ -14,6 +14,7 @@ from aider.coders import Coder
 from aider.io import InputOutput
 from aider.repo import GitRepo
 from aider.versioncheck import check_version
+from aider.models.litellm import is_litellm_installed
 
 from .dump import dump  # noqa: F401
 
@@ -564,6 +565,11 @@ def main(argv=None, input=None, output=None, force_git_root=None):
             io.tool_output(f"  - {arg}: {val}")
 
     io.tool_output(*map(scrub_sensitive_info, sys.argv), log_only=True)
+
+    if not (args.openai_api_key or args.openai_api_base) and \
+            args.model is not None and \
+            is_litellm_installed():
+        args.litellm = True
 
     if args.litellm:
         if not args.model:

--- a/aider/models/__init__.py
+++ b/aider/models/__init__.py
@@ -2,16 +2,10 @@ from .model import Model
 from .openai import OpenAIModel
 from .openrouter import OpenRouterModel
 
-GPT4 = Model.create("gpt-4")
-GPT35 = Model.create("gpt-3.5-turbo")
-GPT35_0125 = Model.create("gpt-3.5-turbo-0125")
-
 DEFAULT_MODEL_NAME = "gpt-4-1106-preview"
 
 __all__ = [
+    Model,
     OpenAIModel,
     OpenRouterModel,
-    GPT4,
-    GPT35,
-    GPT35_0125,
 ]

--- a/aider/models/litellm.py
+++ b/aider/models/litellm.py
@@ -1,8 +1,6 @@
 import pkg_resources
 import logging
 import tiktoken
-import platform
-import os
 
 from .model import Model
 

--- a/aider/models/litellm.py
+++ b/aider/models/litellm.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.util
 import logging
 import tiktoken
 
@@ -7,11 +7,7 @@ from .model import Model
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger("aider-litellm")
 
-LITELLM_VERSION = None
-try:
-  LITELLM_VERSION = pkg_resources.get_distribution("litellm").version
-except pkg_resources.DistributionNotFound:
-  pass
+LITELLM_SPEC = importlib.util.find_spec("litellm")
 
 model_aliases = {
     # claude-3

--- a/aider/models/litellm.py
+++ b/aider/models/litellm.py
@@ -1,0 +1,104 @@
+import pkg_resources
+import logging
+import tiktoken
+
+from .model import Model
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+logger = logging.getLogger('aider-litellm')
+
+model_aliases = {
+    # claude-3
+    "opus": "claude-3-opus-20240229",
+    "sonnet": "claude-3-sonnet-20240229",
+    "haiku": "claude-3-haiku-20240307",
+    # gemini-1.5-pro
+    "gemini": "gemini-1.5-pro-preview-0409",
+    # gpt-3.5
+    "gpt-3.5": "gpt-3.5-turbo-0613",
+    "gpt-3.5-turbo": "gpt-3.5-turbo-0613",
+    "gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k-0613",
+    # gpt-4
+    "gpt-4": "gpt-4-0613",
+    "gpt-4-32k": "gpt-4-32k-0613",
+}
+
+models_info = None
+
+class LiteLLMModel(Model):
+    def __init__(self, name):
+        model_id = name
+        if name in model_aliases:
+            model_id = model_aliases[name]
+
+        global models_info
+        if not models_info:
+          models_info = fetchModelsInfo()
+
+        model_data = models_info.get(model_id)
+        if not model_data:
+            raise ValueError(f"Unsupported model: {model_id}")
+
+        self.tokenizer = tiktoken.get_encoding("cl100k_base")
+
+        self.name = model_id
+        self.max_context_tokens = model_data.get("max_input_tokens")
+        self.prompt_price = model_data.get("input_cost_per_token") * 100
+        self.completion_price = model_data.get("output_cost_per_token") * 100
+
+        is_high_end = model_id.startswith("gpt-4") or model_id.startswith("claude-3-opus")
+        
+        self.edit_format = "udiff" if is_high_end else "whole"
+        self.use_repo_map = is_high_end
+        self.send_undo_reply = is_high_end
+
+        # set the history token limit
+        if self.max_context_tokens < 32 * 1024:
+            self.max_chat_history_tokens = 1024
+        else:
+            self.max_chat_history_tokens = 2 * 1024
+
+# Returns a JSON object where each key is a model name and each model name
+# points to a JSON object. See the following example:
+#
+#     "gemini/gemini-1.5-pro": {
+#        "max_tokens": 8192,
+#        "max_input_tokens": 1000000,
+#        "max_output_tokens": 8192,
+#        "input_cost_per_token": 0, 
+#        "output_cost_per_token": 0,
+#        "litellm_provider": "gemini",
+#        "mode": "chat",
+#        "supports_function_calling": true,
+#        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
+#      }
+#
+# The 'source', 'mode', and 'supports_function_calling' properties may not
+# exist.
+#
+def fetchModelsInfo():
+  import requests
+  import json
+
+  try:
+    version = pkg_resources.get_distribution("litellm").version
+    logger.info(f"Found LiteLLM version: {version}")
+  except pkg_resources.DistributionNotFound:
+    logger.error("LiteLLM not installed. Please run 'pip install litellm' first.")
+    return {}
+
+  supported_models_url = f"https://raw.githubusercontent.com/BerriAI/litellm/v{version}/model_prices_and_context_window.json"
+
+  try:
+    logger.info(f"Fetching supported models from {supported_models_url}")
+    response = requests.get(supported_models_url)
+
+    if response.status_code == 200:
+      return json.loads(response.text)
+
+    logger.error(f"Request failed with status code {response.status_code}")
+    return {}
+
+  except Exception as e:
+    logger.error(f"Failed to fetch models info: {str(e)}")
+    return {}

--- a/aider/models/litellm.py
+++ b/aider/models/litellm.py
@@ -7,6 +7,15 @@ from .model import Model
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 logger = logging.getLogger('aider-litellm')
 
+LITELLM_VERSION = None
+try:
+  LITELLM_VERSION = pkg_resources.get_distribution("litellm").version
+except pkg_resources.DistributionNotFound:
+  pass
+
+def is_litellm_installed():
+  return LITELLM_VERSION is not None
+
 model_aliases = {
     # claude-3
     "opus": "claude-3-opus-20240229",
@@ -80,14 +89,13 @@ def fetchModelsInfo():
   import requests
   import json
 
-  try:
-    version = pkg_resources.get_distribution("litellm").version
-    logger.info(f"Found LiteLLM version: {version}")
-  except pkg_resources.DistributionNotFound:
+  global LITELLM_VERSION
+  if LITELLM_VERSION is None:
     logger.error("LiteLLM not installed. Please run 'pip install litellm' first.")
     return {}
 
-  supported_models_url = f"https://raw.githubusercontent.com/BerriAI/litellm/v{version}/model_prices_and_context_window.json"
+  logger.info(f"Found LiteLLM version: {LITELLM_VERSION}")
+  supported_models_url = f"https://raw.githubusercontent.com/BerriAI/litellm/v{LITELLM_VERSION}/model_prices_and_context_window.json"
 
   try:
     logger.info(f"Fetching supported models from {supported_models_url}")

--- a/aider/models/litellm.py
+++ b/aider/models/litellm.py
@@ -24,7 +24,7 @@ model_aliases = {
     "sonnet": "claude-3-sonnet-20240229",
     "haiku": "claude-3-haiku-20240307",
     # gemini-1.5-pro
-    "gemini": "gemini-1.5-pro-preview-0409",
+    "gemini": "gemini/gemini-1.5-pro-latest",
     # gpt-3.5
     "gpt-3.5": "gpt-3.5-turbo-0613",
     "gpt-3.5-turbo": "gpt-3.5-turbo-0613",
@@ -48,7 +48,15 @@ class LiteLLMModel(Model):
 
         model_data = models_info.get(model_id)
         if not model_data:
-            raise ValueError(f"Unsupported model: {model_id}")
+            # HACK: for gemini 1.5 pro to work, LiteLLM needs the "-latest" part
+            # included in the model name, but it's not included in the list of
+            # supported models that way, so finesse it here
+            if model_id == "gemini/gemini-1.5-pro-latest":
+               model_data = models_info.get("gemini/gemini-1.5-pro")
+               if not model_data:
+                   raise ValueError(f"Unsupported model: {model_id}")
+            else:
+                raise ValueError(f"Unsupported model: {model_id}")
 
         self.tokenizer = tiktoken.get_encoding("cl100k_base")
 

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -24,7 +24,7 @@ class Model:
         from .openrouter import OpenRouterModel
         from .litellm import LiteLLMModel
 
-        if not hasattr(client, "base_url"):
+        if client and not hasattr(client, "base_url"):
             return LiteLLMModel(name)
         if client and client.base_url.host == "openrouter.ai":
             return OpenRouterModel(client, name)

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -24,7 +24,7 @@ class Model:
         from .openrouter import OpenRouterModel
         from .litellm import LiteLLMModel
 
-        if client and not hasattr(client, "base_url"):
+        if client and type(client).__name__ == "LiteLLM":
             return LiteLLMModel(name)
         if client and client.base_url.host == "openrouter.ai":
             return OpenRouterModel(client, name)

--- a/aider/models/model.py
+++ b/aider/models/model.py
@@ -22,7 +22,10 @@ class Model:
     def create(cls, name, client=None):
         from .openai import OpenAIModel
         from .openrouter import OpenRouterModel
+        from .litellm import LiteLLMModel
 
+        if not hasattr(client, "base_url"):
+            return LiteLLMModel(name)
         if client and client.base_url.host == "openrouter.ai":
             return OpenRouterModel(client, name)
         return OpenAIModel(name)
@@ -38,9 +41,10 @@ class Model:
     def weak_model():
         return Model.create("gpt-3.5-turbo-0125")
 
-    @staticmethod
-    def commit_message_models():
-        return [Model.weak_model()]
+    def get_weak_model(self):
+        if self.use_repo_map:
+            return Model.weak_model()
+        return self
 
     def token_count(self, messages):
         if not self.tokenizer:

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -16,7 +16,8 @@ class GitRepo:
     aider_ignore_spec = None
     aider_ignore_ts = 0
 
-    def __init__(self, io, fnames, git_dname, aider_ignore_file=None, client=None):
+    def __init__(self, io, fnames, git_dname, main_model=None, aider_ignore_file=None, client=None):
+        self.main_model = main_model
         self.client = client
         self.io = io
 
@@ -120,10 +121,8 @@ class GitRepo:
             dict(role="user", content=content),
         ]
 
-        for model in models.Model.commit_message_models():
-            commit_message = simple_send_with_retries(self.client, model.name, messages)
-            if commit_message:
-                break
+        commit_model = self.main_model.get_weak_model()
+        commit_message = simple_send_with_retries(self.client, commit_model.name, messages)
 
         if not commit_message:
             self.io.tool_error("Failed to generate commit message!")

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -12,6 +12,7 @@ from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.utils import ChdirTemporaryDirectory, GitTemporaryDirectory
 
+GPT4 = models.Model.create("gpt-4")
 
 class TestCoder(unittest.TestCase):
     def setUp(self):
@@ -38,7 +39,7 @@ class TestCoder(unittest.TestCase):
 
             # YES!
             io = InputOutput(yes=True)
-            coder = Coder.create(models.GPT4, None, io, fnames=["added.txt"])
+            coder = Coder.create(GPT4, None, io, fnames=["added.txt"])
 
             self.assertTrue(coder.allowed_to_edit("added.txt"))
             self.assertTrue(coder.allowed_to_edit("repo.txt"))
@@ -66,7 +67,7 @@ class TestCoder(unittest.TestCase):
             # say NO
             io = InputOutput(yes=False)
 
-            coder = Coder.create(models.GPT4, None, io, fnames=["added.txt"])
+            coder = Coder.create(GPT4, None, io, fnames=["added.txt"])
 
             self.assertTrue(coder.allowed_to_edit("added.txt"))
             self.assertFalse(coder.allowed_to_edit("repo.txt"))
@@ -90,7 +91,7 @@ class TestCoder(unittest.TestCase):
             # say NO
             io = InputOutput(yes=False)
 
-            coder = Coder.create(models.GPT4, None, io, fnames=["added.txt"])
+            coder = Coder.create(GPT4, None, io, fnames=["added.txt"])
 
             self.assertTrue(coder.allowed_to_edit("added.txt"))
             self.assertFalse(coder.need_commit_before_edits)
@@ -111,7 +112,7 @@ class TestCoder(unittest.TestCase):
             repo.git.commit("-m", "new")
 
             # Initialize the Coder object with the mocked IO and mocked repo
-            coder = Coder.create(models.GPT4, None, mock_io)
+            coder = Coder.create(GPT4, None, mock_io)
 
             mod = coder.get_last_modified()
 
@@ -134,7 +135,7 @@ class TestCoder(unittest.TestCase):
         files = [file1, file2]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, None, io=InputOutput(), fnames=files)
+        coder = Coder.create(GPT4, None, io=InputOutput(), fnames=files)
 
         content = coder.get_files_content().splitlines()
         self.assertIn("file1.txt", content)
@@ -157,7 +158,7 @@ class TestCoder(unittest.TestCase):
             repo.git.commit("-m", "new")
 
             # Initialize the Coder object with the mocked IO and mocked repo
-            coder = Coder.create(models.GPT4, None, mock_io)
+            coder = Coder.create(GPT4, None, mock_io)
 
             # Call the check_for_file_mentions method
             coder.check_for_file_mentions("Please check file1.txt and file2.py")
@@ -175,7 +176,7 @@ class TestCoder(unittest.TestCase):
     def test_check_for_ambiguous_filename_mentions_of_longer_paths(self):
         with GitTemporaryDirectory():
             io = InputOutput(pretty=False, yes=True)
-            coder = Coder.create(models.GPT4, None, io)
+            coder = Coder.create(GPT4, None, io)
 
             fname = Path("file1.txt")
             fname.touch()
@@ -196,7 +197,7 @@ class TestCoder(unittest.TestCase):
     def test_check_for_subdir_mention(self):
         with GitTemporaryDirectory():
             io = InputOutput(pretty=False, yes=True)
-            coder = Coder.create(models.GPT4, None, io)
+            coder = Coder.create(GPT4, None, io)
 
             fname = Path("other") / "file1.txt"
             fname.parent.mkdir(parents=True, exist_ok=True)
@@ -225,7 +226,7 @@ class TestCoder(unittest.TestCase):
         files = [file1, file2]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, None, io=InputOutput(), fnames=files)
+        coder = Coder.create(GPT4, None, io=InputOutput(), fnames=files)
 
         def mock_send(*args, **kwargs):
             coder.partial_response_content = "ok"
@@ -251,7 +252,7 @@ class TestCoder(unittest.TestCase):
         files = [file1, file2]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, None, io=InputOutput(), fnames=files)
+        coder = Coder.create(GPT4, None, io=InputOutput(), fnames=files)
 
         def mock_send(*args, **kwargs):
             coder.partial_response_content = "ok"
@@ -281,7 +282,7 @@ class TestCoder(unittest.TestCase):
         files = [file1]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, None, io=InputOutput(), fnames=files)
+        coder = Coder.create(GPT4, None, io=InputOutput(), fnames=files)
 
         def mock_send(*args, **kwargs):
             coder.partial_response_content = "ok"
@@ -306,7 +307,7 @@ class TestCoder(unittest.TestCase):
 
         # Initialize the Coder object with the mocked IO and mocked repo
         coder = Coder.create(
-            models.GPT4,
+            GPT4,
             None,
             io=InputOutput(encoding=encoding),
             fnames=files,
@@ -339,7 +340,7 @@ class TestCoder(unittest.TestCase):
             mock_client = MagicMock()
 
             # Initialize the Coder object with the mocked IO and mocked repo
-            coder = Coder.create(models.GPT4, None, mock_io, client=mock_client)
+            coder = Coder.create(GPT4, None, mock_io, client=mock_client)
 
             # Set up the mock to raise
             mock_client.chat.completions.create.side_effect = openai.BadRequestError(
@@ -360,7 +361,7 @@ class TestCoder(unittest.TestCase):
             fname = Path("file.txt")
 
             io = InputOutput(yes=True)
-            coder = Coder.create(models.GPT4, "diff", io=io, fnames=[str(fname)])
+            coder = Coder.create(GPT4, "diff", io=io, fnames=[str(fname)])
 
             self.assertTrue(fname.exists())
 
@@ -416,7 +417,7 @@ new
             fname1.write_text("ONE\n")
 
             io = InputOutput(yes=True)
-            coder = Coder.create(models.GPT4, "diff", io=io, fnames=[str(fname1), str(fname2)])
+            coder = Coder.create(GPT4, "diff", io=io, fnames=[str(fname1), str(fname2)])
 
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""
@@ -468,7 +469,7 @@ TWO
             fname2.write_text("OTHER\n")
 
             io = InputOutput(yes=True)
-            coder = Coder.create(models.GPT4, "diff", io=io, fnames=[str(fname)])
+            coder = Coder.create(GPT4, "diff", io=io, fnames=[str(fname)])
 
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""
@@ -545,7 +546,7 @@ three
             repo.git.commit("-m", "initial")
 
             io = InputOutput(yes=True)
-            coder = Coder.create(models.GPT4, "diff", io=io, fnames=[str(fname)])
+            coder = Coder.create(GPT4, "diff", io=io, fnames=[str(fname)])
 
             def mock_send(*args, **kwargs):
                 coder.partial_response_content = f"""
@@ -595,7 +596,7 @@ two
 
             io = InputOutput(yes=True)
             coder = Coder.create(
-                models.GPT4,
+                GPT4,
                 None,
                 io,
                 fnames=[fname1, fname2, fname3],

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,6 +17,7 @@ from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.utils import ChdirTemporaryDirectory, GitTemporaryDirectory, make_repo
 
+GPT35 = models.Model.create("gpt-3.5")
 
 class TestCommands(TestCase):
     def setUp(self):
@@ -37,7 +38,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # Call the cmd_add method with 'foo.txt' and 'bar.txt' as a single string
@@ -53,7 +54,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=False)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         commands.cmd_add("**.txt")
@@ -63,7 +64,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # Create some test files
@@ -89,7 +90,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=False)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # Call the cmd_add method with a non-existent file pattern
@@ -103,7 +104,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         fname = Path("[abc].nonexistent")
@@ -120,7 +121,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=False)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # Create a directory and add files to it using pathlib
@@ -171,7 +172,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         subdir = Path("subdir")
@@ -198,7 +199,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # Create a new file foo.bad which will fail to decode as utf-8
@@ -218,7 +219,7 @@ class TestCommands(TestCase):
             with open(f"{tempdir}/test.txt", "w") as f:
                 f.write("test")
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             # Run the cmd_git method with the arguments "commit -a -m msg"
@@ -234,7 +235,7 @@ class TestCommands(TestCase):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, yes=True)
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         commands.cmd_add("foo.txt bar.txt")
@@ -275,7 +276,7 @@ class TestCommands(TestCase):
         os.chdir("subdir")
 
         io = InputOutput(pretty=False, yes=True)
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         # this should get added
@@ -293,7 +294,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             Path("side_dir").mkdir()
@@ -317,7 +318,7 @@ class TestCommands(TestCase):
             repo.git.commit("-m", "initial")
 
             io = InputOutput(pretty=False, yes=True)
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             self.assertFalse(repo.is_dirty())
@@ -338,7 +339,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             outside_file = Path(tmp_dname) / "outside.txt"
@@ -361,7 +362,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             outside_file = Path(tmp_dname) / "outside.txt"
@@ -379,7 +380,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             fname = Path("with[brackets].txt")
@@ -394,7 +395,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             fname = Path("file.txt")
@@ -409,7 +410,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             fname = Path("file with spaces.txt")
@@ -437,7 +438,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=True)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             # There's no reason this /add should trigger a commit
@@ -460,7 +461,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=True)
         from aider.coders import Coder
 
-        coder = Coder.create(models.GPT35, None, io)
+        coder = Coder.create(GPT35, None, io)
         commands = Commands(io, coder)
 
         fname = "file.txt"
@@ -479,7 +480,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             fname = Path("test.txt")
@@ -502,7 +503,7 @@ class TestCommands(TestCase):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)
             io = InputOutput(pretty=False, yes=True)
-            coder = Coder.create(models.GPT35, None, io)
+            coder = Coder.create(GPT35, None, io)
             commands = Commands(io, coder)
 
             other_path = Path(repo_dir) / "other_file.txt"
@@ -562,8 +563,9 @@ class TestCommands(TestCase):
             aignore.write_text(f"{fname1}\n{fname2}\ndir\n")
 
             io = InputOutput(yes=True)
+            model = models.Model.create("gpt-4")
             coder = Coder.create(
-                models.GPT4, None, io, fnames=[fname1, fname2], aider_ignore_file=str(aignore)
+                model, None, io, fnames=[fname1, fname2], aider_ignore_file=str(aignore)
             )
             commands = Commands(io, coder)
 

--- a/tests/test_editblock.py
+++ b/tests/test_editblock.py
@@ -302,7 +302,7 @@ These changes replace the `subprocess.run` patches with `subprocess.check_output
         files = [file1]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, "diff", io=InputOutput(), fnames=files)
+        coder = Coder.create(models.Model.create("gpt-4"), "diff", io=InputOutput(), fnames=files)
 
         def mock_send(*args, **kwargs):
             coder.partial_response_content = f"""
@@ -339,7 +339,7 @@ new
 
         # Initialize the Coder object with the mocked IO and mocked repo
         coder = Coder.create(
-            models.GPT4,
+            models.Model.create("gpt-4"),
             "diff",
             io=InputOutput(dry_run=True),
             fnames=files,

--- a/tests/test_wholefile.py
+++ b/tests/test_wholefile.py
@@ -11,6 +11,7 @@ from aider.coders.wholefile_coder import WholeFileCoder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 
+GPT35 = models.Model.create("gpt-3.5")
 
 class TestWholeFileCoder(unittest.TestCase):
     def setUp(self):
@@ -32,7 +33,7 @@ class TestWholeFileCoder(unittest.TestCase):
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
 
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[])
         coder.partial_response_content = (
             'To print "Hello, World!" in most programming languages, you can use the following'
             ' code:\n\n```python\nprint("Hello, World!")\n```\n\nThis code will output "Hello,'
@@ -44,7 +45,7 @@ class TestWholeFileCoder(unittest.TestCase):
 
     def test_no_files_new_file_should_ask(self):
         io = InputOutput(yes=False)  # <- yes=FALSE
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[])
         coder.partial_response_content = (
             'To print "Hello, World!" in most programming languages, you can use the following'
             ' code:\n\nfoo.js\n```python\nprint("Hello, World!")\n```\n\nThis code will output'
@@ -61,7 +62,7 @@ class TestWholeFileCoder(unittest.TestCase):
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
         coder.partial_response_content = f"{sample_file}\n```\nUpdated content\n```"
@@ -85,7 +86,7 @@ class TestWholeFileCoder(unittest.TestCase):
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
         coder.partial_response_content = f"{sample_file}\n```\n0\n\1\n2\n"
@@ -109,7 +110,7 @@ Quote!
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         coder.choose_fence()
 
@@ -139,7 +140,7 @@ Quote!
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
         # With path/to/ prepended onto the filename
@@ -164,7 +165,7 @@ Quote!
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io)
+        coder = WholeFileCoder(None, main_model=GPT35, io=io)
 
         # Set the partial response content with the updated content
         coder.partial_response_content = f"{sample_file}\n```\nUpdated content\n```"
@@ -192,7 +193,7 @@ Quote!
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
         coder.partial_response_content = (
@@ -235,7 +236,7 @@ after b
 """
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[fname_a, fname_b])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[fname_a, fname_b])
 
         # Set the partial response content with the updated content
         coder.partial_response_content = response
@@ -259,7 +260,7 @@ after b
 
         # Initialize WholeFileCoder with the temporary directory
         io = InputOutput(yes=True)
-        coder = WholeFileCoder(None, main_model=models.GPT35, io=io, fnames=[sample_file])
+        coder = WholeFileCoder(None, main_model=GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
         coder.partial_response_content = (
@@ -292,7 +293,7 @@ after b
         files = [file1]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(models.GPT4, "whole", io=InputOutput(), fnames=files)
+        coder = Coder.create(models.Model.create("gpt-4"), "whole", io=InputOutput(), fnames=files)
 
         # no trailing newline so the response content below doesn't add ANOTHER newline
         new_content = "new\ntwo\nthree"


### PR DESCRIPTION
### 🚨 *Feedback wanted!*

When all of `--openai-api-key`, `--openai-api-base`, and `--openrouter` are **not passed** and the user has installed LiteLLM with `pip install litellm`, Aider will default to using the LiteLLM client, which has support for [many models](https://docs.litellm.ai/docs/providers), including Claude 3, Gemini 1.5 Pro, and Command R+.

You also need to install model-specific clients, which LiteLLM will use under the hood. For example, you'll need to `pip install anthropic` to use Claude 3. To use Gemini 1.5 Pro, you'll need to `pip install google-generativeai` first.

Since LiteLLM loads the nearest `.env` file, it's recommended to place your model-specific API key in there. For example, LiteLLM expects an `ANTHROPIC_API_KEY` environment variable to exist when using Claude 3. Of course, you can define the environment variable however you please, so an `.env` file is optional. Find your preferred model on the [LiteLLM supported models](https://docs.litellm.ai/docs/providers) page to determine which environment variable is expected by LiteLLM based on which model you're using.

- **Does this add dependencies to Aider?**  
  No, the user must run `pip install litellm` for Aider to support LiteLLM.

- **Can I use any model supported by LiteLLM?**  
  Yes, the supported models are loaded directly from LiteLLM's Github repository. As long as you keep LiteLLM up-to-date, any new models can be used as long as LiteLLM supports them.

- **What model is used for the summarizer and repo-map?**  
  If you're using Claude 3 Opus or GPT-4, Aider will use GPT-3.5 Turbo for the chat summarizer and repo-map features. Otherwise, the `--model` you defined is what's used.

- **Has this been tested extensively?**  
  No, I'm looking for people to try it out and leave feedback on this pull request.

### Model aliases

When defining the `--model` name, you can use these aliases:

```
# claude-3
opus   => claude-3-opus-20240229
sonnet => claude-3-sonnet-20240229
haiku  => claude-3-haiku-20240307

# gemini-1.5-pro
gemini => gemini-1.5-pro-preview-0409

# gpt-3.5
gpt-3.5           => gpt-3.5-turbo-0613
gpt-3.5-turbo     => gpt-3.5-turbo-0613
gpt-3.5-turbo-16k => gpt-3.5-turbo-16k-0613

# gpt-4
gpt-4     => gpt-4-0613
gpt-4-32k => gpt-4-32k-0613
```

The gpt-3.5 and gpt-4 aliases were already supported, but they're also supported when using the `--litellm` flag or when LiteLLM is used by default.

### Additional improvements
I've added some environment variables to improve `.env` file support, so I can run aider with `dotenv run aider` to use them:
- the `AIDER_MODEL` environment variable is now supported
- the `AIDER_EDIT_FORMAT` environment variable is now supported