### PR TITLE
Support custom shortcut key commands

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -462,6 +462,22 @@ def get_parser(default_config_files, git_root):
         help="Run aider in your browser",
         default=False,
     )
+    group.add_argument(
+        "--short_key_1",
+        help="short key command 1 stored in the config file",
+    )
+    group.add_argument(
+        "--short_key_2",
+        help="short key command 2 stored in the config file",
+    )
+    group.add_argument(
+        "--short_key_3",
+        help="short key command 3 stored in the config file",
+    )
+    group.add_argument(
+        "--short_key_4",
+        help="short key command 4 stored in the config file",
+    )
 
     return parser
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -218,6 +218,10 @@ class Coder:
         auto_test=False,
         lint_cmds=None,
         test_cmd=None,
+        short_key_1=None,
+        short_key_2=None,
+        short_key_3=None,
+        short_key_4=None,
     ):
         if not fnames:
             fnames = []
@@ -265,7 +269,12 @@ class Coder:
 
         self.show_diffs = show_diffs
 
-        self.commands = Commands(self.io, self, voice_language)
+        short_key_commands = {
+            str(i): short_key_command
+            for i, short_key_command in enumerate([short_key_1, short_key_2, short_key_3, short_key_4], start=1)
+            if short_key_command
+        }
+        self.commands = Commands(self.io, self, voice_language, short_key_commands)
 
         if use_git:
             try:
@@ -616,6 +625,7 @@ class Coder:
         if not inp:
             return
 
+        inp = self.commands.convert_inpput_if_short_key(inp)
         if self.commands.is_command(inp):
             return self.commands.run(inp)
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -25,7 +25,7 @@ class Commands:
     voice = None
     scraper = None
 
-    def __init__(self, io, coder, voice_language=None):
+    def __init__(self, io, coder, voice_language=None, short_key_commands=None):
         self.io = io
         self.coder = coder
 
@@ -33,6 +33,7 @@ class Commands:
             voice_language = None
 
         self.voice_language = voice_language
+        self.short_key_commands = short_key_commands or {}
 
     def cmd_model(self, args):
         "Switch to a new LLM"
@@ -79,6 +80,11 @@ class Commands:
         content = f"{url}:\n\n" + content
 
         return content
+
+    def convert_inpput_if_short_key(self, inp):
+        if len(inp) == 2 and inp[0] == "/" and inp[1] in self.short_key_commands:
+            return self.short_key_commands[inp[1]]
+        return inp
 
     def is_command(self, inp):
         return inp[0] in "/!"

--- a/aider/main.py
+++ b/aider/main.py
@@ -392,6 +392,10 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             auto_test=args.auto_test,
             lint_cmds=lint_cmds,
             test_cmd=args.test_cmd,
+            short_key_1=args.short_key_1,
+            short_key_2=args.short_key_2,
+            short_key_3=args.short_key_3,
+            short_key_4=args.short_key_4,
         )
 
     except ValueError as err:


### PR DESCRIPTION
This PR introduces basic support for custom shortcut keys in Aider.

Many programmers may love custom shortcuts, especially in terminal-based environments like Aider.

This feature allows users to define their own shortcut keys in the `.aider.conf.yml` configuration file. (1,2,3,4 are reserved)

For example:

```yaml
short_key_1: "/run ./useful_script_like_rust_cargo_test_in_sub_dir_and_come_back.sh"
short_key_2: "refactor this code"
short_key_3: "/model gpt-4o"
short_key_4: "/model claude-3-opus-20240229"
```
then you can just type `/1` or `/2` in Aider.

The `short_key_1` example is particularly useful for Rust programmers.
Since Aider needs to be run from the root directory of the git repo, while running `cargo test` directly from the root will not work if the Rust code is located in a subdirectory.

The default behavior of Aider remains the same if no custom shortcut keys are configured.