### PR TITLE
Use "python" in windows install instructions

### DIFF
--- a/aider/website/docs/install/install.md
+++ b/aider/website/docs/install/install.md
@@ -30,7 +30,7 @@ To work with Anthropic's models like Claude 3.5 Sonnet you need a paid
 
 ```
 # Install aider
-py -m pip install aider-chat
+python -m pip install aider-chat
 
 # To work with GPT-4o:
 $ aider --4o --openai-api-key sk-xxx...


### PR DESCRIPTION
"Py" confused me, it often refers to "PyInstaller"