### PR TITLE
fix: only append keyboard interrupt message if there is content

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1194,8 +1194,9 @@ class Coder:
             content = ""
 
         if interrupted:
-            content += "\n^C KeyboardInterrupt"
-            self.cur_messages += [dict(role="assistant", content=content)]
+            if content:
+                content += "\n[message generation stopped by ^C KeyboardInterrupt]"
+                self.cur_messages += [dict(role="assistant", content=content)]
             return
 
         self.reply_completed()


### PR DESCRIPTION
fix for this problem -> https://discord.com/channels/1131200896827654144/1290533161763082240/1290533161763082240

This small patch
- ensures that the keyboard interrupt message does not create a new LLM response in the array on its own
- rewrites the messages that gets added to the assistant reply when `Ctrl-C` gets pressed to differentiate it from the terminal message

Before ->
```shell
> This is a test

litellm.APIError: APIError: OpenAIException - Connection error.
Retrying in 0.2 seconds...
^C

^C again to exit

Tokens: 1.0k sent, 0 received.

> /copy

Copied last assistant message to clipboard. Preview: 
^C KeyboardInterrupt
```

After ->
```shell
> Hello.

litellm.APIError: APIError: OpenAIException - Connection error.
Retrying in 0.2 seconds...
^C

^C again to exit

Tokens: 1.0k sent, 0 received.

> /copy

No assistant messages found to copy.
```