### PR TITLE
feat: Add --tool-completion-color for styling command completion

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -324,6 +324,11 @@ def get_parser(default_config_files, git_root):
         help="Set the color for tool warning messages (default: #FFA500)",
     )
     group.add_argument(
+        "--tool-completion-color",
+        default=None,
+        help="Set the colors for tool command completion (default: None)",
+    )
+    group.add_argument(
         "--assistant-output-color",
         default="#0088ff",
         help="Set the color for assistant output (default: #0088ff)",

--- a/aider/main.py
+++ b/aider/main.py
@@ -405,6 +405,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             user_input_color=args.user_input_color,
             tool_output_color=args.tool_output_color,
             tool_error_color=args.tool_error_color,
+            tool_completion_color=args.tool_completion_color,
             assistant_output_color=args.assistant_output_color,
             code_theme=args.code_theme,
             dry_run=args.dry_run,
@@ -565,7 +566,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         return 1
 
     commands = Commands(
-        io, None, verify_ssl=args.verify_ssl, args=args, parser=parser, verbose=args.verbose
+        io,
+        None,
+        verify_ssl=args.verify_ssl,
+        args=args,
+        parser=parser,
+        verbose=args.verbose,
     )
 
     summarizer = ChatSummary(


### PR DESCRIPTION
I had a issue with styling command completion as it's difficult to read for me.

![image](https://github.com/user-attachments/assets/ee98344b-5fb6-4a4f-8caa-45f7eaa446b1)

Note that I haven't updated the documentation, I am not aware of the guidelines. Not sure if I should edit them directly.