### PR TITLE
fix: handle OSError when executing lint command

### DIFF
--- a/aider/linter.py
+++ b/aider/linter.py
@@ -46,14 +46,18 @@ class Linter:
         cmd += " " + rel_fname
         cmd = cmd.split()
 
-        process = subprocess.Popen(
-            cmd,
-            cwd=self.root,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            encoding=self.encoding,
-            errors="replace",
-        )
+        try:
+            process = subprocess.Popen(
+                cmd,
+                cwd=self.root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                encoding=self.encoding,
+                errors="replace",
+            )
+        except OSError as err:
+            print(f"Unable to execute lint command: {err}")
+            return
         stdout, _ = process.communicate()
         errors = stdout
         if process.returncode == 0:


### PR DESCRIPTION
Show a nice error message instead of crashing if the lint command cannot be executed for some reason.

fix #1376 