### PR TITLE
feat: Add error handling for ImportError

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -658,7 +658,13 @@ class Model(ModelSettings):
         # https://github.com/BerriAI/litellm/issues/3190
 
         model = self.name
-        res = litellm.validate_environment(model)
+
+        try:
+            res = litellm.validate_environment(model)
+        except ImportError as err:
+            self.io.tool_error("Error while loading necessary module: {err}")
+            sys.exit(1)
+
         if res["keys_in_environment"]:
             return res
         if res["missing_keys"]:

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -389,6 +389,9 @@ class RepoMap:
             ranked = nx.pagerank(G, weight="weight", **pers_args)
         except ZeroDivisionError:
             return []
+        except ImportError as err:
+            self.io.tool_error("Error while loading necessary module: {err}")
+            sys.exit(1)
 
         # distribute the rank from each source node, across all of its out edges
         ranked_definitions = defaultdict(float)

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import sys
 
 import backoff
 
@@ -83,7 +84,11 @@ def send_completion(
 
     # del kwargs['stream']
 
-    res = litellm.completion(**kwargs)
+    try:
+        res = litellm.completion(**kwargs)
+    except ImportError as err:
+        print("Error while loading necessary module: {err}")
+        sys.exit(1)
 
     if not stream and CACHE is not None:
         CACHE[key] = res


### PR DESCRIPTION
More band-aid fixes to reduce issue spam (`ImportError: libstdc++.so.6: cannot open shared object file`)

Rationale: When such an ImportError happens the underlying system (most likely NixOS or similar) is broken, there is nothing aider can do, sending more issues is pointless, so just print an error and exit.

fix #1412 
fix #1411 
fix #1407 
fix #1405 
fix #1372
fix #1371 
fix #1364 
fix #1333 
