### PR TITLE
feat: add `extra_body`field and use in model settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _site
 .jekyll-cache/
 .jekyll-metadata
 aider/__version__.py
+.venv/

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1396,6 +1396,7 @@ class Coder:
                 self.stream,
                 temp,
                 extra_headers=model.extra_headers,
+                extra_body=model.extra_body,
                 max_tokens=model.max_tokens,
             )
             self.chat_completion_call_hashes.append(hash_object.hexdigest())

--- a/aider/models.py
+++ b/aider/models.py
@@ -74,6 +74,7 @@ class ModelSettings:
     reminder: str = "user"
     examples_as_sys_msg: bool = False
     extra_headers: Optional[dict] = None
+    extra_body: Optional[dict] = None
     max_tokens: Optional[int] = None
     cache_control: bool = False
     caches_by_default: bool = False

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -53,6 +53,7 @@ def send_completion(
     stream,
     temperature=0,
     extra_headers=None,
+    extra_body=None,
     max_tokens=None,
 ):
     from aider.llm import litellm
@@ -71,6 +72,8 @@ def send_completion(
         kwargs["tool_choice"] = {"type": "function", "function": {"name": function["name"]}}
     if extra_headers is not None:
         kwargs["extra_headers"] = extra_headers
+    if extra_body is not None:
+        kwargs["extra_body"] = extra_body
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
 
@@ -103,6 +106,8 @@ def simple_send_with_retries(model_name, messages, extra_headers=None):
         }
         if extra_headers is not None:
             kwargs["extra_headers"] = extra_headers
+        if extra_body is not None:
+            kwargs["extra_body"] = extra_body
 
         _hash, response = send_completion(**kwargs)
         return response.choices[0].message.content

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -96,7 +96,7 @@ def send_completion(
 
 
 @lazy_litellm_retry_decorator
-def simple_send_with_retries(model_name, messages, extra_headers=None):
+def simple_send_with_retries(model_name, messages, extra_headers=None, extra_body=None):
     try:
         kwargs = {
             "model_name": model_name,


### PR DESCRIPTION
resolved: #1583 

The `extra_body` field is a parameter used by the `openai` provider.

Since `litellm` also uses this field to additionally transmit `request body`, I added a function so that `aider` can also utilize the `extra_body` field.

The `openrouter` provider also supports various functions through the additional field of `request body`, so we added the function.

The following is how to use it in model settings.
```yaml
# .aider.model.settings.yml
- name: "openrouter/<YOUR_MODEL>"
  edit_format: "whole"
  use_repo_map: true
  extra_body:
    provider:
      order:
      - Azure
      allow_fallbacks: false
```