### PR TITLE
Add support for vertex_ai/claude_* models

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -196,6 +196,20 @@ MODEL_SETTINGS = [
         weak_model_name="openrouter/anthropic/claude-3-haiku-20240307",
         use_repo_map=True,
     ),
+    # Vertex AI Claude models
+    ModelSettings(
+        "vertex_ai/claude-3-5-sonnet@20240620",
+        "diff",
+        weak_model_name="vertex_ai/claude-3-haiku@20240307",
+        use_repo_map=True,
+    ),
+    ModelSettings(
+        "vertex_ai/claude-3-opus@20240229",
+        "diff",
+        weak_model_name="vertex_ai/claude-3-haiku@20240307",
+        use_repo_map=True,
+        send_undo_reply=True,
+    ),
     # Cohere
     ModelSettings(
         "command-r-plus",


### PR DESCRIPTION
Fixes #700

(Note: using Copilot Workspace beta for grins. It wrote exactly what I wrote in my own temp fix last night, so that's something :smile:)

This pull request adds support for Vertex AI Claude models in `aider/models.py` by updating the `MODEL_SETTINGS` constant.

- Adds two new `ModelSettings` entries for `vertex_ai/claude-3-5-sonnet@20240620` and `vertex_ai/claude-3-opus@20240229` to handle the at-sign notation in model names.
- Configures `edit_format`, `weak_model_name`, `use_repo_map`, and `send_undo_reply` settings for the newly added Vertex AI Claude models to ensure they are correctly recognized and processed by the application.

NB: Current `litellm` will return an error related to calculating token costs for the haiku weak model. As of *this* PR, I have a [PR](https://github.com/BerriAI/litellm/pull/4337) open in `litellm` to fix this.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paul-gauthier/aider/issues/700?shareId=baef94e8-e13b-41f9-9449-8442674006b9).