### PR TITLE
Custom Sys prompts for Coder objects

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -232,6 +232,7 @@ class Coder:
         attribute_commit_message=False,
         aider_commit_hashes=None,
         map_mul_no_files=8,
+        custom_system_prompt=None,
     ):
         if not fnames:
             fnames = []
@@ -250,6 +251,8 @@ class Coder:
 
         self.verbose = verbose
         self.abs_fnames = set()
+
+        self.custom_system_prompt = custom_system_prompt
 
         if cur_messages:
             self.cur_messages = cur_messages
@@ -735,6 +738,12 @@ class Coder:
     def fmt_system_prompt(self, prompt):
         lazy_prompt = self.gpt_prompts.lazy_prompt if self.main_model.lazy else ""
 
+        if self.custom_system_prompt:
+            custom_prompt_header = "\nOn top of being an expert software developer, you also specialize in the following job:\n"
+            custom_prompt = custom_prompt_header + self.main_model.system_prompt
+        else: 
+            custom_prompt = ""
+
         platform_text = f"- The user's system: {platform.platform()}\n"
         if os.name == "nt":
             var = "COMSPEC"
@@ -750,6 +759,7 @@ class Coder:
             fence=self.fence,
             lazy_prompt=lazy_prompt,
             platform=platform_text,
+            custom_prompt=custom_prompt,
         )
         return prompt
 

--- a/aider/coders/editblock_func_prompts.py
+++ b/aider/coders/editblock_func_prompts.py
@@ -9,6 +9,7 @@ Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
 Once you understand the request you MUST use the `replace_lines` function to edit the files to make the needed changes.
+{custom_prompt}
 """
 
     system_reminder = """

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -22,7 +22,7 @@ All changes to files must use the *SEARCH/REPLACE block* format.
 
 Keep this info about the user's system in mind:
 {platform}
-
+{custom_prompt}
 """
 
     example_messages = [

--- a/aider/coders/single_wholefile_func_prompts.py
+++ b/aider/coders/single_wholefile_func_prompts.py
@@ -9,6 +9,7 @@ Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
 Once you understand the request you MUST use the `write_file` function to update the file to make the changes.
+{custom_prompt}
 """
 
     system_reminder = """

--- a/aider/coders/udiff_prompts.py
+++ b/aider/coders/udiff_prompts.py
@@ -15,6 +15,7 @@ If the request is ambiguous, ask questions.
 Always reply to the user in the same language they are using.
 
 For each file that needs to be changed, write out the changes similar to a unified diff like `diff -U0` would produce.
+{custom_prompt}
 """
 
     example_messages = [

--- a/aider/coders/wholefile_func_prompts.py
+++ b/aider/coders/wholefile_func_prompts.py
@@ -9,6 +9,7 @@ Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
 Once you understand the request you MUST use the `write_file` function to edit the files to make the needed changes.
+{custom_prompt}
 """
 
     system_reminder = """

--- a/aider/coders/wholefile_prompts.py
+++ b/aider/coders/wholefile_prompts.py
@@ -15,6 +15,7 @@ Once you understand the request you MUST:
 1. Determine if any code changes are needed.
 2. Explain any needed changes.
 3. If changes are needed, output a copy of each file that needs changes.
+{custom_prompt}
 """
 
     example_messages = [


### PR DESCRIPTION
Allow users using aider python library to enter their own custom system prompts on top of the existing system prompt for extra specialization for a certain job, e.g. may want one coder object to be especially focused on following a certain convention while another coder object uses another convention etc.