### PR TITLE
During repo_map, treat read-only files as other_files, not chat_files

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -584,8 +584,7 @@ class Coder:
         mentioned_fnames.update(self.get_ident_filename_matches(mentioned_idents))
 
         all_abs_files = set(self.get_all_abs_files())
-        repo_abs_read_only_fnames = set(self.abs_read_only_fnames) & all_abs_files
-        chat_files = set(self.abs_fnames) | repo_abs_read_only_fnames
+        chat_files = set(self.abs_fnames)
         other_files = all_abs_files - chat_files
 
         repo_content = self.repo_map.get_repo_map(


### PR DESCRIPTION
Resolves #1536, where adding a read-only file not referenced elsewhere in the codebase would result in an empty repo map.

I'm not entirely sure why read-only files were explicitly being treated as chat_files for the purposes of repo_map, but this reverses that decision in the code.