### PR TITLE
feat: Option to compress audio files by ~90%

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -486,6 +486,13 @@ def get_parser(default_config_files, git_root):
         default=False,
     )
     group.add_argument(
+        "--voice-format",
+        metavar="VOICE_FORMAT",
+        default="wav",
+        choices=["wav", "mp3", "webm"],
+        help="Audio format for voice recording (default: wav). webm and mp3 require ffmpeg",
+    )
+    group.add_argument(
         "--voice-language",
         metavar="VOICE_LANGUAGE",
         default="en",

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -997,7 +997,7 @@ class Commands:
                 self.io.tool_error("To use /voice you must provide an OpenAI API key.")
                 return
             try:
-                self.voice = voice.Voice()
+                self.voice = voice.Voice(audio_format=self.args.voice_format)
             except voice.SoundDeviceError:
                 self.io.tool_error(
                     "Unable to import `sounddevice` and/or `soundfile`, is portaudio installed?"

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -242,6 +242,9 @@
 ## Use VI editing mode in the terminal (default: False)
 #vim: false
 
+## Specify the audio format for voice recording (default: wav). webm and mp3 require ffmpeg
+#voice-format: wav
+
 ## Specify the language for voice using ISO 639-1 code (default: auto)
 #voice-language: en
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,6 +144,8 @@ pydantic==2.9.2
     #   openai
 pydantic-core==2.23.4
     # via pydantic
+pydub==0.25.1
+    # via -r requirements/requirements.in
 pyflakes==3.2.0
     # via flake8
 pygments==2.18.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,6 +2,7 @@
 #    pip-compile requirements.in --upgrade
 #
 
+pydub
 configargparse
 GitPython
 jsonschema


### PR DESCRIPTION
Add option to reduce bandwidth (and potentially latency) by converting voice recordings (wav) into a compressed audio format (webm or mp3).

Default behaviour is unchanged.

> File uploads are currently limited to 25 MB and the following input file
> types are supported: mp3, mp4, mpeg, mpga, m4a, wav, and webm.
>
> - https://platform.openai.com/docs/guides/speech-to-text

I'm a big fan of using Aider voice and noticed while using my cellphone's internet connection that it was using 10MB per minute. This reduced that to ~1MB per minute which sped up responses and reduced the rate at which I was chewing through my monthly traffic allowance.