### PR TITLE
chore: update .gitignore to exclude venv and tmp.benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ _site
 .jekyll-cache/
 .jekyll-metadata
 aider/__version__.py
+venv
+tmp.benchmarks


### PR DESCRIPTION
It is a bit annoying that the tmp.benchmarks folder and the venv do not get ignored.

Please consider ignoring these folders, currently switching to the main branch makes git explode with those folders, in VSCode (and on the command line).
