### PR TITLE
docs: add benchmark results for new gemini experimental models

### DIFF
--- a/aider/website/_data/edit_leaderboard.yml
+++ b/aider/website/_data/edit_leaderboard.yml
@@ -881,7 +881,7 @@
 
 - dirname: 2024-08-28-07-10-50--gemini-1.5-pro-exp-0827-diff-fenced
   test_cases: 133
-  model: gemini/gemini-1.5-pro-exp-0827
+  model: gemini-1.5-pro-exp-0827
   edit_format: diff-fenced
   commit_hash: d8adc75
   pass_rate_1: 54.9
@@ -904,7 +904,7 @@
 
 - dirname: 2024-08-27-19-20-19--gemini-1.5-flash-exp-0827
   test_cases: 133
-  model: gemini/gemini-1.5-flash-exp-0827
+  model: gemini-1.5-flash-exp-0827
   edit_format: whole
   commit_hash: d8adc75
   pass_rate_1: 40.6
@@ -927,7 +927,7 @@
 
 - dirname: 2024-08-27-19-42-05--gemini-1.5-flash-8b-exp-0827
   test_cases: 133
-  model: gemini/gemini-1.5-flash-8b-exp-0827
+  model: gemini-1.5-flash-8b-exp-0827
   edit_format: whole
   commit_hash: d8adc75
   pass_rate_1: 31.6
@@ -947,5 +947,3 @@
   versions: 0.53.1-dev
   seconds_per_case: 7.2
   total_cost: 0.0000
-
-  


### PR DESCRIPTION
Added benchmark results for the 3 new experimental Gemini models (Gemini 1.5 Pro, Gemini 1.5 Flash, Gemini 1.5 Flash-8B) available on AI Studio announced yesterday: https://x.com/OfficialLoganK/status/1828480081574142227

Rate limits means I've been limited to running one full benchmark test per day per model, so I've only tested `gemini/gemini-1.5-pro-exp-0827` with `whole` and `diff-fenced`. The pro model constantly failed at `whole` because it kept adding the file name inside of an already open code block (example chat history attached).

`````
# aider chat started at 2024-08-27 19:32:58


#### # Instructions  
####   
#### Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.  
####   
#### Given the collection of numbers:  
####   
#### - 1, 2, 3, 4, 5  
####   
#### And the operation:  
####   
#### - square a number (`x => x * x`)  
####   
#### Your code should be able to produce the collection of squares:  
####   
#### - 1, 4, 9, 16, 25  
####   
#### Check out the test suite to see the expected function signature.  
####   
#### ## Restrictions  
####   
#### Keep your hands off that collect/map/fmap/whatchamacallit functionality provided by your standard library!  
#### Solve this one yourself using other basic tools instead.  
####   
#### ####  
####   
#### Use the above instructions to modify the supplied files: accumulate.py  
#### Don't change the names of existing functions or classes, as they may be referenced from other code like unit tests, etc.  
#### Only use standard python libraries, don't suggest installing any packages.  

```python
accumulate.py
```python
def accumulate(collection, operation):
    new_collection = []
    for element in collection:
        new_collection.append(operation(element))
    return new_collection

```

> Tokens: 683 sent, 51 received.  
> Applied edit to accumulate.py  
>  
> # Fix any errors below, if possible.  
>  
> ## Running: /usr/local/bin/python -m flake8 --select=E9,F821,F823,F831,F406,F407,F701,F702,F704,F706 --show-source --isolated accumulate.py  
>  
> accumulate.py:1:1: F821 undefined name 'accumulate'  
> accumulate.py  
> ^  
>  
> ## See relevant line below marked with █.  
>  
> accumulate.py:  
> 1█accumulate.py  
>  
> Attempt to fix lint errors? (Y)es/(N)o [Yes]: n  
```
E
====
ERROR: accumulate_test (unittest.loader._FailedTest)
----
ImportError: Failed to import test module: accumulate_test
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/local/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "accumulate/accumulate_test.py", line 3, in <module>
    from accumulate import accumulate
  File "accumulate/accumulate.py", line 1, in <module>
    accumulate.py
NameError: name 'accumulate' is not defined


----
Ran 1 test in 0.000s

FAILED (errors=1)

```
#### E  
#### ====  
#### ERROR: accumulate_test (unittest.loader._FailedTest)  
#### ----  
#### ImportError: Failed to import test module: accumulate_test  
#### Traceback (most recent call last):  
####   File "/usr/local/lib/python3.10/unittest/loader.py", line 436, in _find_test_path  
####     module = self._get_module_from_name(name)  
####   File "/usr/local/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name  
####     __import__(name)  
####   File "accumulate/accumulate_test.py", line 3, in <module>  
####     from accumulate import accumulate  
####   File "accumulate/accumulate.py", line 1, in <module>  
####     accumulate.py  
#### NameError: name 'accumulate' is not defined  
####   
####   
#### ----  
#### Ran 1 test in 0.000s  
####   
#### FAILED (errors=1)  
#### ####  
####   
#### See the testing errors above.  
#### The tests are correct.  
#### Fix the code in accumulate.py to resolve the errors.  

The error message indicates that the `accumulate` function is not defined in `accumulate.py`. This is because the file content is incorrect. It should contain the function definition instead of just the filename.

Here's the corrected `accumulate.py` file:

accumulate.py
```python
def accumulate(collection, operation):
    new_collection = []
    for element in collection:
        new_collection.append(operation(element))
    return new_collection
```

> Tokens: 984 sent, 102 received.  
> Applied edit to accumulate.py  
```
......
----


OK

```
`````

Some other benchmark results:

```yaml
- dirname: 2024-08-28-08-05-48--gemini-1.5-pro-exp-0827-diff
  test_cases: 133
  model: gemini-1.5-pro-exp-0827
  edit_format: diff
  commit_hash: d8adc75
  pass_rate_1: 53.4
  pass_rate_2: 68.4
  percent_cases_well_formed: 94.0
  error_outputs: 103
  num_malformed_responses: 18
  num_with_malformed_responses: 8
  user_asks: 49
  lazy_comments: 0
  syntax_errors: 0
  indentation_errors: 2
  exhausted_context_windows: 0
  test_timeouts: 5
  command: aider --model gemini/gemini-1.5-pro-exp-0827
  date: 2024-08-28
  versions: 0.53.1-dev
  seconds_per_case: 22.4
  total_cost: 0.0000
- dirname: 2024-08-27-19-02-19--gemini-1.5-pro-exp-0827
  test_cases: 133
  model: gemini-1.5-pro-exp-0827
  edit_format: whole
  commit_hash: d8adc75
  pass_rate_1: 23.3
  pass_rate_2: 57.9
  percent_cases_well_formed: 100.0
  error_outputs: 101
  num_malformed_responses: 0
  num_with_malformed_responses: 0
  user_asks: 101
  lazy_comments: 2
  syntax_errors: 0
  indentation_errors: 0
  exhausted_context_windows: 0
  test_timeouts: 1
  command: aider --model gemini/gemini-1.5-pro-exp-0827
  date: 2024-08-27
  versions: 0.53.1-dev
  seconds_per_case: 14.0
  total_cost: 0.0000
- dirname: 2024-08-28-07-14-01--gemini-1.5-flash-exp-0827-diff-fenced
  test_cases: 133
  model: gemini-1.5-flash-exp-0827
  edit_format: diff-fenced
  commit_hash: d8adc75
  pass_rate_1: 34.6
  pass_rate_2: 44.4
  percent_cases_well_formed: 87.2
  error_outputs: 258
  num_malformed_responses: 58
  num_with_malformed_responses: 17
  user_asks: 76
  lazy_comments: 2
  syntax_errors: 10
  indentation_errors: 3
  exhausted_context_windows: 0
  test_timeouts: 2
  command: aider --model gemini/gemini-1.5-flash-exp-0827
  date: 2024-08-28
  versions: 0.53.1-dev
  seconds_per_case: 8.5
  total_cost: 0.0000
# The following test case removed the option to use ```` for fences
- dirname: 2024-08-28-11-02-31--gemini-1.5-pro-exp-0827-whole-no-backtick-fence
  test_cases: 133
  model: gemini-1.5-pro-exp-0827
  edit_format: whole
  commit_hash: d8adc75-dirty
  pass_rate_1: 42.9
  pass_rate_2: 64.7
  percent_cases_well_formed: 100.0
  error_outputs: 8
  num_malformed_responses: 0
  num_with_malformed_responses: 0
  user_asks: 5
  lazy_comments: 0
  syntax_errors: 6
  indentation_errors: 0
  exhausted_context_windows: 0
  test_timeouts: 0
  command: aider --model gemini/gemini-1.5-pro-exp-0827
  date: 2024-08-28
  versions: 0.53.1-dev
  seconds_per_case: 13.3
  total_cost: 0.0000
- dirname: 2024-08-28-16-33-07--gemini-1.5-pro-exp-0827-udiff
  test_cases: 133
  model: gemini-1.5-pro-exp-0827
  edit_format: udiff
  commit_hash: d8adc75
  pass_rate_1: 52.6
  pass_rate_2: 64.7
  percent_cases_well_formed: 98.5
  error_outputs: 76
  num_malformed_responses: 3
  num_with_malformed_responses: 2
  user_asks: 13
  lazy_comments: 0
  syntax_errors: 0
  indentation_errors: 4
  exhausted_context_windows: 0
  test_timeouts: 1
  command: aider --model gemini/gemini-1.5-pro-exp-0827
  date: 2024-08-28
  versions: 0.53.1-dev
  seconds_per_case: 21.2
  total_cost: 0.0000
```