### PR TITLE
fix broken dotenv link in docs/config/aider_conf.html

### DIFF
--- a/website/_includes/special-keys.md
+++ b/website/_includes/special-keys.md
@@ -6,4 +6,4 @@ have their keys and settings
 specified in environment variables.
 This can be done in your shell, 
 or by using a 
-[`.env` file](/docs/dotenv.html).
+[`.env` file](/docs/config/dotenv.html).


### PR DESCRIPTION
noticed this is broken on the live documentation site