### PR TITLE
feat: adding support for diff mode using openai o1-preview and o1-mini

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -90,6 +90,22 @@ def get_parser(default_config_files, git_root):
         const=gpt_4o_mini_model,
         help=f"Use {gpt_4o_mini_model} model for the main chat",
     )
+    o1_preview_model = "o1-preview"
+    group.add_argument(
+        "--o1",
+        action="store_const",
+        dest="model",
+        const=o1_preview_model,
+        help=f"Use {o1_preview_model} model for the main chat",
+    )
+    o1_mini_model = "o1-mini"
+    group.add_argument(
+        "--o1-mini",
+        action="store_const",
+        dest="model",
+        const=o1_mini_model,
+        help=f"Use {o1_mini_model} model for the main chat",
+    )
     gpt_4_turbo_model = "gpt-4-1106-preview"
     group.add_argument(
         "--4-turbo",

--- a/aider/models.py
+++ b/aider/models.py
@@ -21,6 +21,10 @@ DEFAULT_MODEL_NAME = "gpt-4o"
 ANTHROPIC_BETA_HEADER = "prompt-caching-2024-07-31"
 
 OPENAI_MODELS = """
+o1-preview
+o1-preview-2024-09-12
+o1-mini
+o1-mini-2024-09-12
 gpt-4
 gpt-4o
 gpt-4o-2024-05-13
@@ -233,6 +237,25 @@ MODEL_SETTINGS = [
         "diff",
         weak_model_name="gpt-4o-mini",
         use_repo_map=True,
+        reminder="sys",
+    ),
+    # o1-preview
+    ModelSettings(
+        "o1-preview",
+        "diff",
+        weak_model_name="o1-mini",
+        use_repo_map=True,
+        accepts_images=False,
+        lazy=True,
+        reminder="sys",
+    ),
+    ModelSettings(
+        "o1-mini",
+        "diff",
+        weak_model_name="o1-mini",
+        use_repo_map=True,
+        accepts_images=False,
+        lazy=True,
         reminder="sys",
     ),
     # Claude

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -27,7 +27,7 @@ def retry_exceptions():
         litellm.exceptions.ServiceUnavailableError,
         litellm.exceptions.Timeout,
         litellm.exceptions.InternalServerError,
-        litellm.llms.anthropic.AnthropicError,
+        litellm.llms.anthropic.chat.AnthropicError,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ jsonschema==4.23.0
     #   litellm
 jsonschema-specifications==2023.12.1
     # via jsonschema
-litellm==1.44.7
+litellm==1.44.27
     # via -r requirements/requirements.in
 markdown-it-py==3.0.0
     # via rich

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -28,6 +28,12 @@ class TestModels(unittest.TestCase):
         model = Model("gpt-4-0613")
         self.assertEqual(model.info["max_input_tokens"], 8 * 1024)
 
+        model = Model("o1-preview")
+        self.assertEqual(model.info["max_input_tokens"], 128000)
+
+        model = Model("o1-mini")
+        self.assertEqual(model.info["max_input_tokens"], 128000)
+
     @patch("os.environ")
     def test_sanity_check_model_all_set(self, mock_environ):
         mock_environ.get.return_value = "dummy_value"


### PR DESCRIPTION
This PR request introduces support for diff mode using the newest OpenAI models: o1-preview and o1-mini.

### Main changes include:

 - Update litellm to use the version with support to the model
 - Changes in the args file to support --o1 and --o1-preview shorthand arguments
 - Changes in the models file
 - Updating unit tests
 
### Important

I would appreciate if someone with OpenAI account at Tier 5 could test it before merging. Unfortunately I got stuck at this step because my account is Tier 4 and o1-preview is only available for 5 onwards.

### Steps for testing

Just run:
- `aider --o1`
- and
- `aider --o1-mini`


Fixes https://github.com/paul-gauthier/aider/issues/1511