### PR TITLE
doc: Add tips for including git history in Aider chat context

### DIFF
--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -106,6 +106,24 @@ The repo map is usually disabled for a good reason.
 
 If you would like to force it on, you can run aider with `--map-tokens 1024`.
 
+## How do I include the git history in the context?
+
+When starting a fresh aider session, you can include recent git history in the chat context. This can be useful for providing the LLM with information about recent changes. To do this:
+
+1. Use the `/run` command with `git diff` to show recent changes:
+   ```
+   /run git diff HEAD~1
+   ```
+   This will include the diff of the last commit in the chat history.
+
+2. To include diffs from multiple commits, increase the number after the tilde:
+   ```
+   /run git diff HEAD~3
+   ```
+   This will show changes from the last three commits.
+
+Remember, the chat history already includes recent changes made during the current session, so this tip is most useful when starting a new aider session and you want to provide context about recent work.
+
 ## How can I run aider locally from source code?
 
 To run the project locally, follow these steps:

--- a/aider/website/docs/usage/tips.md
+++ b/aider/website/docs/usage/tips.md
@@ -71,24 +71,6 @@ and aider will scrape and read it. For example: `Add a submit button like this h
 - Use the [`/read` command](commands.html) to read doc files into the chat from anywhere on your filesystem.
 - If you have coding conventions or standing instructions you want aider to follow, consider using a [conventions file](conventions.html).
 
-## Including git history in the context
-
-When starting a fresh aider session, you can include recent git history in the chat context. This can be useful for providing the LLM with information about recent changes. To do this:
-
-1. Use the `/run` command with `git diff` to show recent changes:
-   ```
-   /run git diff HEAD~1
-   ```
-   This will include the diff of the last commit in the chat history.
-
-2. To include diffs from multiple commits, increase the number after the tilde:
-   ```
-   /run git diff HEAD~3
-   ```
-   This will show changes from the last three commits.
-
-Remember, the chat history already includes recent changes made during the current session, so this tip is most useful when starting a new aider session and you want to provide context about recent work.
-
 ## Interrupting & inputting
 
 Use Control-C to interrupt aider if it isn't providing a useful response. The partial response remains in the conversation, so you can refer to it when you reply with more information or direction.

--- a/aider/website/docs/usage/tips.md
+++ b/aider/website/docs/usage/tips.md
@@ -71,6 +71,24 @@ and aider will scrape and read it. For example: `Add a submit button like this h
 - Use the [`/read` command](commands.html) to read doc files into the chat from anywhere on your filesystem.
 - If you have coding conventions or standing instructions you want aider to follow, consider using a [conventions file](conventions.html).
 
+## Including git history in the context
+
+When starting a fresh aider session, you can include recent git history in the chat context. This can be useful for providing the LLM with information about recent changes. To do this:
+
+1. Use the `/run` command with `git diff` to show recent changes:
+   ```
+   /run git diff HEAD~1
+   ```
+   This will include the diff of the last commit in the chat history.
+
+2. To include diffs from multiple commits, increase the number after the tilde:
+   ```
+   /run git diff HEAD~3
+   ```
+   This will show changes from the last three commits.
+
+Remember, the chat history already includes recent changes made during the current session, so this tip is most useful when starting a new aider session and you want to provide context about recent work.
+
 ## Interrupting & inputting
 
 Use Control-C to interrupt aider if it isn't providing a useful response. The partial response remains in the conversation, so you can refer to it when you reply with more information or direction.


### PR DESCRIPTION
fix #1758 

This adds another section in tips document about how to access past commits when starting aider new.
It may also inspire other creative usages of `/run`.