### PR TITLE
Improve SEARCH/REPLACE accuracy (fixed)

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -116,11 +116,22 @@ def perfect_replace(whole_lines, part_lines, replace_lines):
     part_tup = tuple(part_lines)
     part_len = len(part_lines)
 
+    result_candidates = []
     for i in range(len(whole_lines) - part_len + 1):
         whole_tup = tuple(whole_lines[i : i + part_len])
         if part_tup == whole_tup:
             res = whole_lines[:i] + replace_lines + whole_lines[i + part_len :]
-            return "".join(res)
+            result_candidates.append("".join(res))
+
+    if len(result_candidates) > 1:
+        raise ValueError("""Multiple code matches found.
+Please provide more lines in the SEARCH block to disambiguate.
+Do not forget to include the additional lines in the REPLACE block as well.
+Your goal is to make the code correct after the entire SEARCH block is directly replaced by the REPLACE block.
+""")
+    if len(result_candidates) == 1:
+        return result_candidates[0]
+    return None
 
 
 def replace_most_similar_chunk(whole, part, replace):

--- a/aider/tests/test_editblock.py
+++ b/aider/tests/test_editblock.py
@@ -287,6 +287,26 @@ These changes replace the `subprocess.run` patches with `subprocess.check_output
         result = eb.replace_most_similar_chunk(whole, part, replace)
         self.assertEqual(result, expected_output)
 
+    def test_rejection_of_multiple_perfect_matches(self):
+        """
+        If there are multiple perfect matches, we can't decide which one to replace.
+        Therefore, we should reject the edit.
+        """
+        whole = """
+def alice(self):
+    return None
+
+def bob(self):
+    return None
+"""
+
+        part = "    return None\n"
+        replace = "print('bob is None')\n    return None\n"
+
+        with self.assertRaises(ValueError) as cm:
+            _result = eb.replace_most_similar_chunk(whole, part, replace)
+        self.assertIn("Multiple code matches", str(cm.exception))
+
     def test_full_edit(self):
         # Create a few temporary files
         _, file1 = tempfile.mkstemp()


### PR DESCRIPTION
LLMs, including GPT-4o, often provide a very short context for the SEARCH block to match.

For example:

```
<<<<<<< SEARCH
}
=======
// some long code block
>>>>>>> REPLACE
```

In this case, the current Aider code just uses the first match with just }, which may be a wrong place to edit with a high probability.

This issue could be mitigated by prompt engineering, and we may need to do so.
However, in my opinion, we should extract the full effectiveness of classic coding before relying on LLMs.

This PR handles multiple perfect matches since, at the very least, it is safe to reject if there are multiple perfect matches.

A test has been added as well.


(The previous draft PR at https://github.com/paul-gauthier/aider/pull/677 was accidentally closed. I force-pushed as it was my repo's branch :) )