### PR TITLE
fix: remove redundant output message

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1891,7 +1891,6 @@ class Coder:
                     message=commit_message,
                 )
 
-            self.io.tool_output("No changes made to git tracked files.")
             return self.gpt_prompts.files_content_gpt_no_edits
         except ANY_GIT_ERROR as err:
             self.io.tool_error(f"Unable to commit: {str(err)}")


### PR DESCRIPTION
This removes the IMHO redundant and only confusing
```
No changes made to git tracked files.
```
messages.

Those gets displayed right after every commit, which is kinda irritating, as changes clearly have been made.