### PR TITLE
doc: small fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ The project's documentation is built using Jekyll and hosted on GitHub Pages. To
    ```
    bundle exec jekyll build
    ```
+5. Preview the website while editing (optional):
+   ```
+   bundle exec jekyll serve
+   ```
 
 The built documentation will be available in the `aider/website/_site` directory.
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1040,7 +1040,7 @@ class Commands:
         return text
 
     def cmd_paste(self, args):
-        """Paste image/text from the clipboard into the chat.
+        """Paste image/text from the clipboard into the chat.\
         Optionally provide a name for the image."""
         try:
             # Check for image first

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -735,7 +735,7 @@ class Commands:
                     self.io.tool_output(f"Removed {matched_file} from the chat")
 
     def cmd_git(self, args):
-        "Run a git command"
+        "Run a git command (output excluded from chat)"
         combined_output = None
         try:
             args = "git " + args

--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -124,6 +124,9 @@ When starting a fresh aider session, you can include recent git history in the c
 
 Remember, the chat history already includes recent changes made during the current session, so this tip is most useful when starting a new aider session and you want to provide context about recent work.
 
+{: .tip }
+The `/git` command will not work for this purpose, as its output is not included in the chat. 
+
 ## How can I run aider locally from source code?
 
 To run the project locally, follow these steps:
@@ -194,12 +197,18 @@ Yes, you can now share aider chat logs in a pretty way.
 
 1. Copy the markdown logs you want to share from `.aider.chat.history.md` and make a github gist. Or publish the raw markdown logs on the web any way you'd like.
 
-https://gist.github.com/paul-gauthier/2087ab8b64034a078c0a209440ac8be0
+   ```
+   https://gist.github.com/paul-gauthier/2087ab8b64034a078c0a209440ac8be0
+   ```
 
 2. Take the gist URL and append it to:
 
-https://aider.chat/share/?mdurl=
+   ```
+   https://aider.chat/share/?mdurl=
+   ```
 
 This will give you a URL like this, which shows the chat history like you'd see in a terminal:
 
+```
 https://aider.chat/share/?mdurl=https://gist.github.com/paul-gauthier/2087ab8b64034a078c0a209440ac8be0
+```

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -25,7 +25,7 @@ cog.out(get_help_md())
 | **/diff** | Display the diff of changes since the last message |
 | **/drop** | Remove files from the chat session to free up context space |
 | **/exit** | Exit the application |
-| **/git** | Run a git command |
+| **/git** | Run a git command (output excluded from chat)|
 | **/help** | Ask questions about aider |
 | **/lint** | Lint and fix in-chat files or all dirty files if none in chat |
 | **/ls** | List all known files and indicate which are included in the chat session |

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -25,7 +25,7 @@ cog.out(get_help_md())
 | **/diff** | Display the diff of changes since the last message |
 | **/drop** | Remove files from the chat session to free up context space |
 | **/exit** | Exit the application |
-| **/git** | Run a git command (output excluded from chat)|
+| **/git** | Run a git command (output excluded from chat) |
 | **/help** | Ask questions about aider |
 | **/lint** | Lint and fix in-chat files or all dirty files if none in chat |
 | **/ls** | List all known files and indicate which are included in the chat session |
@@ -33,8 +33,7 @@ cog.out(get_help_md())
 | **/map-refresh** | Force a refresh of the repository map |
 | **/model** | Switch to a new LLM |
 | **/models** | Search the list of available models |
-| **/paste** | Paste image/text from the clipboard into the chat.
-        Optionally provide a name for the image. |
+| **/paste** | Paste image/text from the clipboard into the chat.        Optionally provide a name for the image. |
 | **/quit** | Exit the application |
 | **/read-only** | Add files to the chat that are for reference, not to be edited |
 | **/report** | Report a problem by opening a GitHub Issue |


### PR DESCRIPTION
Here are some small documentation fixes for you to consider:
- point out that `/git` output is not included in the chat history in the help text
- add a small tip to the FAQ that `/git` will not work to include the git history/diffs
- add the `jekyll serve` command to the contributing guide (I had to look that up)
- prettier share transcript instructions in the FAQ
- fix /paste entry in docs/usage/commands.html spilling into new line