### PR TITLE
fix: improve automatic upgrade flow for aider

### DIFF
--- a/aider/config.py
+++ b/aider/config.py
@@ -1,0 +1,6 @@
+class Config:
+    args = None
+
+    @classmethod
+    def initialize(cls, parsed_args):
+        cls.args = parsed_args

--- a/aider/main.py
+++ b/aider/main.py
@@ -15,6 +15,7 @@ from aider import __version__, models, utils
 from aider.args import get_parser
 from aider.coders import Coder
 from aider.commands import Commands, SwitchCoder
+from aider.config import Config
 from aider.format_settings import format_settings, scrub_sensitive_info
 from aider.history import ChatSummary
 from aider.io import InputOutput
@@ -374,6 +375,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     # Parse again to include any arguments that might have been defined in .env
     args = parser.parse_args(argv)
+
+    # Initialize system wide config object with arguments
+    Config.initialize(args)
 
     if not args.verify_ssl:
         import httpx

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -222,6 +222,15 @@ def get_pip_install(args):
 
 
 def run_install(cmd):
+    """
+    Execute the pip install command and provide real-time feedback.
+
+    Args:
+        cmd (list): The pip install command to execute.
+
+    Returns:
+        tuple: (success: bool, output: str)
+    """
     print()
     print("Installing:", printable_shell_command(cmd))
 
@@ -243,25 +252,22 @@ def run_install(cmd):
             char = process.stdout.read(1)
             if not char:
                 break
-
             output.append(char)
             spinner.step()
 
         spinner.end()
         return_code = process.wait()
-        output = "".join(output)
+        output_str = "".join(output)
 
         if return_code == 0:
-            print("Installation complete.")
-            print()
-            return True, output
+            print("Installation complete.\n")
+            return True, output_str
 
     except subprocess.CalledProcessError as e:
         print(f"\nError running pip install: {e}")
 
     print("\nInstallation failed.\n")
-
-    return False, output
+    return False, "".join(output)
 
 
 class Spinner:

--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -28,37 +28,39 @@ def install_from_main_branch(io):
 
 def install_upgrade(io, latest_version=None):
     """
-    Install the latest version of aider from PyPI.
+    Install the latest version of aider from PyPI or provide Docker upgrade instructions.
+    Exits the application gracefully if the upgrade fails.
     """
-
     if latest_version:
         new_ver_text = f"Newer aider version v{latest_version} is available."
     else:
-        new_ver_text = "Install latest version of aider?"
+        new_ver_text = "Install the latest version of aider?"
 
     docker_image = os.environ.get("AIDER_DOCKER_IMAGE")
     if docker_image:
-        text = f"""
+        upgrade_instructions = f"""
 {new_ver_text} To upgrade, run:
 
     docker pull {docker_image}
 """
-        io.tool_warning(text)
-        return True
+        io.tool_warning(upgrade_instructions)
+        return
 
+    # Attempt to upgrade the main application via pip
     success = utils.check_pip_install_extra(
         io,
-        None,
-        new_ver_text,
-        ["--upgrade", "aider-chat"],
+        module=None,
+        prompt=new_ver_text,
+        pip_install_args=["--upgrade", "aider-chat"],
         self_update=True,
     )
 
     if success:
-        io.tool_output("Re-run aider to use new version.")
+        io.tool_output("Upgrade successful. Re-run aider to use the new version.")
         sys.exit()
-
-    return
+    else:
+        io.tool_error("Failed to upgrade the main application. Exiting.")
+        sys.exit(1)
 
 
 def check_version(io, just_check=False, verbose=False):

--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -14,16 +14,22 @@ VERSION_CHECK_FNAME = Path.home() / ".aider" / "caches" / "versioncheck"
 
 def install_from_main_branch(io):
     """
-    Install the latest version of aider from the main branch of the GitHub repository.
+    Install the latest development version of aider from the main branch of the GitHub repository.
+    Exits the application gracefully if the installation fails.
     """
+    prompt = "Install the development version of aider from the main branch?"
+    pip_install_args = ["--upgrade", "git+https://github.com/paul-gauthier/aider.git"]
 
-    return utils.check_pip_install_extra(
-        io,
-        None,
-        "Install the development version of aider from the main branch?",
-        ["--upgrade", "git+https://github.com/paul-gauthier/aider.git"],
-        self_update=True,
+    success = utils.check_pip_install_extra(
+        io=io, module=None, prompt=prompt, pip_install_args=pip_install_args, self_update=True
     )
+
+    if success:
+        io.tool_output("Development version installed. Re-run aider to use the new version.")
+        sys.exit()
+    else:
+        io.tool_error("Failed to install the development version. Exiting.")
+        sys.exit(1)
 
 
 def install_upgrade(io, latest_version=None):

--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import packaging.version
 
 import aider
-from aider import args, utils
+from aider import utils
+from aider.config import Config
 from aider.dump import dump  # noqa: F401
 
 VERSION_CHECK_FNAME = Path.home() / ".aider" / "caches" / "versioncheck"
@@ -26,11 +27,11 @@ def install_from_main_branch(io):
 
     if success:
         io.tool_output("Development version installed. Re-run aider to use the new version.")
-        if not args.exit:
+        if not Config.args.exit:
             sys.exit()
     else:
         io.tool_error("Failed to install the development version. Exiting.")
-        if not args.exit:
+        if not Config.args.exit:
             sys.exit(1)
 
 
@@ -65,11 +66,11 @@ def install_upgrade(io, latest_version=None):
 
     if success:
         io.tool_output("Upgrade successful. Re-run aider to use the new version.")
-        if not args.exit:
+        if not Config.args.exit:
             sys.exit()
     else:
         io.tool_error("Failed to upgrade the main application. Exiting.")
-        if not args.exit:
+        if not Config.args.exit:
             sys.exit(1)
 
 

--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import packaging.version
 
 import aider
-from aider import utils
+from aider import args, utils
 from aider.dump import dump  # noqa: F401
 
 VERSION_CHECK_FNAME = Path.home() / ".aider" / "caches" / "versioncheck"
@@ -26,10 +26,12 @@ def install_from_main_branch(io):
 
     if success:
         io.tool_output("Development version installed. Re-run aider to use the new version.")
-        sys.exit()
+        if not args.exit:
+            sys.exit()
     else:
         io.tool_error("Failed to install the development version. Exiting.")
-        sys.exit(1)
+        if not args.exit:
+            sys.exit(1)
 
 
 def install_upgrade(io, latest_version=None):
@@ -63,10 +65,12 @@ def install_upgrade(io, latest_version=None):
 
     if success:
         io.tool_output("Upgrade successful. Re-run aider to use the new version.")
-        sys.exit()
+        if not args.exit:
+            sys.exit()
     else:
         io.tool_error("Failed to upgrade the main application. Exiting.")
-        sys.exit(1)
+        if not args.exit:
+            sys.exit(1)
 
 
 def check_version(io, just_check=False, verbose=False):


### PR DESCRIPTION
fix #1687 (in spirit)

- documented installation routine
- assured that the application exits after upgrading and does not continue running
- introduced Config class/module to get access to parsed command line arguments
- only exit app if not `--exit` is set, this is necessary to make tests with `--yes` pass, which seem to auto upgrade aider in some cases, see [example log](https://github.com/paul-gauthier/aider/actions/runs/11010721560/job/30573274393?pr=1688)