### PR TITLE
doc: Removed template typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ and can [connect to almost any LLM](https://aider.chat/docs/llms.html).
 
 ## Getting started
 
-{% include get-started.md %}
-
 **See the
 [installation instructions](https://aider.chat/docs/install.html)
 and other


### PR DESCRIPTION
There was a template typo in the Getting Started section of the README that I removed