### PR TITLE
fix: handle git errors when getting tracked files

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -257,6 +257,9 @@ class GitRepo:
             commit = self.repo.head.commit
         except ValueError:
             commit = None
+        except ANY_GIT_ERROR as err:
+            commit = None
+            self.io.tool_error(f"Unable to get tracked files: {err}")
 
         files = set()
         if commit:


### PR DESCRIPTION
Band-aid fix to reduce issue spam ('gitdb.exc.BadObject').

Rationale: When git returns a bad object error, the underlying git repository is broken (probably due to automatic syncing happening or other outside interference with the `.git` directory structure), there is nothing aider can do about this, sending more issue is points.

We just print an error and in this case do not exit, but just clear the commit and move on. Hopefully the git repository fixes itself (e.g. via the suspected syncing). If this does not work out, we still can switch to exiting later.

fix #1428
fix #1422
fix #1420
fix #1419
fix #1413
fix #1410
fix #1404
fix #1357
fix #1353 
fix #1307