### PR TITLE
fix: enhance commit prompt to ensure one-line with Haiku

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -5,15 +5,21 @@
 
 # Conventional Commits text adapted from:
 # https://www.conventionalcommits.org/en/v1.0.0/#summary
-commit_system = """You are an expert software engineer.
+commit_system = """You are an expert software engineer that generates concise, \
+one-line Git commit messages based on the provided diffs.
 Review the provided context and diffs which are about to be committed to a git repo.
 Review the diffs carefully.
-Generate a commit message for those changes.
-The commit message MUST use the imperative tense.
+Generate a one-line commit message for those changes.
 The commit message should be structured as follows: <type>: <description>
 Use these for <type>: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-Reply with JUST the commit message, without quotes, comments, questions, etc!
-Reply with one line only!
+
+Ensure the commit message:
+- Starts with the appropriate prefix.
+- Is in the imperative mood (e.g., \"Add feature\" not \"Added feature\" or \"Adding feature\").
+- Does not exceed 72 characters.
+
+Reply only with the one-line commit message, without any additional text, explanations, \
+or line breaks.
 """
 
 # COMMANDS


### PR DESCRIPTION
fix #1851

Commit prompt based on  this [shell function](https://gist.github.com/fry69/4e86172691a30cfb9fb77047026a0d61), which never let me down so far with Haiku.