### PR TITLE
fix(InputOutput): apply tool warning color

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -412,6 +412,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             output=output,
             user_input_color=args.user_input_color,
             tool_output_color=args.tool_output_color,
+            tool_warning_color=args.tool_warning_color,
             tool_error_color=args.tool_error_color,
             completion_menu_color=args.completion_menu_color,
             completion_menu_bg_color=args.completion_menu_bg_color,


### PR DESCRIPTION
When changing the `tool-warning-color` e.g. in the config file `~/.aider.conf.yml`

```
## Set the color for tool warning messages (default: #FFA500)
tool-warning-color: magenta
```

The setting was not applied

![image](https://github.com/user-attachments/assets/9c70356f-c35c-4fa7-9c74-02b0898dcc2b)

With this change, the setting is used

![image](https://github.com/user-attachments/assets/bd7b3dbf-18f1-44c6-871d-71cb3c163dd5)
