### PR TITLE
Add /addimgclipboard

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from PIL import ImageGrab
 import tempfile
+import shutil
 
 import git
 import openai
@@ -492,9 +493,15 @@ class Commands:
         try:
             image = ImageGrab.grabclipboard()
             if image:
-                file = tempfile.NamedTemporaryFile(suffix=".png")
-                image.save(file.name, 'PNG')
-                return self.cmd_add(file.name)
+                tmp = tempfile.mkdtemp()
+                f = tempfile.NamedTemporaryFile(mode='w+t', delete=False, suffix='.png')
+                file_name = f.name
+                image.save(file_name, 'PNG')
+                f.close()
+                shutil.copy(file_name, tmp)
+                os.remove(file_name)
+                true_file_name = os.path.join(tmp, os.path.basename(file_name))
+                return self.cmd_add(true_file_name)
         except Exception as e:
             exception_text = str(e)
             pass

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -2,7 +2,10 @@ import os
 import re
 import subprocess
 import sys
+
 from pathlib import Path
+from PIL import ImageGrab
+import tempfile
 
 import git
 import openai
@@ -483,6 +486,20 @@ class Commands:
 
         reply = prompts.added_files.format(fnames=", ".join(added_fnames))
         return reply
+    
+    def cmd_addimgclipboard(self, args):
+        exception_text = ""
+        try:
+            image = ImageGrab.grabclipboard()
+            if image:
+                file = tempfile.NamedTemporaryFile(suffix=".png")
+                image.save(file.name, 'PNG')
+                return self.cmd_add(file.name)
+        except Exception as e:
+            exception_text = str(e)
+            pass
+
+        return self.io.tool_error("No image found in clipboard. " + exception_text)
 
     def completions_drop(self, partial):
         files = self.coder.get_inchat_relative_files()

--- a/website/_posts/2024-07-01-sonnet-not-lazy.md
+++ b/website/_posts/2024-07-01-sonnet-not-lazy.md
@@ -20,7 +20,7 @@ Unexpectedly,
 this initially presented a few challenges 
 that prevented aider from taking maximum advantage of
 Sonnet's capabilities.
-It was often hitting the 4k output token limit,
+Sonnet was often hitting the 4k output token limit,
 truncating its coding in mid-stream.
 
 It's been worth the effort to adapt aider to work 


### PR DESCRIPTION
This adds a simple command to retrieve an image from clipboard and save it to a temporary file. This is a feature that was requested here: #751. I don't know if it works in Windows and Mac.