### PR TITLE
Added commands for emitting template configuration files

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -6,6 +6,21 @@ import configargparse
 from aider import __version__, models
 
 
+# custom action used for --config-template
+class EmitAction(argparse.Action):
+    def __init__(self, *args, emit_src=None, **kwargs):
+        super(EmitAction, self).__init__(*args, **kwargs)
+        self.emit_src = emit_src
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, True)  # The option itself
+        setattr(namespace, "emit_src", self.emit_src)
+        if values is True:
+            setattr(namespace, "emit_dest", None)
+        else:
+            setattr(namespace, "emit_dest", values)
+
+
 def get_parser(default_config_files, git_root):
     parser = configargparse.ArgumentParser(
         description="aider is GPT powered coding in your terminal",
@@ -437,6 +452,26 @@ def get_parser(default_config_files, git_root):
             "Specify the config file (default: search for .aider.conf.yml in git root, cwd"
             " or home directory)"
         ),
+    )
+    group.add_argument(
+        "--config-template-yml",
+        metavar="DIR",
+        nargs="?",
+        default=False,
+        const=True,  # if no dest dir is specified, emit to STDOUT
+        help="Write .aider.conf.yml template to the specified directory or stdout if omitted",
+        action=EmitAction,
+        emit_src=".aider.conf.yml",
+    )
+    group.add_argument(
+        "--config-template-env",
+        metavar="DIR",
+        nargs="?",
+        default=False,
+        const=True,  # if no dest dir is specified, emit to STDOUT
+        help="Write .env template to the specified directory or stdout if omitted",
+        action=EmitAction,
+        emit_src=".env",
     )
     group.add_argument(
         "--gui",

--- a/aider/emit.py
+++ b/aider/emit.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from pathlib import Path
+
+
+def emit(src, dest):
+    try:
+        template_content = read_template(src)
+    except FileNotFoundError as e:
+        print(e, file=sys.stderr)
+        return
+    if dest is None:
+        print(template_content)
+    else:
+        dest_file_path = dest_path(src, dest)
+        dest_dir = os.path.dirname(dest_file_path)
+        if not os.path.exists(dest_dir):
+            print(f"Error: The directory {dest_dir} does not exist.", file=sys.stderr)
+        elif os.path.exists(dest_file_path):
+            print(f"Refusing to overwrite the existing file at: {dest_file_path}", file=sys.stderr)
+        else:
+            write_template(template_content, dest_file_path)
+
+
+def src_path(fname):
+    return os.path.join(Path(__file__).parent, "emit", fname)
+
+
+def dest_path(src, dest):
+    return os.path.join(dest, src)
+
+
+def read_template(fname):
+    template_path = src_path(fname)
+    if not os.path.exists(template_path):
+        raise FileNotFoundError(f"Error: The template file {fname} does not exist.")
+    with open(template_path, "r") as file:
+        return file.read()
+
+
+def write_template(template_content, file_path):
+    with open(file_path, "w") as file:
+        file.write(template_content)
+    print(f"Template written to: {file_path}")

--- a/aider/emit/.aider.conf.yml
+++ b/aider/emit/.aider.conf.yml
@@ -1,0 +1,244 @@
+# This file can be used to set the configuration for aider and may
+# be placed in $PROJECT_DIR/.aider.conf.yml or $HOME/.aider.conf.yml
+# In general, precedence is as follows:
+#  - command-line values override... 
+#  - environment variables which override...
+#  - config file values which override... 
+#  - default values
+ 
+# ====================
+# Model selection
+# ====================
+
+# Specify the model to use for the main chat (default: gpt-4o)
+# Many OpenAI and Anthropic models may be specified in a short form.
+# For example:
+# - gpt-4o
+# - gpt-4-1106-preview
+# - gpt-3.5-turbo
+# - claude-3-opus-20240229
+# - claude-3-sonnet-20240229
+# Most models are specified with a provider prefix, e.g.,
+# - gemini/gemini-1.5-pro-latest
+# - groq/llama3-70b-8192
+# - ollama/llama3:70b
+model: gpt-4o
+
+# See https://aider.chat/docs/llms.html for details about supported models.
+# The following commands may also be used to list specific models for various
+# providers:
+# $ aider --models openai/
+# $ aider --models anthropic/
+# $ aider --models gemini/
+# $ aider --models groq/
+# $ aider --models cohere_chat/
+# $ aider --models azure/
+# $ aider --models openrouter/
+
+# Specify the OpenAI API key
+# Required for using OpenAI models like GPT-4o, GPT-4 Turbo, and GPT-3.5 Turbo
+# default: null
+openai-api-key: null
+
+# Specify the Anthropic API key
+# Required for using Anthropic models like Claude 3 Opus and Claude 3 Sonnet
+# default: null
+anthropic-api-key: null
+
+# Specify the Gemini API key
+# Required for using Gemini models like Gemini 1.5 Pro
+# default: null
+gemini-api-key: null
+
+# Specify the Groq API key
+# Required for using Groq models like Llama 3 70B
+# default: null
+groq-api-key: null
+
+# Specify the Cohere API key
+# Required for using Cohere models like Command-R+
+# default: null
+cohere-api-key: null
+
+# Specify the Azure API key
+# Required for using Azure models
+# default: null
+azure-api-key: null
+
+# Specify the OpenRouter API key
+# Required for using OpenRouter models
+# default: null
+openrouter-api-key: null
+
+# Specify the Deepseek API key
+# Required for using Deepseek models like Deepseek Chat v2
+# default: null
+deepseek-api-key: null
+
+# ====================
+# Model Behavior
+# ====================
+
+# Specify what edit format the LLM should use (default depends on model)
+# Options: whole, diff, udiff
+# edit_format: "diff"
+
+# Specify the model to use for commit messages and chat history summarization
+# default: ???
+# weak_model: "gpt-3.5-turbo"
+
+# Only work with models that have meta-data available (default: true)
+show-model-warnings: true
+
+# Max number of tokens to use for repo map, use 0 to disable (default: 1024)
+map-tokens: 1024
+
+# Maximum number of tokens to use for chat history
+# max_chat_history_tokens: 2048
+
+# =======================
+# Model Specific Settings
+# =======================
+
+# Specify the API base URL
+# Required for custom API endpoints, e.g., Azure or OpenRouter
+# openai_api_base: "https://api.openai.com/v1"
+
+# Used for specifying the type of API, e.g., Azure
+# openai_api_type: "azure"
+
+# Used for specifying the version of the API, e.g., Azure API version
+# openai_api_version: "2023-05-15"
+
+# Used for specifying the deployment ID in Azure
+# openai_api_deployment_id: "deployment-id"
+
+# Used for specifying the organization ID in OpenAI
+# openai_organization_id: "org-id"
+
+# Specify the Ollama API base URL
+# Required for using local Ollama models
+# default: "http://127.0.0.1:11434"
+# ollama_api_base: "http://127.0.0.1:11434"
+
+# ====================
+# History files
+# ====================
+
+# Specify the chat input history file
+input-history-file: .aider.input.history
+
+# Specify the chat history file
+chat-history-file: .aider.chat.history.md
+
+# Restore the previous chat history messages (default: false)
+restore-chat-history: false
+
+# Restore the previous chat history messages (default: false)
+restore-chat-history: false
+
+# ====================
+# Output settings
+# ====================
+
+# Use colors suitable for a dark terminal background (default: false)
+dark-mode: false
+
+# Use colors suitable for a light terminal background (default: false)
+light-mode: false
+
+# Enable/disable pretty, colorized output (default: true)
+pretty: true
+
+# Enable/disable streaming responses (default: true)
+stream: true
+
+# Set the color for user input
+# Default: #00cc00 (light mode: green, dark mode: #32FF32)
+user-input-color: "#00cc00"
+
+# Set the color for tool output
+# Default: null
+# tool_output_color: "#FFA500"
+
+# Set the color for tool error messages
+# Default: #FF2222 (light mode: red, dark mode: #FF3333)
+tool-error-color: "#FF2222"
+
+# Set the color for assistant output
+# Default: #0088ff (light mode: blue, dark mode: #00FFFF)
+assistant-output-color: "#0088ff"
+
+# Set the markdown code theme
+# Default: default
+# Other code theme options:
+# - monokai (dark mode)
+# - solarized-dark (dark mode)
+# - solarized-light (light mode)
+code-theme: default
+
+# Show diffs when committing changes (default: false)
+show-diffs: false
+
+# ====================
+# Git settings
+# ====================
+
+# Enable/disable looking for a git repo (default: true)
+git: true
+
+# Enable/disable adding .aider* to .gitignore (default: true)
+gitignore: true
+
+# Specify the aider ignore file (default: .aiderignore in git root)
+aiderignore: .aiderignore
+
+# Enable/disable auto commit of LLM changes (default: true)
+auto-commits: true
+
+# Enable/disable commits when repo is found dirty (default: true)
+dirty-commits: true
+
+# ====================
+# Fixing and committing
+# ====================
+
+# Specify lint commands to run for different languages
+# Example: "python: flake8 --select=E9"
+lint-cmd: ["typescript: cd workspace/llm-swarm-space/cli && npm run lint"]
+
+# Enable/disable automatic linting after changes (default: true)
+auto-lint: true
+
+# Specify command to run tests
+test-cmd: []
+
+# Enable/disable automatic testing after changes (default: false)
+auto-test: false
+
+# Run tests and fix problems found
+test: false
+
+# ====================
+# Other settings
+# ====================
+# Specify the language for voice using ISO 639-1 code (default: auto)
+# voice_language: en
+
+# Check for updates and return status in the exit code
+# check-update: false
+
+# Skips checking for the update when the program runs
+skip-check-update: false
+
+# Always say yes to every confirmation (default: false)
+# yes: true
+
+# Enable verbose output
+verbose: false
+
+# Specify the encoding for input and output (default: utf-8)
+encoding: utf-8
+
+# Run aider in your browser (default: false)
+gui: false

--- a/aider/emit/.env
+++ b/aider/emit/.env
@@ -1,0 +1,1 @@
+# I'll generate .env once we are happy with the content of .aider.conf.yaml

--- a/aider/main.py
+++ b/aider/main.py
@@ -12,6 +12,7 @@ from aider import __version__, models, utils
 from aider.args import get_parser
 from aider.coders import Coder
 from aider.commands import SwitchModel
+from aider.emit import emit
 from aider.io import InputOutput
 from aider.litellm import litellm  # noqa: F401; properly init litellm on launch
 from aider.repo import GitRepo
@@ -128,7 +129,7 @@ def format_settings(parser, args):
     for arg, val in sorted(vars(args).items()):
         if val:
             val = scrub_sensitive_info(args, str(val))
-        show += f"  - {arg}: {val}\n"
+        show += f"  - {arg}: {val}\n"  # noqa: E221
     return show
 
 
@@ -226,6 +227,10 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     parser = get_parser(default_config_files, git_root)
     args = parser.parse_args(argv)
+
+    if args.config_template_yml or args.config_template_env:
+        emit(args.emit_src, args.emit_dest)
+        return
 
     if args.gui and not return_coder:
         launch_gui(argv)

--- a/tests/test_emit.py
+++ b/tests/test_emit.py
@@ -1,0 +1,69 @@
+import io
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from aider.emit import emit, read_template
+
+
+class TestEmit(TestCase):
+    def setUp(self):
+        self.original_cwd = os.getcwd()
+        self.tempdir = tempfile.mkdtemp()
+        os.chdir(self.tempdir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_emit_stdout(self):
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            emit(".aider.conf.yml", None)
+            output = mock_stdout.getvalue()
+            expected_output = read_template(".aider.conf.yml")
+            self.assertEqual(output.strip(), expected_output.strip())
+
+    def test_emit_new_file(self):
+        new_file_path = Path(self.tempdir) / ".aider.conf.yml"
+        self.assertFalse(new_file_path.exists())
+
+        emit(".aider.conf.yml", self.tempdir)
+        self.assertTrue(new_file_path.exists())
+        expected_content = read_template(".aider.conf.yml")
+        self.assertEqual(new_file_path.read_text().strip(), expected_content.strip())
+
+    def test_emit_nonexistent_template_file(self):
+        invalid_template_file = "nonexistent_template.yml"
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            emit(invalid_template_file, self.tempdir)
+            error_output = mock_stderr.getvalue()
+            self.assertIn(
+                f"Error: The template file {invalid_template_file} does not exist.", error_output
+            )
+        existing_file_path = Path(self.tempdir) / ".aider.conf.yml"
+        existing_content = "# existing content\ndark-mode: false"
+        existing_file_path.write_text(existing_content)
+
+    def test_emit_existing_file(self):
+        existing_file_path = Path(self.tempdir) / ".aider.conf.yml"
+        existing_content = "# existing content\ndark-mode: false"
+        existing_file_path.write_text(existing_content)
+
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            emit(".aider.conf.yml", self.tempdir)
+            error_output = mock_stderr.getvalue()
+            self.assertIn(
+                f"Refusing to overwrite the existing file at: {existing_file_path}", error_output
+            )
+            self.assertEqual(existing_file_path.read_text(), existing_content)
+
+    def test_emit_nonexistent_directory(self):
+        nonexistent_dir = Path(self.tempdir) / "nonexistent_subdir"
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            emit(".aider.conf.yml", str(nonexistent_dir))
+            error_output = mock_stderr.getvalue()
+            self.assertIn(f"Error: The directory {nonexistent_dir} does not exist.", error_output)
+            self.assertFalse((nonexistent_dir / ".aider.conf.yml").exists())


### PR DESCRIPTION
Address issue #637 with two new command-line options which write out a template configuration file to make it easy for new users to properly configure aider:

```
--config-template-yml
--config-template-env
```

This is a draft PR as we have a couple of TODOs:

1. Comment out default settings from .aider.config.yml so that `--verbose` will list options as defaults when they have not really be set to a non-default value.

2. Write some new doc to cover this.

Note that this is a follow-on to #633.