### PR TITLE
Split all console commands to derived class Terminal (from InputOutput)

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -24,7 +24,7 @@ from rich.markdown import Markdown
 from aider import __version__, models, prompts, urls, utils
 from aider.commands import Commands
 from aider.history import ChatSummary
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.linter import Linter
 from aider.llm import litellm
 from aider.mdstream import MarkdownStream
@@ -226,7 +226,7 @@ class Coder:
             fnames = []
 
         if io is None:
-            io = InputOutput()
+            io = Terminal()
 
         if aider_commit_hashes:
             self.aider_commit_hashes = aider_commit_hashes

--- a/aider/gui.py
+++ b/aider/gui.py
@@ -9,12 +9,12 @@ import streamlit as st
 from aider import urls
 from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.io import Terminal
 from aider.main import main as cli_main
 from aider.scrape import Scraper
 
 
-class CaptureIO(InputOutput):
+class CaptureIO(Terminal):
     lines = []
 
     def tool_output(self, msg, log_only=False):

--- a/aider/io.py
+++ b/aider/io.py
@@ -1,165 +1,26 @@
 import base64
-import os
-from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-from prompt_toolkit.completion import Completer, Completion
-from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.history import FileHistory
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.lexers import PygmentsLexer
-from prompt_toolkit.shortcuts import CompleteStyle, PromptSession, confirm, prompt
-from prompt_toolkit.styles import Style
-from pygments.lexers import MarkdownLexer, guess_lexer_for_filename
-from pygments.token import Token
-from pygments.util import ClassNotFound
-from rich.console import Console
-from rich.text import Text
 
 from .dump import dump  # noqa: F401
 from .utils import is_image_file
 
 
-class AutoCompleter(Completer):
-    def __init__(self, root, rel_fnames, addable_rel_fnames, commands, encoding):
-        self.addable_rel_fnames = addable_rel_fnames
-        self.rel_fnames = rel_fnames
-        self.encoding = encoding
-
-        fname_to_rel_fnames = defaultdict(list)
-        for rel_fname in addable_rel_fnames:
-            fname = os.path.basename(rel_fname)
-            if fname != rel_fname:
-                fname_to_rel_fnames[fname].append(rel_fname)
-        self.fname_to_rel_fnames = fname_to_rel_fnames
-
-        self.words = set()
-
-        self.commands = commands
-        self.command_completions = dict()
-        if commands:
-            self.command_names = self.commands.get_commands()
-
-        for rel_fname in addable_rel_fnames:
-            self.words.add(rel_fname)
-
-        for rel_fname in rel_fnames:
-            self.words.add(rel_fname)
-
-            fname = Path(root) / rel_fname
-            try:
-                with open(fname, "r", encoding=self.encoding) as f:
-                    content = f.read()
-            except (FileNotFoundError, UnicodeDecodeError, IsADirectoryError):
-                continue
-            try:
-                lexer = guess_lexer_for_filename(fname, content)
-            except ClassNotFound:
-                continue
-            tokens = list(lexer.get_tokens(content))
-            self.words.update(token[1] for token in tokens if token[0] in Token.Name)
-
-    def get_command_completions(self, text, words):
-        candidates = []
-        if len(words) == 1 and not text[-1].isspace():
-            partial = words[0].lower()
-            candidates = [cmd for cmd in self.command_names if cmd.startswith(partial)]
-            return candidates
-
-        if len(words) <= 1:
-            return []
-        if text[-1].isspace():
-            return []
-
-        cmd = words[0]
-        partial = words[-1].lower()
-
-        if cmd not in self.command_names:
-            return
-
-        if cmd not in self.command_completions:
-            candidates = self.commands.get_completions(cmd)
-            self.command_completions[cmd] = candidates
-        else:
-            candidates = self.command_completions[cmd]
-
-        if candidates is None:
-            return
-
-        candidates = [word for word in candidates if partial in word.lower()]
-        return candidates
-
-    def get_completions(self, document, complete_event):
-        text = document.text_before_cursor
-        words = text.split()
-        if not words:
-            return
-
-        if text[0] == "/":
-            candidates = self.get_command_completions(text, words)
-            if candidates is not None:
-                for candidate in candidates:
-                    yield Completion(candidate, start_position=-len(words[-1]))
-                return
-
-        candidates = self.words
-        candidates.update(set(self.fname_to_rel_fnames))
-        candidates = [(word, f"`{word}`") for word in candidates]
-
-        last_word = words[-1]
-        for word_match, word_insert in candidates:
-            if word_match.lower().startswith(last_word.lower()):
-                rel_fnames = self.fname_to_rel_fnames.get(word_match, [])
-                if rel_fnames:
-                    for rel_fname in rel_fnames:
-                        yield Completion(
-                            f"`{rel_fname}`", start_position=-len(last_word), display=rel_fname
-                        )
-                else:
-                    yield Completion(
-                        word_insert, start_position=-len(last_word), display=word_match
-                    )
-
-
 class InputOutput:
     num_error_outputs = 0
     num_user_asks = 0
-
+    
     def __init__(
         self,
-        pretty=True,
-        yes=False,
         input_history_file=None,
         chat_history_file=None,
-        input=None,
-        output=None,
-        user_input_color="blue",
-        tool_output_color=None,
-        tool_error_color="red",
         encoding="utf-8",
         dry_run=False,
         llm_history_file=None,
-        editingmode=EditingMode.EMACS,
     ):
-        self.editingmode = editingmode
-        no_color = os.environ.get("NO_COLOR")
-        if no_color is not None and no_color != "":
-            pretty = False
-
-        self.user_input_color = user_input_color if pretty else None
-        self.tool_output_color = tool_output_color if pretty else None
-        self.tool_error_color = tool_error_color if pretty else None
-
-        self.input = input
-        self.output = output
-
-        self.pretty = pretty
-        if self.output:
-            self.pretty = False
-
-        self.yes = yes
-
+        
         self.input_history_file = input_history_file
         self.llm_history_file = llm_history_file
         if chat_history_file is not None:
@@ -169,11 +30,6 @@ class InputOutput:
 
         self.encoding = encoding
         self.dry_run = dry_run
-
-        if pretty:
-            self.console = Console()
-        else:
-            self.console = Console(force_terminal=False, no_color=True)
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.append_chat_history(f"\n# aider chat started at {current_time}\n\n")
@@ -218,81 +74,7 @@ class InputOutput:
             f.write(content)
 
     def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
-        if self.pretty:
-            style = dict(style=self.user_input_color) if self.user_input_color else dict()
-            self.console.rule(**style)
-        else:
-            print()
-
-        rel_fnames = list(rel_fnames)
-        show = " ".join(rel_fnames)
-        if len(show) > 10:
-            show += "\n"
-        show += "> "
-
-        inp = ""
-        multiline_input = False
-
-        if self.user_input_color:
-            style = Style.from_dict(
-                {
-                    "": self.user_input_color,
-                    "pygments.literal.string": f"bold italic {self.user_input_color}",
-                }
-            )
-        else:
-            style = None
-
-        completer_instance = AutoCompleter(
-            root, rel_fnames, addable_rel_fnames, commands, self.encoding
-        )
-
-        while True:
-            if multiline_input:
-                show = ". "
-
-            session_kwargs = {
-                "message": show,
-                "completer": completer_instance,
-                "reserve_space_for_menu": 4,
-                "complete_style": CompleteStyle.MULTI_COLUMN,
-                "input": self.input,
-                "output": self.output,
-                "lexer": PygmentsLexer(MarkdownLexer),
-            }
-            if style:
-                session_kwargs["style"] = style
-
-            if self.input_history_file is not None:
-                session_kwargs["history"] = FileHistory(self.input_history_file)
-
-            kb = KeyBindings()
-
-            @kb.add("escape", "c-m", eager=True)
-            def _(event):
-                event.current_buffer.insert_text("\n")
-
-            session = PromptSession(
-                key_bindings=kb, editing_mode=self.editingmode, **session_kwargs
-            )
-            line = session.prompt()
-
-            if line and line[0] == "{" and not multiline_input:
-                multiline_input = True
-                inp += line[1:] + "\n"
-                continue
-            elif line and line[-1] == "}" and multiline_input:
-                inp += line[:-1] + "\n"
-                break
-            elif multiline_input:
-                inp += line + "\n"
-            else:
-                inp = line
-                break
-
-        print()
-        self.user_input(inp)
-        return inp
+        return ""
 
     def add_to_input_history(self, inp):
         if not self.input_history_file:
@@ -305,7 +87,10 @@ class InputOutput:
 
         fh = FileHistory(self.input_history_file)
         return fh.load_history_strings()
-
+    
+    def get_history_file(self):
+        FileHistory(self.input_history_file)
+        
     def log_llm_history(self, role, content):
         if not self.llm_history_file:
             return
@@ -315,22 +100,8 @@ class InputOutput:
             log_file.write(content + "\n")
 
     def user_input(self, inp, log_only=True):
-        if not log_only:
-            style = dict(style=self.user_input_color) if self.user_input_color else dict()
-            self.console.print(inp, **style)
-
-        prefix = "####"
-        if inp:
-            hist = inp.splitlines()
-        else:
-            hist = ["<blank>"]
-
-        hist = f"  \n{prefix} ".join(hist)
-
-        hist = f"""
-{prefix} {hist}"""
-        self.append_chat_history(hist, linebreak=True)
-
+        return
+    
     # OUTPUT
 
     def ai_output(self, content):
@@ -338,44 +109,14 @@ class InputOutput:
         self.append_chat_history(hist)
 
     def confirm_ask(self, question, default="y"):
-        self.num_user_asks += 1
-
-        if self.yes is True:
-            res = True
-        elif self.yes is False:
-            res = False
-        else:
-            res = confirm(question)
-
-        if res:
-            hist = f"{question.strip()} y"
-        else:
-            hist = f"{question.strip()} n"
-
-        self.append_chat_history(hist, linebreak=True, blockquote=True)
-
-        return res
+        return False
 
     def prompt_ask(self, question, default=None):
-        self.num_user_asks += 1
-
-        if self.yes is True:
-            res = "yes"
-        elif self.yes is False:
-            res = "no"
-        else:
-            res = prompt(question + " ", default=default)
-
-        hist = f"{question.strip()} {res.strip()}"
-        self.append_chat_history(hist, linebreak=True, blockquote=True)
-        if self.yes in (True, False):
-            self.tool_output(hist)
-
-        return res
+        return "no"
 
     def tool_error(self, message="", strip=True):
         self.num_error_outputs += 1
-
+        
         if message.strip():
             if "\n" in message:
                 for line in message.splitlines():
@@ -387,20 +128,11 @@ class InputOutput:
                     hist = message
                 self.append_chat_history(hist, linebreak=True, blockquote=True)
 
-        message = Text(message)
-        style = dict(style=self.tool_error_color) if self.tool_error_color else dict()
-        self.console.print(message, **style)
-
     def tool_output(self, *messages, log_only=False):
         if messages:
             hist = " ".join(messages)
             hist = f"{hist.strip()}"
             self.append_chat_history(hist, linebreak=True, blockquote=True)
-
-        if not log_only:
-            messages = list(map(Text, messages))
-            style = dict(style=self.tool_output_color) if self.tool_output_color else dict()
-            self.console.print(*messages, **style)
 
     def append_chat_history(self, text, linebreak=False, blockquote=False, strip=True):
         if blockquote:

--- a/aider/main.py
+++ b/aider/main.py
@@ -14,7 +14,7 @@ from aider.args import get_parser
 from aider.coders import Coder
 from aider.commands import Commands, SwitchCoder
 from aider.history import ChatSummary
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.llm import litellm  # noqa: F401; properly init litellm on launch
 from aider.repo import GitRepo
 from aider.versioncheck import check_version
@@ -356,7 +356,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     editing_mode = EditingMode.VI if args.vim else EditingMode.EMACS
 
-    io = InputOutput(
+    io = Terminal(
         args.pretty,
         args.yes,
         args.input_history_file,

--- a/aider/terminal.py
+++ b/aider/terminal.py
@@ -1,0 +1,312 @@
+import os
+from pathlib import Path
+from collections import defaultdict
+
+from aider.io import InputOutput
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.shortcuts import CompleteStyle, PromptSession, confirm, prompt
+from prompt_toolkit.styles import Style
+from pygments.lexers import MarkdownLexer, guess_lexer_for_filename
+from pygments.token import Token
+from pygments.util import ClassNotFound
+from rich.console import Console
+from rich.text import Text
+
+class AutoCompleter(Completer):
+    def __init__(self, root, rel_fnames, addable_rel_fnames, commands, encoding):
+        self.addable_rel_fnames = addable_rel_fnames
+        self.rel_fnames = rel_fnames
+        self.encoding = encoding
+
+        fname_to_rel_fnames = defaultdict(list)
+        for rel_fname in addable_rel_fnames:
+            fname = os.path.basename(rel_fname)
+            if fname != rel_fname:
+                fname_to_rel_fnames[fname].append(rel_fname)
+        self.fname_to_rel_fnames = fname_to_rel_fnames
+
+        self.words = set()
+
+        self.commands = commands
+        self.command_completions = dict()
+        if commands:
+            self.command_names = self.commands.get_commands()
+
+        for rel_fname in addable_rel_fnames:
+            self.words.add(rel_fname)
+
+        for rel_fname in rel_fnames:
+            self.words.add(rel_fname)
+
+            fname = Path(root) / rel_fname
+            try:
+                with open(fname, "r", encoding=self.encoding) as f:
+                    content = f.read()
+            except (FileNotFoundError, UnicodeDecodeError, IsADirectoryError):
+                continue
+            try:
+                lexer = guess_lexer_for_filename(fname, content)
+            except ClassNotFound:
+                continue
+            tokens = list(lexer.get_tokens(content))
+            self.words.update(token[1] for token in tokens if token[0] in Token.Name)
+
+    def get_command_completions(self, text, words):
+        candidates = []
+        if len(words) == 1 and not text[-1].isspace():
+            partial = words[0].lower()
+            candidates = [cmd for cmd in self.command_names if cmd.startswith(partial)]
+            return candidates
+
+        if len(words) <= 1:
+            return []
+        if text[-1].isspace():
+            return []
+
+        cmd = words[0]
+        partial = words[-1].lower()
+
+        if cmd not in self.command_names:
+            return
+
+        if cmd not in self.command_completions:
+            candidates = self.commands.get_completions(cmd)
+            self.command_completions[cmd] = candidates
+        else:
+            candidates = self.command_completions[cmd]
+
+        if candidates is None:
+            return
+
+        candidates = [word for word in candidates if partial in word.lower()]
+        return candidates
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        words = text.split()
+        if not words:
+            return
+
+        if text[0] == "/":
+            candidates = self.get_command_completions(text, words)
+            if candidates is not None:
+                for candidate in candidates:
+                    yield Completion(candidate, start_position=-len(words[-1]))
+                return
+
+        candidates = self.words
+        candidates.update(set(self.fname_to_rel_fnames))
+        candidates = [(word, f"`{word}`") for word in candidates]
+
+        last_word = words[-1]
+        for word_match, word_insert in candidates:
+            if word_match.lower().startswith(last_word.lower()):
+                rel_fnames = self.fname_to_rel_fnames.get(word_match, [])
+                if rel_fnames:
+                    for rel_fname in rel_fnames:
+                        yield Completion(
+                            f"`{rel_fname}`", start_position=-len(last_word), display=rel_fname
+                        )
+                else:
+                    yield Completion(
+                        word_insert, start_position=-len(last_word), display=word_match
+                    )
+                    
+class Terminal(InputOutput):
+    def __init__(
+        self,
+        pretty=True,
+        yes=False,
+        input_history_file=None,
+        chat_history_file=None,
+        input=None,
+        output=None,
+        user_input_color="blue",
+        tool_output_color=None,
+        tool_error_color="red",
+        encoding="utf-8",
+        dry_run=False,
+        llm_history_file=None,
+        editingmode=EditingMode.EMACS,
+    ):
+        super().__init__(
+            input_history_file=input_history_file,
+            chat_history_file=chat_history_file,
+            encoding=encoding,
+            dry_run=dry_run,
+            llm_history_file=llm_history_file,
+        )
+        self.editingmode = editingmode
+        no_color = os.environ.get("NO_COLOR")
+        if no_color is not None and no_color != "":
+            pretty = False
+
+        self.user_input_color = user_input_color if pretty else None
+        self.tool_output_color = tool_output_color if pretty else None
+        self.tool_error_color = tool_error_color if pretty else None
+
+        self.input = input
+        self.output = output
+
+        self.pretty = pretty
+        if self.output:
+            self.pretty = False
+
+        self.yes = yes
+        
+        self.encoding = encoding
+        
+        if pretty:
+            self.console = Console()
+        else:
+            self.console = Console(force_terminal=False, no_color=True)
+
+
+    def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
+        if self.pretty:
+            style = dict(style=self.user_input_color) if self.user_input_color else dict()
+            self.console.rule(**style)
+        else:
+            print()
+
+        rel_fnames = list(rel_fnames)
+        show = " ".join(rel_fnames)
+        if len(show) > 10:
+            show += "\n"
+        show += "> "
+
+        inp = ""
+        multiline_input = False
+
+        if self.user_input_color:
+            style = Style.from_dict(
+                {
+                    "": self.user_input_color,
+                    "pygments.literal.string": f"bold italic {self.user_input_color}",
+                }
+            )
+        else:
+            style = None
+
+        completer_instance = AutoCompleter(
+            root, rel_fnames, addable_rel_fnames, commands, self.encoding
+        )
+
+        while True:
+            if multiline_input:
+                show = ". "
+
+            session_kwargs = {
+                "message": show,
+                "completer": completer_instance,
+                "reserve_space_for_menu": 4,
+                "complete_style": CompleteStyle.MULTI_COLUMN,
+                "input": self.input,
+                "output": self.output,
+                "lexer": PygmentsLexer(MarkdownLexer),
+            }
+            if style:
+                session_kwargs["style"] = style
+
+            if self.input_history_file is not None:
+                session_kwargs["history"] = super().get_history_file()
+
+            kb = KeyBindings()
+
+            @kb.add("escape", "c-m", eager=True)
+            def _(event):
+                event.current_buffer.insert_text("\n")
+
+            session = PromptSession(
+                key_bindings=kb, editing_mode=self.editingmode, **session_kwargs
+            )
+            line = session.prompt()
+
+            if line and line[0] == "{" and not multiline_input:
+                multiline_input = True
+                inp += line[1:] + "\n"
+                continue
+            elif line and line[-1] == "}" and multiline_input:
+                inp += line[:-1] + "\n"
+                break
+            elif multiline_input:
+                inp += line + "\n"
+            else:
+                inp = line
+                break
+
+        print()
+        self.user_input(inp)
+        return inp
+    
+    def user_input(self, inp, log_only=True):
+        if not log_only:
+            style = dict(style=self.user_input_color) if self.user_input_color else dict()
+            self.console.print(inp, **style)
+
+        prefix = "####"
+        if inp:
+            hist = inp.splitlines()
+        else:
+            hist = ["<blank>"]
+
+        hist = f"  \n{prefix} ".join(hist)
+
+        hist = f"""
+{prefix} {hist}"""
+        self.append_chat_history(hist, linebreak=True)
+        
+    def confirm_ask(self, question, default="y"):
+        self.num_user_asks += 1
+
+        if self.yes is True:
+            res = True
+        elif self.yes is False:
+            res = False
+        else:
+            res = confirm(question)
+
+        if res:
+            hist = f"{question.strip()} y"
+        else:
+            hist = f"{question.strip()} n"
+
+        self.append_chat_history(hist, linebreak=True, blockquote=True)
+
+        return res
+
+    def prompt_ask(self, question, default=None):
+        self.num_user_asks += 1
+
+        if self.yes is True:
+            res = "yes"
+        elif self.yes is False:
+            res = "no"
+        else:
+            res = prompt(question + " ", default=default)
+
+        hist = f"{question.strip()} {res.strip()}"
+        self.append_chat_history(hist, linebreak=True, blockquote=True)
+        if self.yes in (True, False):
+            self.tool_output(hist)
+
+        return res
+    
+    def tool_error(self, message="", strip=True):
+        super().tool_error(message, strip=strip)
+
+        message = Text(message)
+        style = dict(style=self.tool_error_color) if self.tool_error_color else dict()
+        self.console.print(message, **style)
+
+    def tool_output(self, *messages, log_only=False):
+        super().tool_output(*messages, log_only=log_only)
+        
+        if not log_only:
+            messages = list(map(Text, messages))
+            style = dict(style=self.tool_output_color) if self.tool_output_color else dict()
+            self.console.print(*messages, **style)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -26,7 +26,7 @@ from rich.console import Console
 from aider import models
 from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 
 load_dotenv()
 
@@ -543,7 +543,7 @@ def run_test_real(
 
     instructions += prompts.instructions_addendum.format(file_list=file_list)
 
-    io = InputOutput(
+    io = Terminal(
         pretty=True,
         yes=False,
         chat_history_file=history_fname,

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -12,7 +12,7 @@ import git
 from aider.coders import Coder
 from aider.commands import Commands
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 from aider.repo import GitRepo
 from aider.utils import ChdirTemporaryDirectory, GitTemporaryDirectory, make_repo
@@ -31,8 +31,8 @@ class TestCommands(TestCase):
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def test_cmd_add(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -48,7 +48,7 @@ class TestCommands(TestCase):
     def test_cmd_add_bad_glob(self):
         # https://github.com/paul-gauthier/aider/issues/293
 
-        io = InputOutput(pretty=False, yes=False)
+        io = Terminal(pretty=False, yes=False)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -57,8 +57,8 @@ class TestCommands(TestCase):
         commands.cmd_add("**.txt")
 
     def test_cmd_add_with_glob_patterns(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -84,7 +84,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_no_match(self):
         # yes=False means we will *not* create the file when it is not found
-        io = InputOutput(pretty=False, yes=False)
+        io = Terminal(pretty=False, yes=False)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -98,7 +98,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_no_match_but_make_it(self):
         # yes=True means we *will* create the file when it is not found
-        io = InputOutput(pretty=False, yes=True)
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -114,8 +114,8 @@ class TestCommands(TestCase):
         self.assertTrue(fname.exists())
 
     def test_cmd_add_drop_directory(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=False)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=False)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -165,8 +165,8 @@ class TestCommands(TestCase):
         self.assertNotIn(abs_fname, coder.abs_fnames)
 
     def test_cmd_drop_with_glob_patterns(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -192,8 +192,8 @@ class TestCommands(TestCase):
         self.assertNotIn(str(Path("test2.py").resolve()), coder.abs_fnames)
 
     def test_cmd_add_bad_encoding(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -208,8 +208,8 @@ class TestCommands(TestCase):
         self.assertEqual(coder.abs_fnames, set())
 
     def test_cmd_git(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
 
         with GitTemporaryDirectory() as tempdir:
             # Create a file in the temporary directory
@@ -229,8 +229,8 @@ class TestCommands(TestCase):
             self.assertIn("test.txt", files_in_repo)
 
     def test_cmd_tokens(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
 
         coder = Coder.create(self.GPT35, None, io)
         commands = Commands(io, coder)
@@ -272,7 +272,7 @@ class TestCommands(TestCase):
 
         os.chdir("subdir")
 
-        io = InputOutput(pretty=False, yes=True)
+        io = Terminal(pretty=False, yes=True)
         coder = Coder.create(self.GPT35, None, io)
         commands = Commands(io, coder)
 
@@ -288,7 +288,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_from_subdir_again(self):
         with GitTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -314,7 +314,7 @@ class TestCommands(TestCase):
             repo.git.add(fname)
             repo.git.commit("-m", "initial")
 
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             coder = Coder.create(self.GPT35, None, io)
             commands = Commands(io, coder)
 
@@ -333,7 +333,7 @@ class TestCommands(TestCase):
             root.mkdir()
             os.chdir(str(root))
 
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -356,7 +356,7 @@ class TestCommands(TestCase):
 
             make_repo()
 
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -374,7 +374,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_filename_with_special_chars(self):
         with ChdirTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -399,7 +399,7 @@ class TestCommands(TestCase):
             repo.git.add(A=True)
             repo.git.commit("-m", "Initial commit")
 
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(Model("claude-3-5-sonnet-20240620"), None, io)
@@ -439,7 +439,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_dirname_with_special_chars(self):
         with ChdirTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -456,7 +456,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_abs_filename(self):
         with ChdirTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -471,7 +471,7 @@ class TestCommands(TestCase):
 
     def test_cmd_add_quoted_filename(self):
         with ChdirTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -499,7 +499,7 @@ class TestCommands(TestCase):
             # leave a dirty `git rm`
             repo.git.rm("one.txt")
 
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -521,8 +521,8 @@ class TestCommands(TestCase):
             del repo
 
     def test_cmd_add_unicode_error(self):
-        # Initialize the Commands and InputOutput objects
-        io = InputOutput(pretty=False, yes=True)
+        # Initialize the Commands and Terminal objects
+        io = Terminal(pretty=False, yes=True)
         from aider.coders import Coder
 
         coder = Coder.create(self.GPT35, None, io)
@@ -539,7 +539,7 @@ class TestCommands(TestCase):
 
     def test_cmd_test_unbound_local_error(self):
         with ChdirTemporaryDirectory():
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -556,7 +556,7 @@ class TestCommands(TestCase):
         with GitTemporaryDirectory():
             repo = git.Repo()
 
-            io = InputOutput(pretty=False, yes=False)
+            io = Terminal(pretty=False, yes=False)
             from aider.coders import Coder
 
             coder = Coder.create(self.GPT35, None, io)
@@ -581,7 +581,7 @@ class TestCommands(TestCase):
     def test_cmd_undo_with_dirty_files_not_in_last_commit(self):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             coder = Coder.create(self.GPT35, None, io)
             commands = Commands(io, coder)
 
@@ -629,7 +629,7 @@ class TestCommands(TestCase):
     def test_cmd_undo_with_newly_committed_file(self):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             coder = Coder.create(self.GPT35, None, io)
             commands = Commands(io, coder)
 
@@ -665,7 +665,7 @@ class TestCommands(TestCase):
     def test_cmd_undo_on_first_commit(self):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             coder = Coder.create(self.GPT35, None, io)
             commands = Commands(io, coder)
 
@@ -706,7 +706,7 @@ class TestCommands(TestCase):
             aignore = Path(".aiderignore")
             aignore.write_text(f"{fname1}\n{fname2}\ndir\n")
 
-            io = InputOutput(yes=True)
+            io = Terminal(yes=True)
 
             fnames = [fname1, fname2]
             repo = GitRepo(
@@ -732,7 +732,7 @@ class TestCommands(TestCase):
             self.assertNotIn(fname3, str(coder.abs_fnames))
 
     def test_cmd_ask(self):
-        io = InputOutput(pretty=False, yes=True)
+        io = Terminal(pretty=False, yes=True)
         coder = Coder.create(self.GPT35, None, io)
         commands = Commands(io, coder)
 
@@ -756,7 +756,7 @@ class TestCommands(TestCase):
     def test_cmd_lint_with_dirty_file(self):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             coder = Coder.create(self.GPT35, None, io)
             commands = Commands(io, coder)
 

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from aider.coders import Coder
 from aider.coders import editblock_coder as eb
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 
 
@@ -297,7 +297,7 @@ These changes replace the `subprocess.run` patches with `subprocess.check_output
         files = [file1]
 
         # Initialize the Coder object with the mocked IO and mocked repo
-        coder = Coder.create(self.GPT35, "diff", io=InputOutput(), fnames=files, pretty=False)
+        coder = Coder.create(self.GPT35, "diff", io=Terminal(), fnames=files, pretty=False)
 
         def mock_send(*args, **kwargs):
             coder.partial_response_content = f"""
@@ -337,7 +337,7 @@ new
         coder = Coder.create(
             self.GPT35,
             "diff",
-            io=InputOutput(dry_run=True),
+            io=Terminal(dry_run=True),
             fnames=files,
             dry_run=True,
             pretty=False,

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -3,14 +3,14 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from aider.io import AutoCompleter, InputOutput
+from aider.terminal import AutoCompleter, Terminal
 from aider.utils import ChdirTemporaryDirectory
 
 
-class TestInputOutput(unittest.TestCase):
+class TestTerminal(unittest.TestCase):
     def test_no_color_environment_variable(self):
         with patch.dict(os.environ, {"NO_COLOR": "1"}):
-            io = InputOutput()
+            io = Terminal()
             self.assertFalse(io.pretty)
 
     def test_autocompleter_with_non_existent_file(self):
@@ -49,7 +49,7 @@ class TestInputOutput(unittest.TestCase):
         mock_session = MockPromptSession.return_value
         mock_session.prompt.return_value = "test input"
 
-        io = InputOutput(pretty=False)  # Windows tests throw UnicodeDecodeError
+        io = Terminal(pretty=False)  # Windows tests throw UnicodeDecodeError
         root = "/"
         rel_fnames = ["existing_file.txt"]
         addable_rel_fnames = ["new_file.txt"]

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -11,7 +11,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.main import check_gitignore, main, setup_git
 from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory, make_repo
 
@@ -101,7 +101,7 @@ class TestMain(TestCase):
         main(["--yes", str(fname)], input=DummyInput(), output=DummyOutput())
 
     def test_setup_git(self):
-        io = InputOutput(pretty=False, yes=True)
+        io = Terminal(pretty=False, yes=True)
         git_root = setup_git(None, io)
         git_root = Path(git_root).resolve()
         self.assertEqual(git_root, Path(self.tempdir).resolve())
@@ -116,7 +116,7 @@ class TestMain(TestCase):
         with GitTemporaryDirectory():
             os.environ["GIT_CONFIG_GLOBAL"] = "globalgitconfig"
 
-            io = InputOutput(pretty=False, yes=True)
+            io = Terminal(pretty=False, yes=True)
             cwd = Path.cwd()
             gitignore = cwd / ".gitignore"
 
@@ -225,7 +225,7 @@ class TestMain(TestCase):
 
         with GitTemporaryDirectory():
             with patch("aider.coders.Coder.create") as MockCoder:  # noqa: F841
-                with patch("aider.main.InputOutput") as MockSend:
+                with patch("aider.main.Terminal") as MockSend:
 
                     def side_effect(*args, **kwargs):
                         self.assertEqual(kwargs["encoding"], "iso-8859-15")
@@ -235,32 +235,32 @@ class TestMain(TestCase):
 
                     main(["--yes", fname, "--encoding", "iso-8859-15"])
 
-    @patch("aider.main.InputOutput")
+    @patch("aider.main.Terminal")
     @patch("aider.coders.base_coder.Coder.run")
-    def test_main_message_adds_to_input_history(self, mock_run, MockInputOutput):
+    def test_main_message_adds_to_input_history(self, mock_run, MockTerminal):
         test_message = "test message"
-        mock_io_instance = MockInputOutput.return_value
+        mock_io_instance = MockTerminal.return_value
 
         main(["--message", test_message], input=DummyInput(), output=DummyOutput())
 
         mock_io_instance.add_to_input_history.assert_called_once_with(test_message)
 
-    @patch("aider.main.InputOutput")
+    @patch("aider.main.Terminal")
     @patch("aider.coders.base_coder.Coder.run")
-    def test_yes(self, mock_run, MockInputOutput):
+    def test_yes(self, mock_run, MockTerminal):
         test_message = "test message"
 
         main(["--yes", "--message", test_message])
-        args, kwargs = MockInputOutput.call_args
+        args, kwargs = MockTerminal.call_args
         self.assertTrue(args[1])
 
-    @patch("aider.main.InputOutput")
+    @patch("aider.main.Terminal")
     @patch("aider.coders.base_coder.Coder.run")
-    def test_default_yes(self, mock_run, MockInputOutput):
+    def test_default_yes(self, mock_run, MockTerminal):
         test_message = "test message"
 
         main(["--message", test_message])
-        args, kwargs = MockInputOutput.call_args
+        args, kwargs = MockTerminal.call_args
         self.assertEqual(args[1], None)
 
     def test_dark_mode_sets_code_theme(self):

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import git
 
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 from aider.repo import GitRepo
 from aider.utils import GitTemporaryDirectory
@@ -31,7 +31,7 @@ class TestRepo(unittest.TestCase):
             # Make a change in the working dir
             fname.write_text("workingdir\n")
 
-            git_repo = GitRepo(InputOutput(), None, ".")
+            git_repo = GitRepo(Terminal(), None, ".")
             diffs = git_repo.get_diffs()
             self.assertIn("index", diffs)
             self.assertIn("workingdir", diffs)
@@ -54,7 +54,7 @@ class TestRepo(unittest.TestCase):
 
             fname2.write_text("workingdir\n")
 
-            git_repo = GitRepo(InputOutput(), None, ".")
+            git_repo = GitRepo(Terminal(), None, ".")
             diffs = git_repo.get_diffs()
             self.assertIn("index", diffs)
             self.assertIn("workingdir", diffs)
@@ -84,7 +84,7 @@ class TestRepo(unittest.TestCase):
 
             fname2.write_text("workingdir\n")
 
-            git_repo = GitRepo(InputOutput(), None, ".")
+            git_repo = GitRepo(Terminal(), None, ".")
             diffs = git_repo.get_diffs()
             self.assertIn("index", diffs)
             self.assertIn("workingdir", diffs)
@@ -102,7 +102,7 @@ class TestRepo(unittest.TestCase):
             repo.git.add(str(fname))
             repo.git.commit("-m", "second")
 
-            git_repo = GitRepo(InputOutput(), None, ".")
+            git_repo = GitRepo(Terminal(), None, ".")
             diffs = git_repo.diff_commits(False, "HEAD~1", "HEAD")
             self.assertIn("two", diffs)
 
@@ -112,7 +112,7 @@ class TestRepo(unittest.TestCase):
 
         model1 = Model("gpt-3.5-turbo")
         model2 = Model("gpt-4")
-        repo = GitRepo(InputOutput(), None, None, models=[model1, model2])
+        repo = GitRepo(Terminal(), None, None, models=[model1, model2])
 
         # Call the get_commit_message method with dummy diff and context
         result = repo.get_commit_message("dummy diff", "dummy context")
@@ -131,7 +131,7 @@ class TestRepo(unittest.TestCase):
     def test_get_commit_message_strip_quotes(self, mock_send):
         mock_send.return_value = '"a good commit message"'
 
-        repo = GitRepo(InputOutput(), None, None, models=[self.GPT35])
+        repo = GitRepo(Terminal(), None, None, models=[self.GPT35])
         # Call the get_commit_message method with dummy diff and context
         result = repo.get_commit_message("dummy diff", "dummy context")
 
@@ -142,7 +142,7 @@ class TestRepo(unittest.TestCase):
     def test_get_commit_message_no_strip_unmatched_quotes(self, mock_send):
         mock_send.return_value = 'a good "commit message"'
 
-        repo = GitRepo(InputOutput(), None, None, models=[self.GPT35])
+        repo = GitRepo(Terminal(), None, None, models=[self.GPT35])
         # Call the get_commit_message method with dummy diff and context
         result = repo.get_commit_message("dummy diff", "dummy context")
 
@@ -154,7 +154,7 @@ class TestRepo(unittest.TestCase):
         mock_send.return_value = "Custom commit message"
         custom_prompt = "Generate a commit message in the style of Shakespeare"
 
-        repo = GitRepo(InputOutput(), None, None, models=[self.GPT35], commit_prompt=custom_prompt)
+        repo = GitRepo(Terminal(), None, None, models=[self.GPT35], commit_prompt=custom_prompt)
         result = repo.get_commit_message("dummy diff", "dummy context")
 
         self.assertEqual(result, "Custom commit message")
@@ -181,7 +181,7 @@ class TestRepo(unittest.TestCase):
             raw_repo.git.add(str(fname))
             raw_repo.git.commit("-m", "initial commit")
 
-            io = InputOutput()
+            io = Terminal()
             git_repo = GitRepo(io, None, None)
 
             # commit a change
@@ -236,7 +236,7 @@ class TestRepo(unittest.TestCase):
 
         repo.git.commit("-m", "added")
 
-        tracked_files = GitRepo(InputOutput(), [tempdir], None).get_tracked_files()
+        tracked_files = GitRepo(Terminal(), [tempdir], None).get_tracked_files()
 
         # On windows, paths will come back \like\this, so normalize them back to Paths
         tracked_files = [Path(fn) for fn in tracked_files]
@@ -254,7 +254,7 @@ class TestRepo(unittest.TestCase):
             fname.touch()
             raw_repo.git.add(str(fname))
 
-            git_repo = GitRepo(InputOutput(), None, None)
+            git_repo = GitRepo(Terminal(), None, None)
 
             # better be there
             fnames = git_repo.get_tracked_files()
@@ -286,7 +286,7 @@ class TestRepo(unittest.TestCase):
             raw_repo.git.add(str(fname))
 
             aiderignore = Path(".aiderignore")
-            git_repo = GitRepo(InputOutput(), None, None, str(aiderignore))
+            git_repo = GitRepo(Terminal(), None, None, str(aiderignore))
 
             # better be there
             fnames = git_repo.get_tracked_files()
@@ -338,7 +338,7 @@ class TestRepo(unittest.TestCase):
 
             os.chdir(fname.parent)
 
-            git_repo = GitRepo(InputOutput(), None, None)
+            git_repo = GitRepo(Terminal(), None, None)
 
             # better be there
             fnames = git_repo.get_tracked_files()
@@ -399,6 +399,6 @@ class TestRepo(unittest.TestCase):
             raw_repo.git.add(str(fname))
             raw_repo.git.commit("-m", "new")
 
-            git_repo = GitRepo(InputOutput(), None, None)
+            git_repo = GitRepo(Terminal(), None, None)
 
             git_repo.commit(fnames=[str(fname)])

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 from aider.repomap import RepoMap
 from aider.utils import IgnorantTemporaryDirectory
@@ -26,7 +26,7 @@ class TestRepoMap(unittest.TestCase):
                 with open(os.path.join(temp_dir, file), "w") as f:
                     f.write("")
 
-            io = InputOutput()
+            io = Terminal()
             repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
             other_files = [os.path.join(temp_dir, file) for file in test_files]
             result = repo_map.get_repo_map([], other_files)
@@ -74,7 +74,7 @@ print(my_function(3, 4))
             with open(os.path.join(temp_dir, test_file3), "w") as f:
                 f.write(file_content3)
 
-            io = InputOutput()
+            io = Terminal()
             repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
             other_files = [
                 os.path.join(temp_dir, test_file1),
@@ -109,7 +109,7 @@ print(my_function(3, 4))
                 with open(os.path.join(temp_dir, file), "w") as f:
                     f.write("")
 
-            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=InputOutput())
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=Terminal())
 
             other_files = [os.path.join(temp_dir, file) for file in test_files]
             result = repo_map.get_repo_map([], other_files)
@@ -137,7 +137,7 @@ print(my_function(3, 4))
                 with open(os.path.join(temp_dir, file), "w") as f:
                     f.write("def foo(): pass\n")
 
-            io = InputOutput()
+            io = Terminal()
             repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
             test_files = [os.path.join(temp_dir, file) for file in test_files]
             result = repo_map.get_repo_map(test_files[:2], test_files[2:])
@@ -195,7 +195,7 @@ export function myFunction(input: number): number {
             with open(os.path.join(temp_dir, test_file_ts), "w") as f:
                 f.write(file_content_ts)
 
-            io = InputOutput()
+            io = Terminal()
             repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
             other_files = [os.path.join(temp_dir, test_file_ts)]
             result = repo_map.get_repo_map([], other_files)
@@ -293,7 +293,7 @@ class TestRepoMapAllLanguages(unittest.TestCase):
                 with open(os.path.join(temp_dir, filename), "w") as f:
                     f.write(content)
 
-            io = InputOutput()
+            io = Terminal()
             repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
             other_files = [
                 os.path.join(temp_dir, filename) for filename, _ in language_files.values()

--- a/tests/basic/test_wholefile.py
+++ b/tests/basic/test_wholefile.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 from aider.coders import Coder
 from aider.coders.wholefile_coder import WholeFileCoder
 from aider.dump import dump  # noqa: F401
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 
 
@@ -26,7 +26,7 @@ class TestWholeFileCoder(unittest.TestCase):
 
     def test_no_files(self):
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
 
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[])
         coder.partial_response_content = (
@@ -39,7 +39,7 @@ class TestWholeFileCoder(unittest.TestCase):
         coder.render_incremental_response(True)
 
     def test_no_files_new_file_should_ask(self):
-        io = InputOutput(yes=False)  # <- yes=FALSE
+        io = Terminal(yes=False)  # <- yes=FALSE
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[])
         coder.partial_response_content = (
             'To print "Hello, World!" in most programming languages, you can use the following'
@@ -56,7 +56,7 @@ class TestWholeFileCoder(unittest.TestCase):
             f.write("Original content\n")
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
@@ -80,7 +80,7 @@ class TestWholeFileCoder(unittest.TestCase):
             f.write("\n".join(map(str, range(0, 100))))
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
@@ -104,7 +104,7 @@ Quote!
             f.write(original_content)
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         coder.choose_fence()
@@ -134,7 +134,7 @@ Quote!
             f.write("Original content\n")
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
@@ -159,7 +159,7 @@ Quote!
             f.write("Original content\n")
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io)
 
         # Set the partial response content with the updated content
@@ -187,7 +187,7 @@ Quote!
             f.write("Original content\n")
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
@@ -230,7 +230,7 @@ after b
 ```
 """
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[fname_a, fname_b])
 
         # Set the partial response content with the updated content
@@ -254,7 +254,7 @@ after b
             f.write("Original content\n")
 
         # Initialize WholeFileCoder with the temporary directory
-        io = InputOutput(yes=True)
+        io = Terminal(yes=True)
         coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[sample_file])
 
         # Set the partial response content with the updated content
@@ -289,7 +289,7 @@ after b
 
         # Initialize the Coder object with the mocked IO and mocked repo
         coder = Coder.create(
-            self.GPT35, "whole", io=InputOutput(), fnames=files, stream=False, pretty=False
+            self.GPT35, "whole", io=Terminal(), fnames=files, stream=False, pretty=False
         )
 
         # no trailing newline so the response content below doesn't add ANOTHER newline

--- a/tests/help/test_help.py
+++ b/tests/help/test_help.py
@@ -5,14 +5,14 @@ import aider
 from aider.coders import Coder
 from aider.commands import Commands
 from aider.help import Help
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.models import Model
 
 
 class TestHelp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        io = InputOutput(pretty=False, yes=True)
+        io = Terminal(pretty=False, yes=True)
 
         GPT35 = Model("gpt-3.5-turbo")
 

--- a/tests/scrape/test_scrape.py
+++ b/tests/scrape/test_scrape.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from aider.commands import Commands
-from aider.io import InputOutput
+from aider.terminal import Terminal
 from aider.scrape import Scraper
 
 
@@ -26,7 +26,7 @@ class TestScrape(unittest.TestCase):
         scraper_no_verify.print_error.assert_not_called()
 
     def setUp(self):
-        self.io = InputOutput(yes=True)
+        self.io = Terminal(yes=True)
         self.commands = Commands(self.io, None)
 
     def test_cmd_web_imports_playwright(self):


### PR DESCRIPTION
Remove all console commands form the InputOuput class and put them into a derived class Terminal.
- This allows the InputOutput class to be overridden with other IO classes
- Add support to add a CommandIO class (https://github.com/paul-gauthier/aider/pull/1019), uses stdin/stdout via json encoded commands to send/receive info from Coder