### PR TITLE
feat: add cmd_copy command to copy last assistant reply to clipboard

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1042,8 +1042,29 @@ class Commands:
 
         return text
 
+    def cmd_copy(self, args):
+        "Copy the last reply from the LLM to the clipboard"
+        if not self.coder.cur_messages:
+            self.io.tool_error("No messages to copy.")
+            return
+
+        last_assistant_message = next(
+            (msg for msg in reversed(self.coder.cur_messages) if msg["role"] == "assistant"), None
+        )
+        if not last_assistant_message:
+            self.io.tool_error("No assistant reply to copy.")
+            return
+
+        content = last_assistant_message["content"]
+        try:
+            pyperclip.copy(content)
+            self.io.tool_output("Last assistant reply copied to clipboard.")
+        except pyperclip.PyperclipException as e:
+            self.io.tool_error(f"Failed to copy to clipboard: {e}")
+
     def cmd_paste(self, args):
-        "Paste image/text from the clipboard into the chat (optionally provide a name for the image)"
+        "Paste image/text from the clipboard into the chat"
+        "(optionally provide a name for the image)"
         try:
             # Check for image first
             image = ImageGrab.grabclipboard()

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -21,6 +21,7 @@ cog.out(get_help_md())
 | **/clear** | Clear the chat history |
 | **/code** | Ask for changes to your code |
 | **/commit** | Commit edits to the repo made outside the chat (commit message optional) |
+| **/copy** | Copy the last reply from the LLM to the clipboard |
 | **/diff** | Display the diff of changes since the last message |
 | **/drop** | Remove files from the chat session to free up context space |
 | **/exit** | Exit the application |
@@ -32,7 +33,7 @@ cog.out(get_help_md())
 | **/map-refresh** | Force a refresh of the repository map |
 | **/model** | Switch to a new LLM |
 | **/models** | Search the list of available models |
-| **/paste** | Paste image/text from the clipboard into the chat (optionally provide a name for the image) |
+| **/paste** | Paste image/text from the clipboard into the chat |
 | **/quit** | Exit the application |
 | **/read-only** | Add files to the chat that are for reference, not to be edited |
 | **/report** | Report a problem by opening a GitHub Issue |


### PR DESCRIPTION
This adds the `/copy` command to copy the last reply from the LLM to the clipboard.

Note: flake8 forced the `/paste` description to be cut and put into two lines, as the line was longer than 100 chars. 