### PR TITLE
Allow models to be registered with litellm

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -136,7 +136,7 @@ def get_parser(default_config_files, git_root):
         help="Specify the OpenAI organization ID",
     )
     group.add_argument(
-        "--model_file",
+        "--model-file",
         metavar="MODEL_FILE",
         default=None,
         help={

--- a/aider/args.py
+++ b/aider/args.py
@@ -136,6 +136,23 @@ def get_parser(default_config_files, git_root):
         help="Specify the OpenAI organization ID",
     )
     group.add_argument(
+        "--model_file",
+        metavar="MODEL_FILE",
+        default=None,
+        help={
+            "File with model definitions to be registered for info/cost, json formated",
+            "  {"
+            "    \"gpt-4\": {",
+            "      \"max_tokens\": 8192,",
+            "      \"input_cost_per_token\": 0.00003,",
+            "      \"output_cost_per_token\": 0.00006,",
+            "      \"litellm_provider\": \"openai\",",
+            "      \"mode\": \"chat\"",
+            "    },",
+            "  }"
+        }
+    )
+    group.add_argument(
         "--edit-format",
         metavar="EDIT_FORMAT",
         default=None,

--- a/aider/args.py
+++ b/aider/args.py
@@ -140,7 +140,7 @@ def get_parser(default_config_files, git_root):
         metavar="MODEL_FILE",
         default=None,
         help={
-            "File with model definitions to be registered for info/cost, json formated",
+            "Specify a file with model definitions (info and cost) to be registered with litellm, json formated",
             "  {"
             "    \"gpt-4\": {",
             "      \"max_tokens\": 8192,",

--- a/aider/main.py
+++ b/aider/main.py
@@ -337,8 +337,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     model_def_files.append(Path.home() / model_def_fname)  # homedir
     if git_root:
         model_def_files.append(Path(git_root) / model_def_fname)  # git root
-    if args.models:
-        model_def_files.append(args.models)
+    if args.model_file:
+        model_def_files.append(args.model_file)
     model_def_files = list(map(str, model_def_files))
     models.register_models(model_def_files)
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -343,7 +343,15 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     model_def_files = list(map(str, model_def_files))
     model_def_files = list(dict.fromkeys(model_def_files))
     print(f"model_def_files: {model_def_files}")
-    models.register_models(model_def_files)
+    try:
+        model_files_loaded=models.register_models(model_def_files)
+        if len(model_files_loaded) > 0:
+            io.tool_output(f"Loaded {len(model_files_loaded)} model files")
+            for model_file in model_files_loaded:
+                io.tool_output(f"  - {model_file}")
+    except Exception as e:
+        io.tool_error(f"Error loading model info/cost: {e}")
+        return 1
 
     main_model = models.Model(args.model, weak_model=args.weak_model)
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -341,6 +341,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         model_def_files.append(args.model_file)
     model_def_files.append(model_def_fname.resolve())
     model_def_files = list(map(str, model_def_files))
+    model_def_files = list(dict.fromkeys(model_def_files))
+    print(f"model_def_files: {model_def_files}")
     models.register_models(model_def_files)
 
     main_model = models.Model(args.model, weak_model=args.weak_model)

--- a/aider/main.py
+++ b/aider/main.py
@@ -345,7 +345,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     try:
         model_files_loaded=models.register_models(model_def_files)
         if len(model_files_loaded) > 0:
-            io.tool_output(f"Loaded {len(model_files_loaded)} model files")
+            io.tool_output(f"Loaded {len(model_files_loaded)} model file(s)")
             for model_file in model_files_loaded:
                 io.tool_output(f"  - {model_file}")
     except Exception as e:

--- a/aider/main.py
+++ b/aider/main.py
@@ -332,6 +332,16 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.openai_organization_id:
         os.environ["OPENAI_ORGANIZATION"] = args.openai_organization_id
 
+    model_def_files = []
+    model_def_fname = Path(".aider.models.json")
+    model_def_files.append(Path.home() / model_def_fname)  # homedir
+    if git_root:
+        model_def_files.append(Path(git_root) / model_def_fname)  # git root
+    if args.models:
+        model_def_files.append(args.models)
+    model_def_files = list(map(str, model_def_files))
+    models.register_models(model_def_files)
+
     main_model = models.Model(args.model, weak_model=args.weak_model)
 
     lint_cmds = parse_lint_cmds(args.lint_cmd, io)

--- a/aider/main.py
+++ b/aider/main.py
@@ -342,7 +342,6 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     model_def_files.append(model_def_fname.resolve())
     model_def_files = list(map(str, model_def_files))
     model_def_files = list(dict.fromkeys(model_def_files))
-    print(f"model_def_files: {model_def_files}")
     try:
         model_files_loaded=models.register_models(model_def_files)
         if len(model_files_loaded) > 0:

--- a/aider/main.py
+++ b/aider/main.py
@@ -339,6 +339,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         model_def_files.append(Path(git_root) / model_def_fname)  # git root
     if args.model_file:
         model_def_files.append(args.model_file)
+    model_def_files.append(model_def_fname.resolve())
     model_def_files = list(map(str, model_def_files))
     models.register_models(model_def_files)
 

--- a/aider/models.py
+++ b/aider/models.py
@@ -426,6 +426,18 @@ class Model:
 
         return res
 
+def register_models(model_def_fnames):
+    for model_def_fname in model_def_fnames:
+        if not os.path.exists(model_def_fname):
+            continue
+        print(f"Registering model definition from {model_def_fname}")
+        try:
+            with open(model_def_fname, "r") as model_def_file:
+                model_def = json.load(model_def_file)
+        except json.JSONDecodeError as e:
+            print(f"Error opening/decoding model definition: {e}")
+
+        litellm.register_model(model_def)
 
 def validate_variables(vars):
     missing = []

--- a/aider/models.py
+++ b/aider/models.py
@@ -427,17 +427,20 @@ class Model:
         return res
 
 def register_models(model_def_fnames):
+    model_files_loaded = []
     for model_def_fname in model_def_fnames:
         if not os.path.exists(model_def_fname):
             continue
-        print(f"Registering model definition from {model_def_fname}")
+        model_files_loaded.append(model_def_fname)
         try:
             with open(model_def_fname, "r") as model_def_file:
                 model_def = json.load(model_def_file)
         except json.JSONDecodeError as e:
-            print(f"Error opening/decoding model definition: {e}")
+            raise Exception(f"Error loading model definition from {model_def_fname}: {e}")
 
         litellm.register_model(model_def)
+
+    return model_files_loaded
 
 def validate_variables(vars):
     missing = []

--- a/website/docs/install/optional.md
+++ b/website/docs/install/optional.md
@@ -46,6 +46,7 @@ The json file should be formated as follows
   },
 }
 ```
+see [litellm's model definitions](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) for examples
 
 ## Enable Playwright 
 

--- a/website/docs/install/optional.md
+++ b/website/docs/install/optional.md
@@ -26,6 +26,27 @@ Put a line in it like this to specify your api key:
 openai-api-key: sk-...
 ```
 
+## Registering Models not in litellm 
+
+You can register models info and cost with litellm by adding one or more of the following files
+* {HomeDir}/.aider.models.json
+* {GitRoot}/.aider.models.json
+* {CWD}/.aider.models.json
+* or via the command line argument `model-file`
+If the files above exists, they will be loaded in that order. Files loaded last will take priority.
+The json file should be formated as follows
+```
+{
+  "gpt-4": {
+    "max_tokens": 8192,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat",
+  },
+}
+```
+
 ## Enable Playwright 
 
 Aider supports adding web pages to the chat with the `/web <url>` command.

--- a/website/docs/install/optional.md
+++ b/website/docs/install/optional.md
@@ -28,7 +28,7 @@ openai-api-key: sk-...
 
 ## Registering Models not in litellm 
 
-You can register models info and cost with litellm by adding one or more of the following files
+You can register model info and costs with litellm by adding one or more of the following files
 * {HomeDir}/.aider.models.json
 * {GitRoot}/.aider.models.json
 * {CWD}/.aider.models.json

--- a/website/docs/options.md
+++ b/website/docs/options.md
@@ -103,6 +103,10 @@ Aliases:
 List known models which match the (partial) MODEL name  
 Environment variable: `AIDER_MODELS`  
 
+### `--model-file FILE`
+Specify a file with model definitions (info and cost) to be registered with litellm, json formated. See [Registering Models not in litellm](install/optional.md#registering_models_not_in_litellm) for the format  
+Environment variable: `AIDER_MODEL_FILE`
+
 ### `--openai-api-base OPENAI_API_BASE`
 Specify the api base url  
 Environment variable: `OPENAI_API_BASE`  


### PR DESCRIPTION
When using local models, sometime the model definitions do not exist in litellm model registry. This change allows you to add a `.aider.model.json` file to your home director, the project directory or through a command line argument any file. The change will load in the following order

1. Home directory
2. git root
3. current directory
4. command line arg

litellm's documentation claims he `register_model` function will overwrite existing information so the files loaded last should take priority.