### PR TITLE
Nix flake with `aider` package and development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716218643,
+        "narHash": "sha256-i/E7gzQybvcGAYDRGDl39WL6yVk30Je/NXypBz6/nmM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a8695cbd09a7ecf3376bd62c798b9864d20f86ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+
+    system = lib.genAttrs lib.platforms.all (system: system);
+
+    developerSystems = [system.x86_64-linux];
+
+    allSystems = lib.platforms.all;
+
+    legacyPackages = lib.genAttrs developerSystems (
+      system:
+        import nixpkgs {
+          inherit system;
+          overlays = [
+            self.overlays.default
+          ];
+        }
+    );
+  in {
+    devShells = lib.genAttrs developerSystems (system: {
+      default = legacyPackages.${system}.callPackage ./nix/dev-shells/default {};
+    });
+
+    formatter = lib.genAttrs developerSystems (system: legacyPackages.${system}.alejandra);
+
+    overlays = {
+      default = import ./nix/overlays/default { flake = self; };
+    };
+
+    packages = lib.genAttrs allSystems (
+      system:
+        import ./nix/packages {
+          flake = self;
+          legacyPackages = legacyPackages.${system};
+          inherit lib system;
+        }
+    );
+  };
+}

--- a/nix/dev-shells/default/default.nix
+++ b/nix/dev-shells/default/default.nix
@@ -1,0 +1,54 @@
+{
+  aider,
+  fetchFromGitHub,
+  imgcat,
+  lib,
+  mkShell,
+  pre-commit,
+  python,
+  typer,
+  writeText,
+  # black,
+  # mypy,
+}: let
+  # Environment with plannet dependencies
+  pythonEnv = python.withPackages (
+    pythonPkgs:
+      with pythonPkgs;
+        [
+          flake8
+          pytest
+          # lox (not available in nixpkgs)
+          matplotlib
+          pandas
+          pip-tools
+        ]
+        ++ aider.propagatedBuildInputs
+  );
+in
+  mkShell {
+    buildInputs = [
+      # See dev-requirements.in
+      pythonEnv
+      typer
+      imgcat
+      pre-commit
+      # black
+      # mypy
+    ];
+
+    shellHook = let
+      nocolor = "\\e[0m";
+      white = "\\e[1;37m";
+    in ''
+      clear -x
+      printf "${white}"
+      echo "-----------------------"
+      echo "Development environment"
+      echo "-----------------------"
+      printf "${nocolor}"
+      echo
+
+      export PYTHONPATH="$(pwd):$PYTHONPATH"
+    '';
+  }

--- a/nix/overlays/default/default.nix
+++ b/nix/overlays/default/default.nix
@@ -1,0 +1,32 @@
+{ flake }: final: prev: let
+  pythonOverrides = final: prev: {
+    grep-ast = final.callPackage ../../packages/grep-ast {};
+    tree-sitter-languages = final.callPackage ../../packages/tree-sitter-languages {};
+    openai = final.callPackage ../../packages/openai {};
+    litellm = final.callPackage ../../packages/litellm {};
+    fastapi-sso = final.callPackage ../../packages/fastapi-sso {};
+    prisma = final.callPackage ../../packages/prisma {};
+    resend = final.callPackage ../../packages/resend {};
+    gitpython = final.callPackage ../../packages/gitpython {};
+    streamlit = final.callPackage ../../packages/streamlit {};
+
+    # Fixes
+    eventlet = prev.eventlet.overrideAttrs (oldAttrs: { doCheck = false; });
+  };
+in {
+  python310 = prev.python310.override (oldAttrs: {
+    self = final.python310;
+    packageOverrides = final.lib.composeManyExtensions [
+      (oldAttrs.packageOverrides or (final: prev: {}))
+      pythonOverrides
+    ];
+  });
+
+  python3 = final.python310;
+  python = final.python3;
+  aider = final.python.pkgs.callPackage ../../packages/aider {};
+
+  # Fixes
+  cryptsetup = prev.cryptsetup.overrideAttrs (oldAttrs: { doCheck = false; });
+}
+

--- a/nix/packages/aider/default.nix
+++ b/nix/packages/aider/default.nix
@@ -1,0 +1,101 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+
+# buildInputs
+, setuptools
+
+# propagatedBuildInputs
+, configargparse
+, gitpython
+, openai
+, tiktoken
+, jsonschema
+, rich
+, prompt-toolkit
+, numpy
+, scipy
+, backoff
+, pathspec
+, networkx
+, diskcache
+, grep-ast
+, packaging
+, sounddevice
+, soundfile
+, beautifulsoup4
+, pyyaml
+, pillow
+, diff-match-patch
+, playwright
+, pypandoc
+, httpx
+, litellm
+, streamlit
+}:
+
+buildPythonApplication rec {
+  pname = "aider";
+  version = "0.35.0";
+  format = "pyproject";
+
+  src = lib.fileset.toSource {
+    root = ../../..;
+    fileset = lib.fileset.difference
+      (lib.fileset.gitTracked ../../..)
+      (lib.fileset.unions [
+        ../../../flake.nix
+        ../../../flake.lock
+        ../../../nix
+      ]);
+  };
+
+  # src = fetchFromGitHub {
+  #   owner = "paul-gauthier";
+  #   repo = pname;
+  #   rev = "v${version}";
+  #   hash = "sha256-oDBPji2PBhsjzX+7OjtUY27DyBFVvwMEooNNIS6Cy3g=";
+  # };
+
+  buildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    configargparse
+    gitpython
+    openai
+    tiktoken
+    jsonschema
+    rich
+    prompt-toolkit
+    numpy
+    scipy
+    backoff
+    pathspec
+    networkx
+    diskcache
+    grep-ast
+    packaging
+    sounddevice
+    soundfile
+    beautifulsoup4
+    pyyaml
+    pillow
+    diff-match-patch
+    playwright
+    pypandoc
+    httpx
+    litellm
+    streamlit
+  ];
+
+  meta = with lib; {
+    description = ''
+      aider is AI pair programming in your terminal
+    '';
+    homepage = "https://aider.chat/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [];
+  };
+}

--- a/nix/packages/aider/default.nix
+++ b/nix/packages/aider/default.nix
@@ -24,6 +24,7 @@
 , sounddevice
 , soundfile
 , beautifulsoup4
+, importlib-resources
 , pyyaml
 , pillow
 , diff-match-patch
@@ -36,7 +37,7 @@
 
 buildPythonApplication rec {
   pname = "aider";
-  version = "0.35.0";
+  version = "0.44.0";
   format = "pyproject";
 
   src = lib.fileset.toSource {
@@ -80,6 +81,7 @@ buildPythonApplication rec {
     sounddevice
     soundfile
     beautifulsoup4
+    importlib-resources
     pyyaml
     pillow
     diff-match-patch

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,10 @@
+{
+  flake,
+  lib,
+  legacyPackages,
+  system,
+}: {
+  default = flake.packages.${system}.aider;
+  inherit (legacyPackages)
+    aider;
+}

--- a/nix/packages/fastapi-sso/default.nix
+++ b/nix/packages/fastapi-sso/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  email-validator,
+  fastapi,
+  fetchFromGitHub,
+  httpx,
+  oauthlib,
+  poetry-core,
+  pydantic,
+  pylint,
+  pytest-asyncio,
+  pytest-xdist,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "fastapi-sso";
+  version = "0.15.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "tomasvotava";
+    repo = "fastapi-sso";
+    rev = "refs/tags/${version}";
+    hash = "sha256-jSUogf2Dup8k4BOQAXJwg8R96Blgieg82/X/n1TLnL0=";
+  };
+
+  postPatch = ''
+    sed -i "/--cov/d" pyproject.toml
+  '';
+
+  # build-system = [ poetry-core ];
+  nativeBuildInputs = [ poetry-core ];
+
+  # dependencies = [
+  propagatedBuildInputs = [
+    fastapi
+    httpx
+    oauthlib
+    pydantic
+    pylint
+  ];
+
+  nativeCheckInputs = [
+    email-validator
+    pytest-asyncio
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fastapi_sso" ];
+
+  meta = with lib; {
+    description = "FastAPI plugin to enable SSO to most common providers (such as Facebook login, Google login and login via Microsoft Office 365 Account";
+    homepage = "https://github.com/tomasvotava/fastapi-sso";
+    changelog = "https://github.com/tomasvotava/fastapi-sso/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/nix/packages/gitpython/default.nix
+++ b/nix/packages/gitpython/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, ddt
+, fetchFromGitHub
+, gitdb
+, pkgs
+, pythonOlder
+, substituteAll
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "gitpython";
+  version = "3.1.43";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "gitpython-developers";
+    repo = "GitPython";
+    rev = "refs/tags/${version}";
+    hash = "sha256-HO6t5cOHyDJVz+Bma4Lkn503ZfDmiQxUfSLaSZtUrTk=";
+  };
+
+  propagatedBuildInputs = [
+    ddt
+    gitdb
+    pkgs.gitMinimal
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    typing-extensions
+  ];
+
+  postPatch = ''
+    substituteInPlace git/cmd.py \
+      --replace 'git_exec_name = "git"' 'git_exec_name = "${pkgs.gitMinimal}/bin/git"'
+  '';
+
+  # Tests require a git repo
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "git"
+  ];
+
+  meta = with lib; {
+    description = "Python Git Library";
+    homepage = "https://github.com/gitpython-developers/GitPython";
+    changelog = "https://github.com/gitpython-developers/GitPython/blob/${version}/doc/source/changes.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/nix/packages/grep-ast/default.nix
+++ b/nix/packages/grep-ast/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, tree-sitter-languages
+, pathspec
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "grep-ast";
+  version = "0.3.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "paul-gauthier";
+    repo = pname;
+    rev = "3cf620091364e95e501fa2fd1125cc9fae7971e5";
+    hash = "sha256-xeHT8Zp1NyLeK2864DsFpNoxrct/EcUEbG+d33Gc/LQ=";
+  };
+
+  buildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    tree-sitter-languages
+    pathspec
+  ];
+
+  pythonImportsCheck = [ "grep_ast" ];
+
+  meta = with lib; {
+    description = ''
+      Grep source code and see useful code context about matching lines
+    '';
+    homepage = "https://github.com/paul-gauthier/grep-ast";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/nix/packages/litellm/default.nix
+++ b/nix/packages/litellm/default.nix
@@ -1,0 +1,108 @@
+{ lib
+, aiohttp
+, apscheduler
+, azure-identity
+, azure-keyvault-secrets
+, backoff
+, buildPythonPackage
+, click
+, fastapi
+, fastapi-sso
+, fetchFromGitHub
+, google-cloud-kms
+, gunicorn
+, importlib-metadata
+, jinja2
+, openai
+, orjson
+, poetry-core
+, prisma
+, pyjwt
+, python-dotenv
+, python-multipart
+, pythonOlder
+, pyyaml
+, requests
+, resend
+, rq
+, streamlit
+, tiktoken
+, tokenizers
+, uvicorn
+}:
+
+buildPythonPackage rec {
+  pname = "litellm";
+  version = "1.37.16";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "BerriAI";
+    repo = "litellm";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-WOkblyzncIn1F67qlh8rTosCal6j4zlXsHHrWbwhJOo=";
+  };
+
+  postPatch = ''
+    rm -rf dist
+  '';
+
+  # build-system = [
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  # dependencies = [
+  propagatedBuildInputs = [
+    aiohttp
+    click
+    importlib-metadata
+    jinja2
+    openai
+    requests
+    python-dotenv
+    tiktoken
+    tokenizers
+  ];
+
+  passthru.optional-dependencies = {
+    proxy = [
+      apscheduler
+      backoff
+      fastapi
+      fastapi-sso
+      gunicorn
+      orjson
+      pyjwt
+      python-multipart
+      pyyaml
+      rq
+      uvicorn
+    ];
+    extra_proxy = [
+      azure-identity
+      azure-keyvault-secrets
+      google-cloud-kms
+      prisma
+      resend
+      streamlit
+    ];
+  };
+
+  # the import check phase fails trying to do a network request to openai
+  # pythonImportsCheck = [ "litellm" ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Use any LLM as a drop in replacement for gpt-3.5-turbo. Use Azure, OpenAI, Cohere, Anthropic, Ollama, VLLM, Sagemaker, HuggingFace, Replicate (100+ LLMs)";
+    mainProgram = "litellm";
+    homepage = "https://github.com/BerriAI/litellm";
+    changelog = "https://github.com/BerriAI/litellm/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ happysalada ];
+  };
+}

--- a/nix/packages/openai/default.nix
+++ b/nix/packages/openai/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  anyio,
+  buildPythonPackage,
+  cached-property,
+  dirty-equals,
+  distro,
+  fetchFromGitHub,
+  hatch-fancy-pypi-readme,
+  hatchling,
+  httpx,
+  numpy,
+  pandas,
+  pandas-stubs,
+  pydantic,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+  pythonOlder,
+  respx,
+  sniffio,
+  tqdm,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "openai";
+  version = "1.30.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = "openai-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HREwQvsnG9zzDW8TkTQrvpyDoDxu9j6dOvyUKlBl7cQ=";
+  };
+
+  # build-system = [
+  nativeBuildInputs = [
+    hatchling
+    hatch-fancy-pypi-readme
+  ];
+
+  # dependencies = [
+  propagatedBuildInputs = [
+    httpx
+    pydantic
+    typing-extensions
+    anyio
+    distro
+    sniffio
+    tqdm
+  ] ++ lib.optionals (pythonOlder "3.8") [ cached-property ];
+
+  passthru.optional-dependencies = {
+    datalib = [
+      numpy
+      pandas
+      pandas-stubs
+    ];
+  };
+
+  pythonImportsCheck = [ "openai" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-mock
+    respx
+    dirty-equals
+  ];
+
+  pytestFlagsArray = [
+    "-W"
+    "ignore::DeprecationWarning"
+  ];
+
+  disabledTests = [
+    # Tests make network requests
+    "test_streaming_response"
+    "test_copy_build_request"
+
+    # Test fails with pytest>=8
+    "test_basic_attribute_access_works"
+  ];
+
+  disabledTestPaths = [
+    # Test makes network requests
+    "tests/api_resources"
+  ];
+
+  meta = with lib; {
+    description = "Python client library for the OpenAI API";
+    homepage = "https://github.com/openai/openai-python";
+    changelog = "https://github.com/openai/openai-python/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ malo ];
+    mainProgram = "openai";
+  };
+}

--- a/nix/packages/prisma/default.nix
+++ b/nix/packages/prisma/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, click
+, fetchFromGitHub
+, httpx
+, jinja2
+, nodeenv
+, pydantic
+, pytestCheckHook
+, python-dotenv
+, pythonOlder
+, setuptools
+, strenum
+, tomlkit
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "prisma";
+  version = "0.13.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "RobertCraigie";
+    repo = "prisma-client-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-7pibexiFsyrwC6rVv0CGHRbQU4G3rOXVhQW/7c/vKJA=";
+  };
+
+  # build-system = [
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  # dependencies = [
+  propagatedBuildInputs = [
+    click
+    httpx
+    jinja2
+    nodeenv
+    pydantic
+    python-dotenv
+    tomlkit
+    typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    strenum
+  ];
+
+  # Building the client requires network access
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "prisma"
+  ];
+
+  meta = with lib; {
+    description = "Auto-generated and fully type-safe database client for prisma";
+    homepage = "https://github.com/RobertCraigie/prisma-client-py";
+    changelog = "https://github.com/RobertCraigie/prisma-client-py/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/nix/packages/resend/default.nix
+++ b/nix/packages/resend/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pythonOlder,
+  pytestCheckHook,
+  requests,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "resend";
+  version = "1.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "resend";
+    repo = "resend-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-xLrqkOHdynlwuY3+9aHWgCz8TX9v4RiVCvvPtu6k14c=";
+  };
+
+  # build-system = [ setuptools ];
+  nativeBuildInputs = [ setuptools ];
+
+  # dependencies = [
+  propagatedBuildInputs = [
+    requests
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "resend" ];
+
+  meta = with lib; {
+    description = "SDK for Resend";
+    homepage = "https://github.com/resend/resend-python";
+    changelog = "https://github.com/resend/resend-python/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/nix/packages/streamlit/default.nix
+++ b/nix/packages/streamlit/default.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  altair,
+  blinker,
+  buildPythonPackage,
+  cachetools,
+  click,
+  fetchPypi,
+  gitpython,
+  importlib-metadata,
+  numpy,
+  packaging,
+  pandas,
+  pillow,
+  protobuf,
+  pyarrow,
+  pydeck,
+  pympler,
+  python-dateutil,
+  pythonOlder,
+  pythonRelaxDepsHook,
+  setuptools,
+  requests,
+  rich,
+  tenacity,
+  toml,
+  tornado,
+  typing-extensions,
+  tzlocal,
+  validators,
+  watchdog,
+}:
+
+buildPythonPackage rec {
+  pname = "streamlit";
+  version = "1.34.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-E1o7eaaGsxMrc/IERQrW6IneBPM0nWkpJeCfDiHnS1I=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [ "packaging" ];
+
+  propagatedBuildInputs = [
+    altair
+    blinker
+    cachetools
+    click
+    gitpython
+    importlib-metadata
+    numpy
+    packaging
+    pandas
+    pillow
+    protobuf
+    pyarrow
+    pydeck
+    pympler
+    python-dateutil
+    requests
+    rich
+    tenacity
+    toml
+    tornado
+    typing-extensions
+    tzlocal
+    validators
+  ] ++ lib.optionals (!stdenv.isDarwin) [ watchdog ];
+
+  # pypi package does not include the tests, but cannot be built with fetchFromGitHub
+  doCheck = false;
+
+  pythonImportsCheck = [ "streamlit" ];
+
+  postInstall = ''
+    rm $out/bin/streamlit.cmd # remove windows helper
+  '';
+
+  meta = with lib; {
+    homepage = "https://streamlit.io/";
+    changelog = "https://github.com/streamlit/streamlit/releases/tag/${version}";
+    description = "The fastest way to build custom ML tools";
+    mainProgram = "streamlit";
+    maintainers = with maintainers; [
+      natsukium
+      yrashk
+    ];
+    license = licenses.asl20;
+  };
+}

--- a/nix/packages/tree-sitter-languages/default.nix
+++ b/nix/packages/tree-sitter-languages/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, autoPatchelfHook
+, python
+, fetchurl
+, tree-sitter
+}:
+
+let wheels = {
+      "x86_64-linux-python-3.10" = {
+        url = https://files.pythonhosted.org/packages/f4/86/b50a1a5cc7058bf572acceb8b005c77e2f43b06a13fdb7a52c38b0f8e6fa/tree_sitter_languages-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+        sha256 = "0lv1nml1lfc9017s001pfqmyy8pl6l1r8grzyfwcwq746gh8aqqw";
+      };
+      "x86_64-linux-python-3.11" = {
+        url = https://files.pythonhosted.org/packages/96/81/ab4eda8dbd3f736fcc9a508bc69232d3b9076cd46b932d9bf9d49b9a1ec9/tree_sitter_languages-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+        sha256 = "0jdqscis0lzf4ypjdlabilfpd05cq6agk84q97i0n5x72k1lmqws";
+      };
+      "x86_64-linux-python-3.12" = {
+        url = https://files.pythonhosted.org/packages/f2/e6/eddc76ad899d77adcb5fca6cdf651eb1d33b4a799456bf303540f6cf8204/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl;
+        sha256 = "0q6jykj5wgmcb78m2a3mxlfwyj7ivi4pvdn2z4r57mmxs78iqbvd";
+      };
+    };
+
+in buildPythonPackage rec {
+  pname = "tree-sitter-languages";
+  version = "1.10.2";
+  format = "wheel";
+
+  src = fetchurl wheels."${stdenv.system}-python-${python.pythonVersion}";
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  propagatedBuildInputs = [
+    tree-sitter
+  ];
+
+  meta = with lib; {
+    description = ''
+      Binary Python wheels for all tree sitter languages
+    '';
+    homepage = "https://github.com/grantjenks/py-tree-sitter-languages";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}


### PR DESCRIPTION
This adds a nix flake to build and hack on aider with the [nix package manager](https://nixos.org). I made this because I'm thinking of hacking on aider code a little bit myself.

To start off I want to acknowledge that I don't expect this PR to be merged because it would impose a maintenance burden that is unlikely to be worth the effort for @paul-gauthier (unless you are using nix yourself). I made this draft PR just for folks in #544 to have another option to look at.

I also want to acknowledge that the `aider`, `grep-ast`, `tree-sitter-languages` expressions originates from [nixvital/ml-pkgs](https://github.com/nixvital/ml-pkgs/blob/f05799ad0145cb6a0b4577c54efe531c5895e33b/pkgs/aider/default.nix) and other nix package expressions originates from [nixpkgs](https://github.com/NixOS/nixpkgs). (Thank you to those folks)

### Usage

**1. Running aider:**

```shell
$ nix run .#aider
Aider v0.35.1-dev
Models: gpt-4o with diff edit format, weak model gpt-3.5-turbo
Git repo: .git with 209 files
Repo-map: using 1024 tokens
Use /help to see in-chat commands, run with --help to see cmd line args
──────────────────────────────────────────────────────────────────────────────────────
>  
```

**2. Hacking on aider:**

```shell
$ nix develop
-----------------------
Development environment
-----------------------
$ python
Python 3.10.14 (main, Mar 19 2024, 21:46:16) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import aider
>>> aider.__version__
'0.35.1-dev'
```