### PR TITLE
Add full YAML support for config file

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -26,6 +26,7 @@ def get_parser(default_config_files, git_root):
         add_config_file_help=True,
         default_config_files=default_config_files,
         auto_env_var_prefix="AIDER_",
+        config_file_parser_class=configargparse.YAMLConfigFileParser,
     )
     group = parser.add_argument_group("Main")
     group.add_argument(

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -21,15 +21,6 @@ load whichever is found first.
 
 {% include env-keys-tip.md %}
 
-## A note on lists
-
-The syntax for specifying a list of values is not standard yaml.
-Instead, use this format:
-
-```
-read: [CONVENTIONS.md, anotherfile.txt, thirdfile.py]
-```
-
 ## Sample YAML config file
 
 Below is a sample of the YAML config file, which you
@@ -293,7 +284,10 @@ cog.outl("```")
 ## Specify lint commands to run for different languages, eg: "python: flake8 --select=..." (can be used multiple times)
 #lint-cmd: xxx
 ## Specify multiple values like this:
-#lint-cmd: [xxx,yyyy,zzz]
+#lint-cmd:
+#- xxx
+#- yyyy
+#- zzz
 
 ## Enable/disable automatic linting after changes (default: True)
 #auto-lint: true
@@ -313,12 +307,18 @@ cog.outl("```")
 ## specify a file to edit (can be used multiple times)
 #file: xxx
 ## Specify multiple values like this:
-#file: [xxx,yyyy,zzz]
+#file:
+#- xxx
+#- yyyy
+#- zzz
 
 ## specify a read-only file (can be used multiple times)
 #read: xxx
 ## Specify multiple values like this:
-#read: [xxx,yyyy,zzz]
+#read:
+#- xxx
+#- yyyy
+#- zzz
 
 ## Use VI editing mode in the terminal (default: False)
 #vim: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via litellm
-configargparse==1.7
+configargparse[yaml]==1.7
     # via -r requirements/requirements.in
 diff-match-patch==20230430
     # via -r requirements/requirements.in
@@ -159,6 +159,7 @@ python-dotenv==1.0.1
 pyyaml==6.0.2
     # via
     #   -r requirements/requirements.in
+    #   configargparse
     #   huggingface-hub
 referencing==0.35.1
     # via

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@
 #
 
 pydub
-configargparse
+configargparse[yaml]
 GitPython
 jsonschema
 rich


### PR DESCRIPTION
By default, `configargparse` only supports a subset of valid YAML syntax. Fix this by enabling the `yaml` feature and specifying the corresponding config file parser class.

Fixes #1822.