### PR TITLE
feat: rename /clipboard to /paste

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1035,8 +1035,8 @@ class Commands:
 
         return text
 
-    def cmd_clipboard(self, args):
-        "Add image/text from the clipboard to the chat (optionally provide a name for the image)"
+    def cmd_paste(self, args):
+        "Paste image/text from the clipboard into the chat (optionally provide a name for the image)"
         try:
             # Check for image first
             image = ImageGrab.grabclipboard()


### PR DESCRIPTION
This accomplishes two things:
1. It is now clear that /paste adds to chat from clipboard, instead of the other way around
2. /clear is now the only command starting with `cl`, making it easier to complete unambiguously