### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -478,7 +478,7 @@
 
 - Added `/git` command to run git from inside aider chats.
 - Use Meta-ENTER (Esc+ENTER in some environments) to enter multiline chat messages.
-- Create a `.gitignore` with `.aider*` to prevent users from accidentaly adding aider files to git.
+- Create a `.gitignore` with `.aider*` to prevent users from accidentally adding aider files to git.
 - Check pypi for newer versions and notify user.
 - Updated keyboard interrupt logic so that 2 ^C in 2 seconds always forces aider to exit.
 - Provide GPT with detailed error if it makes a bad edit block, ask for a retry.

--- a/aider/website/HISTORY.md
+++ b/aider/website/HISTORY.md
@@ -493,7 +493,7 @@ cog.out(text)
 
 - Added `/git` command to run git from inside aider chats.
 - Use Meta-ENTER (Esc+ENTER in some environments) to enter multiline chat messages.
-- Create a `.gitignore` with `.aider*` to prevent users from accidentaly adding aider files to git.
+- Create a `.gitignore` with `.aider*` to prevent users from accidentally adding aider files to git.
 - Check pypi for newer versions and notify user.
 - Updated keyboard interrupt logic so that 2 ^C in 2 seconds always forces aider to exit.
 - Provide GPT with detailed error if it makes a bad edit block, ask for a retry.

--- a/aider/website/docs/ctags.md
+++ b/aider/website/docs/ctags.md
@@ -228,7 +228,7 @@ Some possible approaches to reducing the amount of map data are:
 
   - Distill the global map, to prioritize important symbols and discard "internal" or otherwise less globally relevant identifiers. Possibly enlist `gpt-3.5-turbo` to perform this distillation in a flexible and language agnostic way.
   - Provide a mechanism for GPT to start with a distilled subset of the global map, and let it ask to see more detail about subtrees or keywords that it feels are relevant to the current coding task.
-  - Attempt to analyize the natural language coding task given by the user and predict which subset of the repo map is relevant. Possibly by analysis of prior coding chats within the specific repo. Work on certain files or types of features may require certain somewhat predictable context from elsewhere in the repo. Vector and keyword search against the chat history, repo map or codebase may help here.
+  - Attempt to analyze the natural language coding task given by the user and predict which subset of the repo map is relevant. Possibly by analysis of prior coding chats within the specific repo. Work on certain files or types of features may require certain somewhat predictable context from elsewhere in the repo. Vector and keyword search against the chat history, repo map or codebase may help here.
 
 One key goal is to prefer solutions which are language agnostic or
 which can be easily deployed against most popular code languages.

--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -37,7 +37,7 @@ If you still wish to add lots of files to the chat, you can:
 
 - Use a wildcard when you launch aider: `aider src/*.py`
 - Use a wildcard with the in-chat `/add` command: `/add src/*.py`
-- Give the `/add` command a directory name and it will recurisvely add every file under that dir: `/add src`
+- Give the `/add` command a directory name and it will recursively add every file under that dir: `/add src`
 
 ## How can I run aider locally from source code?
 

--- a/aider/website/docs/troubleshooting/edit-errors.md
+++ b/aider/website/docs/troubleshooting/edit-errors.md
@@ -34,7 +34,7 @@ so editing errors are probably unavoidable.
 
 Many LLM now have very large context windows,
 but filling them with irrelevant code or conversation 
-can cofuse the model.
+can confuse the model.
 
 - Don't add too many files to the chat, *just* add the files you think need to be edited.
 Aider also sends the LLM a [map of your entire git repo](https://aider.chat/docs/repomap.html), so other relevant code will be included automatically.

--- a/aider/website/examples/README.md
+++ b/aider/website/examples/README.md
@@ -8,7 +8,7 @@ has_toc: false
 # Example chat transcripts
 
 Below are some chat transcripts showing what it's like to code with aider.
-In the chats, you'll see a varity of coding tasks like generating new code, editing existing code, debugging, exploring unfamiliar code, etc.
+In the chats, you'll see a variety of coding tasks like generating new code, editing existing code, debugging, exploring unfamiliar code, etc.
 
 * [**Hello World Flask App**](https://aider.chat/examples/hello-world-flask.html): Start from scratch and have aider create a simple Flask app with various endpoints, such as adding two numbers and calculating the Fibonacci sequence.
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -23,7 +23,7 @@ litellm
 flake8
 importlib_resources
 
-# The proper depdendency is networkx[default], but this brings
+# The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps
 # https://github.com/networkx/networkx/blob/d7132daa8588f653eacac7a5bae1ee85a183fa43/pyproject.toml#L57
 # We really only need networkx itself and scipy for the repomap.

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -181,9 +181,9 @@ aider/coder.py
 
 aider/coder.py
 <<<<<<< SEARCH
-            self.console.print("[red]Skipped commmit.")
+            self.console.print("[red]Skipped commit.")
 =======
-            self.io.tool_error("Skipped commmit.")
+            self.io.tool_error("Skipped commit.")
 >>>>>>> REPLACE"""
 
         # Should not raise a ValueError


### PR DESCRIPTION
% `codespell --ignore-words-list=assertin --skip="*.svg" --write-changes`
* https://pypi.org/project/codespell