### PR TITLE
Multiline arrow key wrapping

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -491,29 +491,27 @@ class InputOutput:
 
         @kb.add("left")
         def _(event):
-            "Move left or wrap to previous line in multiline mode"
+            "Move left or wrap to previous line"
             buf = event.current_buffer
-            if self.multiline_mode:
-                if buf.cursor_position == 0:
-                    return
-                if buf.document.cursor_position_col == 0:
-                    buf.cursor_up(count=1)
-                    buf.cursor_right(count=len(buf.document.current_line))
-                    return
-            buf.cursor_left(count=1)
+            if buf.cursor_position == 0:
+                return
+            if buf.document.cursor_position_col == 0:
+                buf.cursor_up(count=1)
+                buf.cursor_right(count=len(buf.document.current_line))
+            else:
+                buf.cursor_left(count=1)
 
         @kb.add("right")
         def _(event):
-            "Move right or wrap to next line in multiline mode"
+            "Move right or wrap to next line"
             buf = event.current_buffer
-            if self.multiline_mode:
-                if buf.cursor_position == len(buf.document.text):
-                    return
-                if buf.document.cursor_position_col == len(buf.document.current_line):
-                    buf.cursor_down(count=1)
-                    buf.cursor_left(count=len(buf.document.current_line))
-                    return
-            buf.cursor_right(count=1)
+            if buf.cursor_position == len(buf.document.text):
+                return
+            if buf.document.cursor_position_col == len(buf.document.current_line):
+                buf.cursor_down(count=1)
+                buf.cursor_left(count=len(buf.document.current_line))
+            else:
+                buf.cursor_right(count=1)
 
         @kb.add("c-up")
         def _(event):


### PR DESCRIPTION
This patch allows the arrow keys to wrap the cursor to the end of the previous line when pressing left arrow at the beginning of a line, or to the beginning of the next line, when pressing right arrow at the end of a line.  This operates in both regular input mode and multiline mode, since it may be useful in both.