### PR TITLE
Use standard config paths instead of home root

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+from pathlib import Path
 
 import configargparse
 
@@ -20,11 +21,35 @@ def default_env_file(git_root):
     return os.path.join(git_root, ".env") if git_root else ".env"
 
 
-def get_parser(default_config_files, git_root):
+def get_default_config_files(git_root):
+    conf_fname = Path(".aider.conf.yml")
+    conf_path = "aider/conf.yml"
+
+    files = [conf_fname.resolve()]  # CWD
+    if git_root:
+        git_conf = Path(git_root) / conf_fname  # git root
+        if git_conf not in files:
+            files.append(git_conf)
+
+    # Add XDG_CONFIG_HOME or default Linux/macOS config path
+    xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        files.append(Path(xdg_config_home) / conf_path)
+    elif sys.platform.startswith("linux"):
+        files.append(Path.home() / ".config" / conf_path)
+    elif sys.platform == "darwin":
+        files.append(Path.home() / "Library" / "Application Support" / conf_path)
+
+    files.append(Path.home() / conf_fname)  # homedir
+
+    return list(map(str, files))
+
+
+def get_parser(git_root):
     parser = configargparse.ArgumentParser(
         description="aider is GPT powered coding in your terminal",
         add_config_file_help=True,
-        default_config_files=default_config_files,
+        default_config_files=get_default_config_files(git_root),
         auto_env_var_prefix="AIDER_",
     )
     group = parser.add_argument_group("Main")
@@ -498,7 +523,7 @@ def get_parser(default_config_files, git_root):
         metavar="CONFIG_FILE",
         help=(
             "Specify the config file (default: search for .aider.conf.yml in git root, cwd"
-            " or home directory)"
+            " or home directory, or for aider/conf.yml in $XDG_CONFIG_HOME or Linux/macOS config paths)"
         ),
     )
     group.add_argument(

--- a/aider/main.py
+++ b/aider/main.py
@@ -301,6 +301,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         git_conf = Path(git_root) / conf_fname  # git root
         if git_conf not in default_config_files:
             default_config_files.append(git_conf)
+    xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        default_config_files.append(Path(xdg_config_home) / "aider" / conf_fname)
+    elif sys.platform.startswith("linux"):
+        default_config_files.append(Path.home() / ".config" / "aider" / conf_fname)
     default_config_files.append(Path.home() / conf_fname)  # homedir
     default_config_files = list(map(str, default_config_files))
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -294,22 +294,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     else:
         git_root = get_git_root()
 
-    conf_fname = Path("conf.yml")
-
-    default_config_files = [conf_fname.resolve()]  # CWD
-    if git_root:
-        git_conf = Path(git_root) / conf_fname  # git root
-        if git_conf not in default_config_files:
-            default_config_files.append(git_conf)
-    xdg_config_home = os.getenv("XDG_CONFIG_HOME")
-    if xdg_config_home:
-        default_config_files.append(Path(xdg_config_home) / "aider" / "conf.yml")
-    elif sys.platform.startswith("linux"):
-        default_config_files.append(Path.home() / ".config" / "aider" / "conf.yml")
-    default_config_files.append(Path.home() / conf_fname)  # homedir
-    default_config_files = list(map(str, default_config_files))
-
-    parser = get_parser(default_config_files, git_root)
+    parser = get_parser(git_root)
     args, unknown = parser.parse_known_args(argv)
 
     # Load the .env file specified in the arguments

--- a/aider/main.py
+++ b/aider/main.py
@@ -294,7 +294,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     else:
         git_root = get_git_root()
 
-    conf_fname = Path(".aider.conf.yml")
+    conf_fname = Path("conf.yml")
 
     default_config_files = [conf_fname.resolve()]  # CWD
     if git_root:
@@ -303,9 +303,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             default_config_files.append(git_conf)
     xdg_config_home = os.getenv("XDG_CONFIG_HOME")
     if xdg_config_home:
-        default_config_files.append(Path(xdg_config_home) / "aider" / conf_fname)
+        default_config_files.append(Path(xdg_config_home) / "aider" / "conf.yml")
     elif sys.platform.startswith("linux"):
-        default_config_files.append(Path.home() / ".config" / "aider" / conf_fname)
+        default_config_files.append(Path.home() / ".config" / "aider" / "conf.yml")
     default_config_files.append(Path.home() / conf_fname)  # homedir
     default_config_files = list(map(str, default_config_files))
 

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -1,5 +1,5 @@
 ##########################################################
-# Sample .aider.conf.yaml
+# Sample .aider.conf.yml
 # This file lists *all* the valid configuration entries.
 # Place in your home dir, or at the root of your git repo.
 ##########################################################


### PR DESCRIPTION
Using a standard config path, instead of populating the $HOME root with dot files, is a nicer approach ([relevant](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html)).