### PR TITLE
chore: some further junior -> editor renames

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -215,13 +215,13 @@ def get_parser(default_config_files, git_root):
     )
     group.add_argument(
         "--editor-model",
-        metavar="JUNIOR_MODEL",
+        metavar="EDITOR_MODEL",
         default=None,
         help="Specify the model to use for editor tasks (default depends on --model)",
     )
     group.add_argument(
         "--editor-edit-format",
-        metavar="JUNIOR_EDIT_FORMAT",
+        metavar="EDITOR_EDIT_FORMAT",
         default=None,
         help="Specify the edit format for the editor model (default: depends on editor model)",
     )

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -125,8 +125,8 @@ def main(
     graphs: bool = typer.Option(False, "--graphs", help="Generate graphs"),
     model: str = typer.Option("gpt-3.5-turbo", "--model", "-m", help="Model name"),
     edit_format: str = typer.Option(None, "--edit-format", "-e", help="Edit format"),
-    editor_model: str = typer.Option(None, "--editor-model", help="Junior model name"),
-    editor_edit_format: str = typer.Option(None, "--editor-edit-format", help="Junior edit format"),
+    editor_model: str = typer.Option(None, "--editor-model", help="Editor model name"),
+    editor_edit_format: str = typer.Option(None, "--editor-edit-format", help="Editor edit format"),
     replay: str = typer.Option(
         None,
         "--replay",

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -699,7 +699,7 @@ def run_test_real(
         ),
     )
 
-    if edit_format == "senior":
+    if edit_format == "architect":
         results["editor_model"] = main_model.editor_model.name if main_model.editor_model else None
         results["editor_edit_format"] = main_model.editor_edit_format
     dump(results)


### PR DESCRIPTION
Since this help output is a bit confusing, I'd recommend to finalize the junior -> editor renames:
```shell
 $ aider --help | grep -i editor
             [--editor-model JUNIOR_MODEL]
             [--editor-edit-format JUNIOR_EDIT_FORMAT]
  --editor-model JUNIOR_MODEL
                        Specify the model to use for editor tasks (default
                        depends on --model) [env var: AIDER_EDITOR_MODEL]
  --editor-edit-format JUNIOR_EDIT_FORMAT
                        Specify the edit format for the editor model (default:
                        depends on editor model) [env var:
                        AIDER_EDITOR_EDIT_FORMAT]
```
