### PR TITLE
Correct description of map-refresh command.

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1046,7 +1046,7 @@ class Commands:
             self.io.tool_output("No repository map available.")
 
     def cmd_map_refresh(self, args):
-        "Force a refresh of the repository map and print it out"
+        "Force a refresh of the repository map"
         repo_map = self.coder.get_repo_map(force_refresh=True)
         if repo_map:
             self.io.tool_output("The repo map has been refreshed, use /map to view it.")

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -29,7 +29,7 @@ cog.out(get_help_md())
 | **/lint** | Lint and fix provided files or in-chat files if none provided |
 | **/ls** | List all known files and indicate which are included in the chat session |
 | **/map** | Print out the current repository map |
-| **/map-refresh** | Force a refresh of the repository map and print it out |
+| **/map-refresh** | Force a refresh of the repository map |
 | **/model** | Switch to a new LLM |
 | **/models** | Search the list of available models |
 | **/quit** | Exit the application |


### PR DESCRIPTION
Delete " and print it out" because the map-refresh command doesn't print out the map.