### PR TITLE
fix: handle corrupt help file cache

### DIFF
--- a/aider/help.py
+++ b/aider/help.py
@@ -77,9 +77,8 @@ def get_index():
             )
             index = load_index_from_storage(storage_context)
             return index
-    except JSONDecodeError as err:
-        print(f"Help file cache {dname} is corrupt: {err}")
-        print("Deleting file")
+    except JSONDecodeError:
+        print(f"Error: Corrupted help file cache at {dname}. Deleting and recreating.")
         os.remove(dname)
         # Fall through to create index new
 


### PR DESCRIPTION
fix #1754 

This catches corrupt/unreadable JSON help cache files and deletes those automatically.