### PR TITLE
Add --list-models alias for --models

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -121,7 +121,7 @@ def get_parser(default_config_files, git_root):
     ##########
     group = parser.add_argument_group("Model Settings")
     group.add_argument(
-        "--models",
+        "--models", "--list-models",
         metavar="MODEL",
         help="List known models which match the (partial) MODEL name",
     )

--- a/aider/website/docs/llms/anthropic.md
+++ b/aider/website/docs/llms/anthropic.md
@@ -26,7 +26,7 @@ aider
 aider --opus
 
 # List models available from Anthropic
-aider --models anthropic/
+aider --list-models anthropic/
 ```
 
 {: .tip }

--- a/aider/website/docs/llms/azure.md
+++ b/aider/website/docs/llms/azure.md
@@ -24,7 +24,7 @@ setx AZURE_API_BASE https://myendpt.openai.azure.com
 aider --model azure/<your_deployment_name>
 
 # List models available from Azure
-aider --models azure/
+aider --list-models azure/
 ```
 
 Note that aider will also use environment variables

--- a/aider/website/docs/llms/bedrock.md
+++ b/aider/website/docs/llms/bedrock.md
@@ -54,7 +54,7 @@ aider --model bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0
 To see some models available via Bedrock, run:
 
 ```
-aider --models bedrock/
+aider --list-models bedrock/
 ```
 
 Make sure you have access to these models in your AWS account before attempting to use them with Aider.

--- a/aider/website/docs/llms/cohere.md
+++ b/aider/website/docs/llms/cohere.md
@@ -21,5 +21,5 @@ setx   COHERE_API_KEY <key> # Windows, restart shell after setx
 aider --model command-r-plus
 
 # List models available from Cohere
-aider --models cohere_chat/
+aider --list-models cohere_chat/
 ```

--- a/aider/website/docs/llms/gemini.md
+++ b/aider/website/docs/llms/gemini.md
@@ -20,6 +20,6 @@ setx   GEMINI_API_KEY <key> # Windows, restart shell after setx
 aider --model gemini/gemini-1.5-pro-latest
 
 # List models available from Gemini
-aider --models gemini/
+aider --list-models gemini/
 ```
 

--- a/aider/website/docs/llms/groq.md
+++ b/aider/website/docs/llms/groq.md
@@ -21,7 +21,7 @@ setx   GROQ_API_KEY <key> # Windows, restart shell after setx
 aider --model groq/llama3-70b-8192
 
 # List models available from Groq
-aider --models groq/
+aider --list-models groq/
 ```
 
 

--- a/aider/website/docs/llms/openai.md
+++ b/aider/website/docs/llms/openai.md
@@ -29,7 +29,7 @@ aider --4-turbo
 aider --35-turbo
 
 # List models available from OpenAI
-aider --models openai/
+aider --list-models openai/
 ```
 
 You can use `aider --model <model-name>` to use any other OpenAI model.

--- a/aider/website/docs/llms/openrouter.md
+++ b/aider/website/docs/llms/openrouter.md
@@ -18,7 +18,7 @@ setx   OPENROUTER_API_KEY <key> # Windows, restart shell after setx
 aider --model openrouter/<provider>/<model>
 
 # List models available from OpenRouter
-aider --models openrouter/
+aider --list-models openrouter/
 ```
 
 In particular, many aider users access Sonnet via OpenRouter:

--- a/aider/website/docs/llms/other.md
+++ b/aider/website/docs/llms/other.md
@@ -9,14 +9,14 @@ Aider uses the [litellm](https://docs.litellm.ai/docs/providers) package
 to connect to hundreds of other models.
 You can use `aider --model <model-name>` to use any supported model.
 
-To explore the list of supported models you can run `aider --models <model-name>`
+To explore the list of supported models you can run `aider --list-models <model-name>`
 with a partial model name.
 If the supplied name is not an exact match for a known model, aider will
 return a list of possible matching models.
 For example:
 
 ```
-$ aider --models turbo
+$ aider --list-models turbo
 
 Aider v0.29.3-dev
 Models which match "turbo":


### PR DESCRIPTION
Also replace all occurrences in the documentation to avoid confusion.

For future reference, macOS replace `find`/`sed` call ->
```shell
find . -name "*.md" -type f -exec sed -i '' 's/aider --models/aider --list-models/g' {} +
```

aider prompt to create the alias without knowing anything about the code base:
```
/ask Where do I have to look when I want to give a configuration / command line option an alias, e.g. `--list-models` should be an alias for `--models`? 
```