### PR TITLE
Set max_tokens for openai api

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -959,11 +959,12 @@ class Coder:
 
         self.partial_response_content = ""
         self.partial_response_function_call = dict()
+        max_output_tokens = self.main_model.info.get("max_output_tokens", 512)
 
         interrupted = False
         try:
             hash_object, completion = send_with_retries(
-                model, messages, functions, self.stream, self.temperature
+                model, messages, functions, self.stream, self.temperature, max_output_tokens
             )
             self.chat_completion_call_hashes.append(hash_object.hexdigest())
 

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -48,12 +48,13 @@ def should_giveup(e):
         f"{details.get('exception','Exception')}\nRetry in {details['wait']:.1f} seconds."
     ),
 )
-def send_with_retries(model_name, messages, functions, stream, temperature=0):
+def send_with_retries(model_name, messages, functions, stream, temperature=0, max_tokens=512):
     kwargs = dict(
         model=model_name,
         messages=messages,
         temperature=temperature,
         stream=stream,
+        max_tokens=max_tokens,
     )
     if functions is not None:
         kwargs["functions"] = functions


### PR DESCRIPTION
Aims to fix #645 
Tested with text-generation-webui with openai api.
Without this fix the max_tokens would default to 512. Setting this server-side is not recommended (citation deferred) as it is part of the api spec.

Limitations: it may be better to use the remaining tokens. It might also be useful to expose this parameter. On the other hand, users can set up custom model definitions for this.

~~Testing pending (I'm doing this from my phone).~~

~~Update:
There seems to be another call to the api somewhere, possibly when calling an unknown model. Never mind, that makes sense if the model info is unknown.~~

Tested locally and reviewed with aider.

Also tested with https://aider.chat/docs/llms/warnings.html#specifying-context-window-size-and-token-costs*:
- max_output_tokens is properly passed to the model info.
- without this PR it is not sent to the model (defaults to 512)

*the documentation of this project is really good!