### PR TITLE
feat: customizable timeout duration

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -169,6 +169,13 @@ def get_parser(default_config_files, git_root):
         help="Specify a file with context window and costs for unknown models",
     )
     group.add_argument(
+        "--request-timeout",
+        type=int,
+        metavar="REQUEST_TIMEOUT",
+        default=600,
+        help="Set a custom timeout in seconds for requests to the model"
+    )
+    group.add_argument(
         "--verify-ssl",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/main.py
+++ b/aider/main.py
@@ -369,10 +369,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     # Parse again to include any arguments that might have been defined in .env
     args = parser.parse_args(argv)
 
+    litellm._load_litellm()
+    litellm.request_timeout = args.request_timeout
+
     if not args.verify_ssl:
         import httpx
-
-        litellm._load_litellm()
         litellm._lazy_module.client_session = httpx.Client(verify=False)
 
     if args.dark_mode:

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -84,7 +84,8 @@ def send_completion(
 
     # del kwargs['stream']
 
-    res = litellm.completion(**kwargs)
+    request_timeout = litellm.request_timeout
+    res = litellm.completion(**kwargs, timeout=request_timeout)
 
     if not stream and CACHE is not None:
         CACHE[key] = res

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -168,6 +168,10 @@ Specify a file with context window and costs for unknown models
 Default: .aider.model.metadata.json  
 Environment variable: `AIDER_MODEL_METADATA_FILE`  
 
+### `--request-timeout REQUEST_TIMEOUT`
+Set a custom timeout in seconds for requests to the model (default: 600)
+Environment variable: `AIDER_REQUEST_TIMEOUT`
+
 ### `--verify-ssl`
 Verify the SSL cert when connecting to models (default: True)  
 Default: True  

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -168,10 +168,6 @@ Specify a file with context window and costs for unknown models
 Default: .aider.model.metadata.json  
 Environment variable: `AIDER_MODEL_METADATA_FILE`  
 
-### `--request-timeout REQUEST_TIMEOUT`
-Set a custom timeout in seconds for requests to the model (default: 600)
-Environment variable: `AIDER_REQUEST_TIMEOUT`
-
 ### `--verify-ssl`
 Verify the SSL cert when connecting to models (default: True)  
 Default: True  


### PR DESCRIPTION
When using local LLMs can be useful to set a custom timeout for litellm HTTP calls to the model. The default being 10 minutes.