### PR TITLE
Add support Vertex AI Claude models

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -210,6 +210,11 @@ MODEL_SETTINGS = [
         use_repo_map=True,
         send_undo_reply=True,
     ),
+    ModelSettings(
+        "vertex_ai/claude-3-sonnet@20240229",
+        "whole",
+        weak_model_name="vertex_ai/claude-3-haiku@20240307",
+    ),
     # Cohere
     ModelSettings(
         "command-r-plus",
@@ -477,7 +482,9 @@ def register_models(model_def_fnames):
             with open(model_def_fname, "r") as model_def_file:
                 model_def = json.load(model_def_file)
         except json.JSONDecodeError as e:
-            raise Exception(f"Error loading model definition from {model_def_fname}: {e}")
+            raise Exception(
+                f"Error loading model definition from {model_def_fname}: {e}"
+            )
 
         litellm.register_model(model_def)
 
@@ -510,7 +517,9 @@ def sanity_check_model(io, model):
             io.tool_error(f"- {key}")
     elif not model.keys_in_environment:
         show = True
-        io.tool_output(f"Model {model}: Unknown which environment variables are required.")
+        io.tool_output(
+            f"Model {model}: Unknown which environment variables are required."
+        )
 
     if not model.info:
         show = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,6 +122,8 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
+ijson==3.3.0
+    # via litellm
 importlib-metadata==7.1.0
     # via litellm
 jinja2==3.1.4
@@ -135,7 +137,7 @@ jsonschema==4.22.0
     #   altair
 jsonschema-specifications==2023.12.1
     # via jsonschema
-litellm==1.40.15
+litellm==1.40.20
     # via -r requirements.in
 markdown-it-py==3.0.0
     # via rich


### PR DESCRIPTION
This Pull Request is to support Claude models in Vertex AI.

litellm [supports Claude (Anthropic) models in Vertex AI](https://docs.litellm.ai/docs/providers/vertex#anthropic), but the current version of aider produces an error.

<img width="772" alt="image" src="https://github.com/paul-gauthier/aider/assets/623449/ccbf6fdf-ee80-4541-b15a-8d701235de4e">

By updating the version of litellm and adding settings, the error has been resolved.

<img width="805" alt="image" src="https://github.com/paul-gauthier/aider/assets/623449/78c63f11-5fab-433c-a6c2-c549e6106cfc">

