### PR TITLE
feat: show how much of the raw repo map fits in the token budget

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -355,7 +355,8 @@ class Commands:
             repo_content = self.coder.repo_map.get_repo_map(self.coder.abs_fnames, other_files)
             if repo_content:
                 tokens = self.coder.main_model.token_count(repo_content)
-                res.append((tokens, "repository map", "use --map-tokens to resize"))
+                fit = self.coder.repo_map.fit_percentage
+                res.append((tokens, f"repository map ({fit:.1f}%)", "use --map-tokens to resize"))
 
         fence = "`" * 3
 

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -72,6 +72,7 @@ class RepoMap:
         self.map_cache = {}
         self.map_processing_time = 0
         self.last_map = None
+        self.fit_percentage = None
 
         if self.verbose:
             self.io.tool_output(
@@ -535,6 +536,8 @@ class RepoMap:
         best_tree_tokens = 0
 
         chat_rel_fnames = set(self.get_rel_fname(fname) for fname in chat_fnames)
+        full_tree = self.to_tree(ranked_tags, chat_rel_fnames)
+        total_tokens = self.token_count(full_tree)
 
         self.tree_cache = dict()
 
@@ -564,6 +567,12 @@ class RepoMap:
             middle = (lower_bound + upper_bound) // 2
 
         spin.end()
+
+        # Calculate and store the fit percentage
+        self.fit_percentage = (best_tree_tokens / total_tokens) * 100
+        if self.verbose:
+            self.io.tool_output(f"Repo-map fit: {self.fit_percentage:.1f}% of raw map")
+
         return best_tree
 
     tree_cache = dict()


### PR DESCRIPTION
this helps the user make a more informed choice about whether to override --map-tokens