### PR TITLE
Update requirements.txt so that datasets and aider-chat can be installed together

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.9.0
+fsspec
     # via huggingface-hub
 gitdb==4.0.11
     # via gitpython


### PR DESCRIPTION
Error message

```
 Updated https://github.com/paul-gauthier/aider.git (ffc7d351)
  × No solution found when resolving dependencies for split (python_full_version < '3.13'):
  ╰─▶ Because only aider-chat==0.57.2.dev308+gffc7d351 is available and aider-chat==0.57.2.dev308+gffc7d351 depends on fsspec==2024.9.0, we can conclude that all versions of aider-chat
      depend on fsspec==2024.9.0.
      And because datasets>=3.0.0 depends on fsspec>=2023.1.0,<=2024.6.1 and only the following versions of datasets are available:
          datasets<=3.0.0
          datasets==3.0.1
      we can conclude that all versions of aider-chat and datasets>=3.0.0 are incompatible.
      And because your project depends on aider-chat and datasets>=3.0.0, we can conclude that your project's requirements are unsatisfiable.
```

Pip also throws the same error.