### PR TITLE
doc: update FAQ with short library entry

### DIFF
--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -106,7 +106,7 @@ The repo map is usually disabled for a good reason.
 
 If you would like to force it on, you can run aider with `--map-tokens 1024`.
 
-## How do I include the git history in the context?
+## How do I include the git history in the chat?
 
 When starting a fresh aider session, you can include recent git history in the chat context. This can be useful for providing the LLM with information about recent changes. To do this:
 
@@ -148,9 +148,6 @@ python -m pip install -e .
 python -m aider
 ```
 
-
-
-
 ## Can I change the system prompts that aider uses?
 
 Aider is set up to support different system prompts and edit formats
@@ -190,6 +187,9 @@ all the raw information being sent to/from the LLM in the conversation.
 You can also refer to the
 [instructions for installing a development version of aider](https://aider.chat/docs/install/optional.html#install-the-development-version-of-aider).
 
+## Can I use aider as a library in my own application?
+
+Aider is designed as a standalone interactive console application and is not intended to be used as a library. If you want to incorporate aider's functionality into your own application, you'll need to fork the aider repository and maintain your own version of the code.
 
 ## Can I share my aider chat transcript?
 

--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -189,7 +189,7 @@ You can also refer to the
 
 ## Can I use aider as a library in my own application?
 
-Aider is designed as a standalone interactive console application and is not intended to be used as a library. If you want to incorporate aider's functionality into your own application, you'll need to fork the aider repository and maintain your own version of the code.
+While aider supports [scripting](/docs/scripting), it is primarily designed as a standalone interactive console application and is not intended to be used as a library. Aider does not offer or maintain a stable Python API. If you want to incorporate aider's functionality into your own application, it is recommended that you fork the aider repository and maintain your own version of the code.
 
 ## Can I share my aider chat transcript?
 


### PR DESCRIPTION
This small doc update
- points out that aider is a command line application and not a library and suggests to fork the code base if desired to use it as a library
- removes some whitespace
- renames the title for the git history entry ("context" -> "chat") for consistency

Related #1806