### PR TITLE
fix: Handle new file creation in the same folder

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -442,9 +442,8 @@ def find_original_update_blocks(content, fence=DEFAULT_FENCE, valid_fnames=None)
         # Check for SEARCH/REPLACE blocks
         if line.strip() == HEAD:
             try:
-                # if next line after HEAD is DIVIDER, it's a new file
-                next_line = lines[i + 1]
-                if next_line.strip() == DIVIDER:
+                # if next line after HEAD exists and is DIVIDER, it's a new file
+                if i + 1 < len(lines) and lines[i + 1].strip() == DIVIDER:
                     filename = find_filename(lines[max(0, i - 3) : i], fence, None)
                 else:
                     filename = find_filename(

--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -442,7 +442,15 @@ def find_original_update_blocks(content, fence=DEFAULT_FENCE, valid_fnames=None)
         # Check for SEARCH/REPLACE blocks
         if line.strip() == HEAD:
             try:
-                filename = find_filename(lines[max(0, i - 3) : i], fence, valid_fnames)
+                # if next line after HEAD is DIVIDER, it's a new file
+                next_line = lines[i + 1]
+                if next_line.strip() == DIVIDER:
+                    filename = find_filename(lines[max(0, i - 3) : i], fence, None)
+                else:
+                    filename = find_filename(
+                        lines[max(0, i - 3) : i], fence, valid_fnames
+                    )
+
                 if not filename:
                     if current_filename:
                         filename = current_filename

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -456,6 +456,43 @@ Hope you like it!
             ],
         )
 
+    def test_new_file_created_in_same_folder(self):
+        edit = """
+Here's the change:
+
+path/to/a/file2.txt
+```python
+<<<<<<< SEARCH
+=======
+three
+>>>>>>> REPLACE
+```
+
+another change
+
+path/to/a/file1.txt
+```python
+<<<<<<< SEARCH
+one
+=======
+two
+>>>>>>> REPLACE
+```
+
+Hope you like it!
+"""
+
+        edits = list(
+            eb.find_original_update_blocks(edit, valid_fnames=["path/to/a/file1.txt"])
+        )
+        self.assertEqual(
+            edits,
+            [
+                ("path/to/a/file2.txt", "", "three\n"),
+                ("path/to/a/file1.txt", "one\n", "two\n"),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a fix for https://github.com/paul-gauthier/aider/issues/1222. Currently, if you have an existing file and Aider tries to create a file with similar name, the new file doesn't get created since it's fuzzy-matched to an existing file [here](https://github.com/paul-gauthier/aider/blob/301c4265b76a5b8c4a939acb59314e091cacebec/aider/coders/editblock_coder.py#L532-L535)

This PR checks if edit block tries to create a new file and if so it passes `None` as `valid_fnames`