### PR TITLE
feat: include non-repo files for completing /read (take 2, exclude .files)

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1660,11 +1660,17 @@ class Coder:
         except OSError:
             return
 
-    def get_all_relative_files(self):
-        if self.repo:
-            files = self.repo.get_tracked_files()
+    def get_all_relative_files(self, include_nonrepo=False):
+        if not self.repo or include_nonrepo:
+            files = []
+            for root, dirs, fnames in os.walk(self.root, topdown=True):
+                # Modify dirs in-place to exclude directories starting with '.'
+                dirs[:] = [d for d in dirs if not d.startswith('.')]
+                for fname in fnames:
+                    if not fname.startswith('.'):
+                        files.append(os.path.relpath(os.path.join(root, fname), self.root))
         else:
-            files = self.get_inchat_relative_files()
+            files = self.repo.get_tracked_files()
 
         # This is quite slow in large repos
         # files = [fname for fname in files if self.is_file_safe(fname)]

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -570,7 +570,10 @@ class Commands:
         return fname
 
     def completions_read_only(self):
-        return self.completions_add()
+        files = set(self.coder.get_all_relative_files(include_nonrepo=True))
+        files = files - set(self.coder.get_inchat_relative_files())
+        files = [self.quote_fname(fn) for fn in files]
+        return files
 
     def completions_add(self):
         files = set(self.coder.get_all_relative_files())


### PR DESCRIPTION
This *should* be faster, but I don't have a repo large enough to reproduce the slowdown in the original version (Cassandra isn't big enough), happy to test against a different repo if you have one in mind.