### PR TITLE
Clean up types and drop an unused variable

### DIFF
--- a/aider/coders/editblock_func_coder.py
+++ b/aider/coders/editblock_func_coder.py
@@ -111,9 +111,9 @@ class EditBlockFunctionCoder(Coder):
             updated = get_arg(edit, "updated_lines")
 
             # gpt-3.5 returns lists even when instructed to return a string!
-            if self.code_format == "list" or type(original) == list:
+            if self.code_format == "list" or type(original) is list:
                 original = "\n".join(original)
-            if self.code_format == "list" or type(updated) == list:
+            if self.code_format == "list" or type(updated) is list:
                 updated = "\n".join(updated)
 
             if original and not original.endswith("\n"):

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
+from typing import Generator
 
 import git
 import pyperclip
@@ -527,21 +528,23 @@ class Commands:
         try:
             if os.path.isabs(pattern):
                 # Handle absolute paths
-                raw_matched_files = [Path(pattern)]
+                raw_matched_files: list[Path] = [Path(pattern)]
             else:
-                raw_matched_files = list(Path(self.coder.root).glob(pattern))
+                raw_matched_files: list[Path] = list(
+                    Path(self.coder.root).glob(pattern)
+                )
         except ValueError as err:
             self.io.tool_error(f"Error matching {pattern}: {err}")
-            raw_matched_files = []
+            raw_matched_files: list[Path] = []
 
-        matched_files = []
+        matched_files: list[Path] = []
         for fn in raw_matched_files:
             matched_files += expand_subdir(fn)
 
         matched_files = [
-            str(Path(fn).relative_to(self.coder.root))
+            fn.relative_to(self.coder.root)
             for fn in matched_files
-            if Path(fn).is_relative_to(self.coder.root)
+            if fn.is_relative_to(self.coder.root)
         ]
 
         # if repo, filter against it
@@ -1076,8 +1079,7 @@ class Commands:
         self.io.tool_output(settings)
 
 
-def expand_subdir(file_path):
-    file_path = Path(file_path)
+def expand_subdir(file_path: Path) -> Generator[Path, None, None]:
     if file_path.is_file():
         yield file_path
         return
@@ -1085,7 +1087,7 @@ def expand_subdir(file_path):
     if file_path.is_dir():
         for file in file_path.rglob("*"):
             if file.is_file():
-                yield str(file)
+                yield file
 
 
 def parse_quoted_filenames(args):

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -5,7 +5,6 @@ import sys
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
-from typing import Generator
 
 import git
 import pyperclip
@@ -528,16 +527,16 @@ class Commands:
         try:
             if os.path.isabs(pattern):
                 # Handle absolute paths
-                raw_matched_files: list[Path] = [Path(pattern)]
+                raw_matched_files = [Path(pattern)]
             else:
-                raw_matched_files: list[Path] = list(
+                raw_matched_files = list(
                     Path(self.coder.root).glob(pattern)
                 )
         except ValueError as err:
             self.io.tool_error(f"Error matching {pattern}: {err}")
-            raw_matched_files: list[Path] = []
+            raw_matched_files = []
 
-        matched_files: list[Path] = []
+        matched_files = []
         for fn in raw_matched_files:
             matched_files += expand_subdir(fn)
 
@@ -1079,7 +1078,7 @@ class Commands:
         self.io.tool_output(settings)
 
 
-def expand_subdir(file_path: Path) -> Generator[Path, None, None]:
+def expand_subdir(file_path):
     if file_path.is_file():
         yield file_path
         return

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -555,8 +555,6 @@ class Commands:
     def cmd_add(self, args):
         "Add files to the chat so aider can edit them or review them in detail"
 
-        added_fnames = []
-
         all_matched_files = set()
 
         filenames = parse_quoted_filenames(args)
@@ -618,7 +616,6 @@ class Commands:
                     self.io.tool_output(
                         f"Moved {matched_file} from read-only to editable files in the chat"
                     )
-                    added_fnames.append(matched_file)
                 else:
                     self.io.tool_error(
                         f"Cannot add {matched_file} as it's not part of the repository"
@@ -637,7 +634,6 @@ class Commands:
                     self.coder.abs_fnames.add(abs_file_path)
                     self.io.tool_output(f"Added {matched_file} to the chat")
                     self.coder.check_added_files()
-                    added_fnames.append(matched_file)
 
     def completions_drop(self):
         files = self.coder.get_inchat_relative_files()

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -18,7 +18,7 @@ class TestUtils(unittest.TestCase):
 
     def test_find_filename(self):
         fence = ("```", "```")
-        valid_fnames = ["file1.py", "file2.py", "dir/file3.py", "\windows\__init__.py"]
+        valid_fnames = ["file1.py", "file2.py", "dir/file3.py", r"\windows\__init__.py"]
 
         # Test with filename on a single line
         lines = ["file1.py", "```"]
@@ -45,8 +45,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(eb.find_filename(lines, fence, valid_fnames), "file1.py")
 
         # Test with fuzzy matching
-        lines = ["\windows__init__.py", "```"]
-        self.assertEqual(eb.find_filename(lines, fence, valid_fnames), "\windows\__init__.py")
+        lines = [r"\windows__init__.py", "```"]
+        self.assertEqual(eb.find_filename(lines, fence, valid_fnames), r"\windows\__init__.py")
 
     # fuzzy logic disabled v0.11.2-dev
     def __test_replace_most_similar_chunk(self):


### PR DESCRIPTION
Fixes #1174

- [x] Variable `added_fnames` in [cmd_add](https://github.com/paul-gauthier/aider/blob/483b7ec41fcbf43d37c6319dac7690c6be2e4cb8/aider/commands.py#L555-L633) was only modified, never read
- [x] [expand_subdir()](https://github.com/paul-gauthier/aider/blob/483b7ec41fcbf43d37c6319dac7690c6be2e4cb8/aider/commands.py#L1081-L1090) yielded both `Path`s and `str`s. There are now a bit of hints which I used to verify with Mypy that the types are correct. I also managed to avoid some back-and-forth `str`<->`Path` conversions by changing which ones are stored in some variables.
- [x] correct `type(...) == <SomeClass>` to  `type(...) is <SomeClass>`
- [x] use raw strings when the string contains backslashes (`r"\windows\__init__.py"`) so Python doesn't try to interpret `\w` as a control character