### PR TITLE
feat: Add read-only files to the output of the 'ls' command

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -752,6 +752,7 @@ class Commands:
 
         other_files = []
         chat_files = []
+        read_only_files = []
         for file in files:
             abs_file_path = self.coder.abs_root_path(file)
             if abs_file_path in self.coder.abs_fnames:
@@ -759,13 +760,23 @@ class Commands:
             else:
                 other_files.append(file)
 
-        if not chat_files and not other_files:
-            self.io.tool_output("\nNo files in chat or git repo.")
+        # Add read-only files
+        for abs_file_path in self.coder.abs_read_only_fnames:
+            rel_file_path = self.coder.get_rel_fname(abs_file_path)
+            read_only_files.append(rel_file_path)
+
+        if not chat_files and not other_files and not read_only_files:
+            self.io.tool_output("\nNo files in chat, git repo, or read-only list.")
             return
 
         if other_files:
             self.io.tool_output("Repo files not in the chat:\n")
         for file in other_files:
+            self.io.tool_output(f"  {file}")
+
+        if read_only_files:
+            self.io.tool_output("\nRead-only files:\n")
+        for file in read_only_files:
             self.io.tool_output(f"  {file}")
 
         if chat_files:


### PR DESCRIPTION
Small tweak to make it show read only files when I type ls;:


```
Read-only files:

  setup.py

Files in chat:

  scripts/update-docs.sh
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
scripts/update-docs.sh
>
```