### PR TITLE
Enable prompt caching for OpenRouter

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -18,7 +18,7 @@ from aider.dump import dump  # noqa: F401
 from aider.llm import litellm
 
 DEFAULT_MODEL_NAME = "gpt-4o"
-ANTHROPIC_BETA_HEADER = "max-tokens-3-5-sonnet-2024-07-15,prompt-caching-2024-07-31"
+ANTHROPIC_BETA_HEADER = "prompt-caching-2024-07-31"
 
 OPENAI_MODELS = """
 gpt-4
@@ -306,10 +306,8 @@ MODEL_SETTINGS = [
         examples_as_sys_msg=True,
         accepts_images=True,
         max_tokens=8192,
-        extra_headers={
-            "anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15",
-        },
         reminder="user",
+        cache_control=True,
     ),
     # Vertex AI Claude models
     # Does not yet support 8k token
@@ -320,6 +318,7 @@ MODEL_SETTINGS = [
         use_repo_map=True,
         examples_as_sys_msg=True,
         accepts_images=True,
+        max_tokens=8192,
         reminder="user",
     ),
     ModelSettings(


### PR DESCRIPTION
Here are some small internal configuration changes for you to consider:

- enable prompt caching on OpenRouter for Sonnet-3.5
	- could also be enabled for Opus, but since it is not for direct API via Anthropic I waited with this change, seems like no one is using that model anyway?
- remove unnecessary `"anthropic-beta"` HTTP header for 8k output since this feature is no longer beta
- OpenRouter do not need any `"anthropic-beta"` HTTP header
- updated Vertex AI `max_tokens` size for Sonnet-3.5 since this feature it is GA and available by default there

Also a `.aider.model.metadata.json` is need for correct cost calculation currently ->
```json
{
  "openrouter/anthropic/claude-3.5-sonnet": {
    "max_tokens": 4096,
    "max_input_tokens": 200000,
    "max_output_tokens": 4096,
    "input_cost_per_token": 0.000003,
    "output_cost_per_token": 0.000015,
    "cache_creation_input_token_cost": 0.00000375,
    "cache_read_input_token_cost": 0.0000003,
    "litellm_provider": "openrouter",
    "mode": "chat",
    "supports_function_calling": true,
    "supports_vision": true,
    "tool_use_system_prompt_tokens": 159,
    "supports_assistant_prefill": true
  }
}
```