### PR TITLE
Fix startup issue in Mac homebrew

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -1,5 +1,5 @@
 import difflib
-import importlib
+import importlib.util
 import json
 import math
 import os


### PR DESCRIPTION
Summary
------------------
Changed import line to fix startup issue in the Mac homebrew install

Motivation
------------------
I've installed aider with homebrew. When starting aider using an ollama model, I got this error:

```
aider --model ollama/llama3.1 main.go
Traceback (most recent call last):
  File "/opt/homebrew/bin/aider", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/Cellar/aider/0.48.0/libexec/lib/python3.12/site-packages/aider/main.py", line 463, in main
    main_model = models.Model(args.model, weak_model=args.weak_model)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/aider/0.48.0/libexec/lib/python3.12/site-packages/aider/models.py", line 391, in __init__
    self.info = self.get_model_info(model)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/aider/0.48.0/libexec/lib/python3.12/site-packages/aider/models.py", line 414, in get_model_info
    spec = importlib.util.find_spec("litellm")
           ^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'util'
```

aider works fine after this change. Unfortunately, I wasn't able to reproduce the issue in the virtual environment created as per the guide in CONTRIBUTING.md.

Tests performed
------------------
Modified in-place homebrew install, also ran pytest in repo after change to make sure tests still pass.