### PR TITLE
feat: add warning for 'quit' input to use '/quit' instead

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -56,6 +56,19 @@ class Commands:
         self.voice_language = voice_language
 
         self.help = None
+        self.hidden_commands = set()  # New attribute to store hidden commands
+
+        # Add hidden aliases for quit
+        self.hidden_commands.add("/q")
+        self.hidden_commands.add("/exit")
+        self.hidden_commands.add("/bye")
+        self.hidden_commands.add("/goodbye")
+
+        # Create hidden alias methods
+        self.cmd_q = self.cmd_quit
+        self.cmd_exit = self.cmd_quit
+        self.cmd_bye = self.cmd_quit
+        self.cmd_goodbye = self.cmd_quit
 
     def cmd_model(self, args):
         "Switch to a new LLM"
@@ -180,7 +193,8 @@ class Commands:
                 continue
             cmd = attr[4:]
             cmd = cmd.replace("_", "-")
-            commands.append("/" + cmd)
+            if f"/{cmd}" not in self.hidden_commands:  # Only add if not hidden
+                commands.append("/" + cmd)
 
         return commands
 
@@ -203,9 +217,9 @@ class Commands:
             return
 
         first_word = words[0]
-        rest_inp = inp[len(words[0]) :].strip()
+        rest_inp = inp[len(words[0]):].strip()
 
-        all_commands = self.get_commands()
+        all_commands = self.get_commands() + list(self.hidden_commands)
         matching_commands = [cmd for cmd in all_commands if cmd.startswith(first_word)]
         return matching_commands, first_word, rest_inp
 
@@ -827,11 +841,6 @@ class Commands:
     def cmd_quit(self, args):
         "Exit the application"
         sys.exit()
-
-    cmd_q = cmd_quit
-    cmd_exit = cmd_quit
-    cmd_bye = cmd_quit
-    cmd_goodbye = cmd_quit
 
     def cmd_ls(self, args):
         "List all known files and indicate which are included in the chat session"

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -824,13 +824,14 @@ class Commands:
 
             return msg
 
-    def cmd_exit(self, args):
-        "Exit the application"
-        sys.exit()
-
     def cmd_quit(self, args):
         "Exit the application"
         sys.exit()
+
+    cmd_q = cmd_quit
+    cmd_exit = cmd_quit
+    cmd_bye = cmd_quit
+    cmd_goodbye = cmd_quit
 
     def cmd_ls(self, args):
         "List all known files and indicate which are included in the chat session"

--- a/aider/io.py
+++ b/aider/io.py
@@ -376,11 +376,12 @@ class InputOutput:
                 inp = line
                 break
 
-            if self.check_quit_command(inp):
-                continue
-
         print()
         self.user_input(inp)
+
+        if self.check_quit_command(inp):
+            return "/quit"  # Return "/quit" to indicate that the user wants to exit
+
         return inp
 
     def check_quit_command(self, inp):

--- a/aider/io.py
+++ b/aider/io.py
@@ -380,7 +380,7 @@ class InputOutput:
         self.user_input(inp)
 
         if self.check_quit_command(inp):
-            return "/quit"  # Return "/quit" to indicate that the user wants to exit
+            return self.get_input(root, rel_fnames, addable_rel_fnames, commands, abs_read_only_fnames, edit_format)  # Prompt again
 
         return inp
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -379,16 +379,15 @@ class InputOutput:
         print()
         self.user_input(inp)
 
-        if self.check_quit_command(inp):
+        if self.is_quit_command(inp):
+            self.tool_warning(f'To exit aider, please use the "/quit" command instead of "{inp}".')
             return self.get_input(root, rel_fnames, addable_rel_fnames, commands, abs_read_only_fnames, edit_format)  # Prompt again
 
         return inp
 
-    def check_quit_command(self, inp):
-        if inp.strip().lower() == "quit":
-            self.tool_warning('To exit aider, please use the "/quit" command instead of "quit".')
-            return True
-        return False
+    def is_quit_command(self, inp):
+        quit_commands = ['q', 'quit', 'exit', 'bye', 'goodbye']
+        return inp.strip().lower() in quit_commands
 
     def add_to_input_history(self, inp):
         if not self.input_history_file:

--- a/aider/io.py
+++ b/aider/io.py
@@ -376,9 +376,18 @@ class InputOutput:
                 inp = line
                 break
 
+            if self.check_quit_command(inp):
+                continue
+
         print()
         self.user_input(inp)
         return inp
+
+    def check_quit_command(self, inp):
+        if inp.strip().lower() == "quit":
+            self.tool_warning('To exit aider, please use the "/quit" command instead of "quit".')
+            return True
+        return False
 
     def add_to_input_history(self, inp):
         if not self.input_history_file:

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -387,6 +387,35 @@ class TestCommands(TestCase):
 
             self.assertIn(str(fname.resolve()), coder.abs_fnames)
 
+    def test_hidden_quit_commands(self):
+        io = InputOutput(pretty=False, yes=False)
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+        
+        # Check that hidden commands are not in the visible command list
+        visible_commands = commands.get_commands()
+        self.assertIn("/quit", visible_commands)
+        self.assertNotIn("/q", visible_commands)
+        self.assertNotIn("/exit", visible_commands)
+        self.assertNotIn("/bye", visible_commands)
+        self.assertNotIn("/goodbye", visible_commands)
+        
+        # Check that hidden commands are recognized and treated as quit
+        for cmd in ["/q", "/exit", "/bye", "/goodbye", "/quit"]:
+            with self.assertRaises(SystemExit):
+                commands.run(cmd)
+
+        # Check that partial matches work for visible and hidden commands
+        matching_commands = commands.matching_commands("/q")
+        self.assertIn("/q", matching_commands[0])
+        self.assertIn("/quit", matching_commands[0])
+
+        # Check that the aliases are properly set up
+        self.assertEqual(commands.cmd_q, commands.cmd_quit)
+        self.assertEqual(commands.cmd_exit, commands.cmd_quit)
+        self.assertEqual(commands.cmd_bye, commands.cmd_quit)
+        self.assertEqual(commands.cmd_goodbye, commands.cmd_quit)
+
     def test_cmd_tokens_output(self):
         with GitTemporaryDirectory() as repo_dir:
             # Create a small repository with a few files

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -391,7 +391,7 @@ class TestCommands(TestCase):
         io = InputOutput(pretty=False, yes=False)
         coder = Coder.create(self.GPT35, None, io)
         commands = Commands(io, coder)
-        
+
         # Check that hidden commands are not in the visible command list
         visible_commands = commands.get_commands()
         self.assertIn("/quit", visible_commands)
@@ -399,7 +399,7 @@ class TestCommands(TestCase):
         self.assertNotIn("/exit", visible_commands)
         self.assertNotIn("/bye", visible_commands)
         self.assertNotIn("/goodbye", visible_commands)
-        
+
         # Check that hidden commands are recognized and treated as quit
         for cmd in ["/q", "/exit", "/bye", "/goodbye", "/quit"]:
             with self.assertRaises(SystemExit):

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -213,20 +213,19 @@ class TestInputOutput(unittest.TestCase):
             # Check that the result is "hello"
             self.assertEqual(result, "hello")
 
-    def test_check_quit_command(self):
+    def test_is_quit_command(self):
         io = InputOutput(pretty=False)
         
-        # Test with "quit" input
-        self.assertTrue(io.check_quit_command("quit"))
-        
-        # Test with "QUIT" input (case-insensitive)
-        self.assertTrue(io.check_quit_command("QUIT"))
-        
-        # Test with "quit " input (with whitespace)
-        self.assertTrue(io.check_quit_command("quit "))
+        # Test with various quit commands
+        quit_commands = ['q', 'quit', 'exit', 'bye', 'goodbye']
+        for cmd in quit_commands:
+            self.assertTrue(io.is_quit_command(cmd), f"Failed for '{cmd}'")
+            self.assertTrue(io.is_quit_command(cmd.upper()), f"Failed for '{cmd.upper()}'")
+            self.assertTrue(io.is_quit_command(f" {cmd} "), f"Failed for ' {cmd} '")
         
         # Test with non-quit input
-        self.assertFalse(io.check_quit_command("hello"))
+        self.assertFalse(io.is_quit_command("hello"))
+        self.assertFalse(io.is_quit_command("quitter"))
 
 
 if __name__ == "__main__":

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -184,12 +184,14 @@ class TestInputOutput(unittest.TestCase):
         addable_rel_fnames = []
         commands = MagicMock()
 
-        with patch.object(io, 'tool_warning') as mock_warning:
+        with patch.object(io, "tool_warning") as mock_warning:
             result = io.get_input(root, rel_fnames, addable_rel_fnames, commands)
-            
+
             # Check that the warning was called
-            mock_warning.assert_called_once_with('To exit aider, please use the "/quit" command instead of "quit".')
-            
+            mock_warning.assert_called_once_with(
+                'To exit aider, please use the "/quit" command instead of "quit".'
+            )
+
             # Check that the result is "/quit"
             self.assertEqual(result, "/quit")
 
@@ -204,25 +206,25 @@ class TestInputOutput(unittest.TestCase):
         addable_rel_fnames = []
         commands = MagicMock()
 
-        with patch.object(io, 'tool_warning') as mock_warning:
+        with patch.object(io, "tool_warning") as mock_warning:
             result = io.get_input(root, rel_fnames, addable_rel_fnames, commands)
-            
+
             # Check that the warning was not called
             mock_warning.assert_not_called()
-            
+
             # Check that the result is "hello"
             self.assertEqual(result, "hello")
 
     def test_is_quit_command(self):
         io = InputOutput(pretty=False)
-        
+
         # Test with various quit commands
-        quit_commands = ['q', 'quit', 'exit', 'bye', 'goodbye']
+        quit_commands = ["q", "quit", "exit", "bye", "goodbye"]
         for cmd in quit_commands:
             self.assertTrue(io.is_quit_command(cmd), f"Failed for '{cmd}'")
             self.assertTrue(io.is_quit_command(cmd.upper()), f"Failed for '{cmd.upper()}'")
             self.assertTrue(io.is_quit_command(f" {cmd} "), f"Failed for ' {cmd} '")
-        
+
         # Test with non-quit input
         self.assertFalse(io.is_quit_command("hello"))
         self.assertFalse(io.is_quit_command("quitter"))

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -193,6 +193,9 @@ class TestInputOutput(unittest.TestCase):
             # Check that the result is "/quit"
             self.assertEqual(result, "/quit")
 
+        # Check that input was called twice
+        self.assertEqual(mock_input.call_count, 2)
+
     @patch("builtins.input", return_value="hello")
     def test_get_input_non_quit(self, mock_input):
         io = InputOutput(pretty=False)

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -176,6 +176,55 @@ class TestInputOutput(unittest.TestCase):
         commands.get_completions.assert_called_once_with("/model")
         commands.matching_commands.assert_called_once_with("/model")
 
+    @patch("builtins.input", side_effect=["quit", "/quit"])
+    def test_get_input_quit_warning(self, mock_input):
+        io = InputOutput(pretty=False)
+        root = ""
+        rel_fnames = []
+        addable_rel_fnames = []
+        commands = MagicMock()
+
+        with patch.object(io, 'tool_warning') as mock_warning:
+            result = io.get_input(root, rel_fnames, addable_rel_fnames, commands)
+            
+            # Check that the warning was called
+            mock_warning.assert_called_once_with('To exit aider, please use the "/quit" command instead of "quit".')
+            
+            # Check that the result is "/quit"
+            self.assertEqual(result, "/quit")
+
+    @patch("builtins.input", return_value="hello")
+    def test_get_input_non_quit(self, mock_input):
+        io = InputOutput(pretty=False)
+        root = ""
+        rel_fnames = []
+        addable_rel_fnames = []
+        commands = MagicMock()
+
+        with patch.object(io, 'tool_warning') as mock_warning:
+            result = io.get_input(root, rel_fnames, addable_rel_fnames, commands)
+            
+            # Check that the warning was not called
+            mock_warning.assert_not_called()
+            
+            # Check that the result is "hello"
+            self.assertEqual(result, "hello")
+
+    def test_check_quit_command(self):
+        io = InputOutput(pretty=False)
+        
+        # Test with "quit" input
+        self.assertTrue(io.check_quit_command("quit"))
+        
+        # Test with "QUIT" input (case-insensitive)
+        self.assertTrue(io.check_quit_command("QUIT"))
+        
+        # Test with "quit " input (with whitespace)
+        self.assertTrue(io.check_quit_command("quit "))
+        
+        # Test with non-quit input
+        self.assertFalse(io.check_quit_command("hello"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -227,23 +227,6 @@ class TestInputOutput(unittest.TestCase):
         self.assertFalse(io.is_quit_command("hello"))
         self.assertFalse(io.is_quit_command("quitter"))
 
-    def test_hidden_quit_commands(self):
-        from aider.commands import Commands
-        
-        io = InputOutput(pretty=False)
-        commands = Commands(io, None)
-        
-        visible_commands = commands.get_commands()
-        self.assertIn("/quit", visible_commands)
-        self.assertNotIn("/q", visible_commands)
-        self.assertNotIn("/exit", visible_commands)
-        self.assertNotIn("/bye", visible_commands)
-        self.assertNotIn("/goodbye", visible_commands)
-        
-        all_matching = commands.matching_commands("/q")[0]
-        self.assertIn("/q", all_matching)
-        self.assertIn("/quit", all_matching)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -227,6 +227,23 @@ class TestInputOutput(unittest.TestCase):
         self.assertFalse(io.is_quit_command("hello"))
         self.assertFalse(io.is_quit_command("quitter"))
 
+    def test_hidden_quit_commands(self):
+        from aider.commands import Commands
+        
+        io = InputOutput(pretty=False)
+        commands = Commands(io, None)
+        
+        visible_commands = commands.get_commands()
+        self.assertIn("/quit", visible_commands)
+        self.assertNotIn("/q", visible_commands)
+        self.assertNotIn("/exit", visible_commands)
+        self.assertNotIn("/bye", visible_commands)
+        self.assertNotIn("/goodbye", visible_commands)
+        
+        all_matching = commands.matching_commands("/q")[0]
+        self.assertIn("/q", all_matching)
+        self.assertIn("/quit", all_matching)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This also introduces new hidden command aliases `/q`, `/exit`, `/bye`, `/goodbye` for `/quit`. These aliases/hidden commands will not show up in autocomplete.

Typing these commands without `/` and pressing enter will now produce a warning.

<img width="566" alt="quit" src="https://github.com/user-attachments/assets/94224c30-ac72-40d5-b1d6-3722fd3e4f3f">

The reason to not instantly quit is to not accidentally lose the context/chat.

fix #1441 