### PR TITLE
fix: handle file paths outside project directory in RepoMap

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -307,9 +307,18 @@ class RepoMap:
             if progress and not showing_bar:
                 progress()
 
-            if not Path(fname).is_file():
+            abs_fname = os.path.abspath(fname)
+            if not abs_fname.startswith(self.root):
                 if fname not in self.warned_files:
-                    if Path(fname).exists():
+                    self.io.tool_error(
+                        f"Repo-map can't include {fname}, it is outside the project directory"
+                    )
+                self.warned_files.add(fname)
+                continue
+
+            if not os.path.isfile(abs_fname):
+                if fname not in self.warned_files:
+                    if os.path.exists(abs_fname):
                         self.io.tool_error(
                             f"Repo-map can't include {fname}, it is not a normal file"
                         )


### PR DESCRIPTION
fix #1317

aider about this patch:

---

These changes implement the modifications we discussed earlier:

 1 We've added the import os statement at the beginning of the file.

 2 In the get_ranked_tags method, we now use os.path.abspath() to get the absolute path of each file.

 3 We check if the absolute path starts with self.root (the project directory) before attempting to access it.

 4 We use os.path.isfile() instead of Path(fname).is_file() to check if the path is a file.

These modifications should prevent aider from attempting to access files outside the project directory, including those that start with "/root/". This should resolve the PermissionError issue while still allowing aider to process all relevant files within the project.

---
