### PR TITLE
Use .yml extension for default config in docs

### DIFF
--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -1,5 +1,5 @@
 ##########################################################
-# Sample .aider.conf.yaml
+# Sample .aider.conf.yml
 # This file lists *all* the valid configuration entries.
 # Place in your home dir, or at the root of your git repo.
 ##########################################################

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -38,7 +38,7 @@ cog.outl("```")
 ]]]-->
 ```
 ##########################################################
-# Sample .aider.conf.yaml
+# Sample .aider.conf.yml
 # This file lists *all* the valid configuration entries.
 # Place in your home dir, or at the root of your git repo.
 ##########################################################


### PR DESCRIPTION
I copied the file name from these files. Aider did not find them cause the file is supposed to have the `.yml` extension and not `.yaml` (compare with `aider --help`).