### PR TITLE
Add elixir extensions to watch-files list

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -37,6 +37,8 @@ def is_source_file(path: Path) -> bool:
         ".profile",
         ".yaml",
         ".yml",
+        ".ex",  #Elixir
+        ".exs", #Elixir
         # // style comments
         ".js",
         ".ts",


### PR DESCRIPTION
Elixir uses the hash-style single-line comments so I've added its common extensions to the list used by `watch-files`