### PR TITLE
All AIDER_* environment vars may now be placed within .env

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -13,7 +13,6 @@ on:
       - README.md
     branches:
       - main
-      - issue-630
 
 jobs:
   build:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -13,6 +13,7 @@ on:
       - README.md
     branches:
       - main
+      - issue-630
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/pycqa/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
       - id: isort

--- a/aider/args.py
+++ b/aider/args.py
@@ -12,6 +12,21 @@ from aider.args_formatter import MarkdownHelpFormatter, YamlHelpFormatter
 from .dump import dump  # noqa: F401
 
 
+def default_env_file(git_root):
+    return os.path.join(git_root, ".env") if git_root else ".env"
+
+
+def get_preparser(git_root):
+    parser = configargparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--env-file",
+        metavar="ENV_FILE",
+        default=default_env_file(git_root),
+        help="Specify the .env file to load (default: .env in git root)",
+    )
+    return parser
+
+
 def get_parser(default_config_files, git_root):
     parser = configargparse.ArgumentParser(
         description="aider is GPT powered coding in your terminal",
@@ -184,11 +199,12 @@ def get_parser(default_config_files, git_root):
             " max_chat_history_tokens."
         ),
     )
-    default_env_file = os.path.join(git_root, ".env") if git_root else ".env"
+    # This is a duplicate of the argument in the preparser and is a no-op by this time of
+    # argument parsing, but it's here so that the help is displayed as expected.
     group.add_argument(
         "--env-file",
         metavar="ENV_FILE",
-        default=default_env_file,
+        default=default_env_file(git_root),
         help="Specify the .env file to load (default: .env in git root)",
     )
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -226,7 +226,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     default_config_files = list(map(str, default_config_files))
 
     preparser = get_preparser(git_root)
-    pre_args, _ = preparser.parse_known_args()
+    pre_args, _ = preparser.parse_known_args(argv)
 
     # Load the .env file specified in the arguments
     load_dotenv(pre_args.env_file)

--- a/aider/main.py
+++ b/aider/main.py
@@ -124,6 +124,12 @@ def check_gitignore(git_root, io, ask=True):
 
 def format_settings(parser, args):
     show = scrub_sensitive_info(args, parser.format_values())
+    # clean up the headings for consistency w/ new lines
+    heading_env = "Environment Variables:"
+    heading_defaults = "Defaults:"
+    if heading_env in show:
+        show = show.replace(heading_env, "\n" + heading_env)
+        show = show.replace(heading_defaults, "\n" + heading_defaults)
     show += "\n"
     show += "Option settings:\n"
     for arg, val in sorted(vars(args).items()):

--- a/aider/tests/test_main.py
+++ b/aider/tests/test_main.py
@@ -13,7 +13,7 @@ from prompt_toolkit.output import DummyOutput
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import check_gitignore, main, setup_git
-from aider.utils import GitTemporaryDirectory, make_repo
+from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory, make_repo
 
 
 class TestMain(TestCase):
@@ -21,7 +21,7 @@ class TestMain(TestCase):
         self.original_env = os.environ.copy()
         os.environ["OPENAI_API_KEY"] = "deadbeef"
         self.original_cwd = os.getcwd()
-        self.tempdir_obj = tempfile.TemporaryDirectory()
+        self.tempdir_obj = IgnorantTemporaryDirectory()
         self.tempdir = self.tempdir_obj.name
         os.chdir(self.tempdir)
 
@@ -34,7 +34,7 @@ class TestMain(TestCase):
     def test_main_with_empty_dir_no_files_on_command(self):
         main(["--no-git"], input=DummyInput(), output=DummyOutput())
 
-    def test_main_with_empty_dir_new_file(self):
+    def test_main_with_emptqy_dir_new_file(self):
         main(["foo.txt", "--yes", "--no-git"], input=DummyInput(), output=DummyOutput())
         self.assertTrue(os.path.exists("foo.txt"))
 

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -17,10 +17,16 @@ class IgnorantTemporaryDirectory:
         return self.temp_dir.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
+
+    def cleanup(self):
         try:
-            self.temp_dir.__exit__(exc_type, exc_val, exc_tb)
+            self.temp_dir.cleanup()
         except (OSError, PermissionError):
             pass  # Ignore errors (Windows)
+
+    def __getattr__(self, item):
+        return getattr(self.temp_dir, item)
 
 
 class ChdirTemporaryDirectory(IgnorantTemporaryDirectory):


### PR DESCRIPTION
This PR addresses #630. I have left it in draft mode as I plan to add doc updates and perhaps some additional tests, but this is a first look.