### PR TITLE
Remove universal ctags install from workflows

### DIFF
--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -30,11 +30,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install universal ctags
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y universal-ctags
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -30,10 +30,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install universal ctags
-      run: |
-        choco install universal-ctags
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Remove universal ctags install step from workflows as it's no longer used. There may be some other parts that still use it that would need further cleaning.