### PR TITLE
Use fake home directory to prevent `~/.aider.conf.yml` from affecting the test suite

### DIFF
--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -26,10 +26,14 @@ class TestMain(TestCase):
         self.tempdir_obj = IgnorantTemporaryDirectory()
         self.tempdir = self.tempdir_obj.name
         os.chdir(self.tempdir)
+        # Fake home directory prevents tests from using the real ~/.aider.conf.yml file:
+        self.homedir_obj = IgnorantTemporaryDirectory()
+        os.environ["HOME"] = self.homedir_obj.name
 
     def tearDown(self):
         os.chdir(self.original_cwd)
         self.tempdir_obj.cleanup()
+        self.homedir_obj.cleanup()
         os.environ.clear()
         os.environ.update(self.original_env)
 


### PR DESCRIPTION
Fixes #1165.