### PR TITLE
Use extra_headers also for summary and commit message prompts

### DIFF
--- a/aider/history.py
+++ b/aider/history.py
@@ -108,7 +108,11 @@ class ChatSummary:
 
         for model in self.models:
             try:
-                summary = simple_send_with_retries(model.name, summarize_messages)
+                summary = simple_send_with_retries(
+                    model.name,
+                    summarize_messages,
+                    model.extra_headers
+                )
                 if summary is not None:
                     summary = prompts.summary_prefix + summary
                     return [dict(role="user", content=summary)]

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -178,7 +178,11 @@ class GitRepo:
             max_tokens = model.info.get("max_input_tokens") or 0
             if max_tokens and num_tokens > max_tokens:
                 continue
-            commit_message = simple_send_with_retries(model.name, messages)
+            commit_message = simple_send_with_retries(
+                model.name,
+                messages,
+                model.extra_headers
+            )
             if commit_message:
                 break
 

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -86,13 +86,14 @@ def send_completion(
 
 
 @lazy_litellm_retry_decorator
-def simple_send_with_retries(model_name, messages):
+def simple_send_with_retries(model_name, messages, extra_headers):
     try:
         _hash, response = send_completion(
             model_name=model_name,
             messages=messages,
             functions=None,
             stream=False,
+            extra_headers=extra_headers,
         )
         return response.choices[0].message.content
     except (AttributeError, litellm.exceptions.BadRequestError):

--- a/tests/basic/test_history.py
+++ b/tests/basic/test_history.py
@@ -10,6 +10,7 @@ class TestChatSummary(TestCase):
         self.mock_model.name = "gpt-3.5-turbo"
         self.mock_model.token_count = lambda msg: len(msg["content"].split())
         self.mock_model.info = {"max_input_tokens": 4096}
+        self.mock_model.extra_headers = {}
         self.chat_summary = ChatSummary(self.mock_model, max_tokens=100)
 
     def test_initialization(self):
@@ -73,8 +74,10 @@ class TestChatSummary(TestCase):
     def test_fallback_to_second_model(self, mock_send):
         mock_model1 = mock.Mock(spec=Model)
         mock_model1.name = "gpt-4"
+        mock_model1.extra_headers = {}
         mock_model2 = mock.Mock(spec=Model)
         mock_model2.name = "gpt-3.5-turbo"
+        mock_model2.extra_headers = {}
 
         chat_summary = ChatSummary([mock_model1, mock_model2], max_tokens=100)
 

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -124,8 +124,8 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(mock_send.call_count, 2)
 
         # Check that it was called with the correct model names
-        mock_send.assert_any_call(model1.name, mock_send.call_args[0][1])
-        mock_send.assert_any_call(model2.name, mock_send.call_args[0][1])
+        mock_send.assert_any_call(model1.name, *mock_send.call_args[0][1:])
+        mock_send.assert_any_call(model2.name, *mock_send.call_args[0][1:])
 
     @patch("aider.repo.simple_send_with_retries")
     def test_get_commit_message_strip_quotes(self, mock_send):

--- a/tests/basic/test_sendchat.py
+++ b/tests/basic/test_sendchat.py
@@ -30,7 +30,7 @@ class TestSendChat(unittest.TestCase):
         ]
 
         # Call the simple_send_with_retries method
-        simple_send_with_retries("model", ["message"])
+        simple_send_with_retries("model", ["message"], extra_headers={})
         mock_print.assert_called_once()
 
     @patch("litellm.completion")
@@ -43,5 +43,5 @@ class TestSendChat(unittest.TestCase):
         ]
 
         # Call the simple_send_with_retries method
-        simple_send_with_retries("model", ["message"])
+        simple_send_with_retries("model", ["message"], extra_headers={})
         mock_print.assert_called_once()


### PR DESCRIPTION
My in-house provider uses HTTP headers for authentication.

`extra_headers` can be specified for a model in `.aider.model.settings.yml`, and they are used for coder prompts. But Aider crashes on summary and commit message generation. This simple fix makes sure the headers are used there, too.
