### PR TITLE
fix: remove deepseek/ prefix from model names

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -109,7 +109,7 @@ def get_parser(default_config_files, git_root):
         const=gpt_3_model_name,
         help=f"Use {gpt_3_model_name} model for the main chat",
     )
-    deepseek_model = "deepseek/deepseek-coder"
+    deepseek_model = "deepseek-chat"
     group.add_argument(
         "--deepseek",
         action="store_const",

--- a/aider/models.py
+++ b/aider/models.py
@@ -396,7 +396,7 @@ MODEL_SETTINGS = [
         send_undo_reply=False,
     ),
     ModelSettings(
-        "deepseek/deepseek-chat",
+        "deepseek-chat",
         "diff",
         use_repo_map=True,
         examples_as_sys_msg=True,
@@ -404,7 +404,7 @@ MODEL_SETTINGS = [
         max_tokens=8192,
     ),
     ModelSettings(
-        "deepseek/deepseek-coder",
+        "deepseek-coder",
         "diff",
         use_repo_map=True,
         examples_as_sys_msg=True,


### PR DESCRIPTION
This small patch aligns naming with the LiteLLM database and fixes autocomplete problems.

Parts of the documentation now needs to be updated as `deepseek/deepseek-*` seem to be popular example models.