### PR TITLE
Update help text for specifying the API key to mention Anthropic instead of OpenAI

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -36,7 +36,7 @@ def get_parser(default_config_files, git_root):
         "--anthropic-api-key",
         metavar="ANTHROPIC_API_KEY",
         env_var="ANTHROPIC_API_KEY",
-        help="Specify the OpenAI API key",
+        help="Specify the Anthropic API key",
     )
     default_model = models.DEFAULT_MODEL_NAME
     group.add_argument(


### PR DESCRIPTION
This pull request updates the help text in the aider/args.py file to mention Anthropic instead of OpenAI for specifying the API key. This change ensures that the documentation is accurate and reflects the current usage of the API keys.

**Changes:**

 • Updated the help text for the --anthropic-api-key argument to mention Anthropic instead of OpenAI.

**Files Modified:**

 • aider/args.py
