### PR TITLE
Bump NumPy to v2.0.2 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -193,7 +193,7 @@ networkx==3.2.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   scipy

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -223,7 +223,7 @@ nltk==3.9.1
     # via llama-index-core
 nodeenv==1.9.1
     # via pre-commit
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -r requirements/requirements-help.in
     #   contourpy
@@ -395,7 +395,9 @@ semver==3.0.4
 sentence-transformers==3.4.1
     # via llama-index-embeddings-huggingface
 setuptools==75.8.2
-    # via pip-tools
+    # via
+    #   pip-tools
+    #   torch
 shellingham==1.5.4
     # via typer
 six==1.17.0
@@ -421,7 +423,7 @@ sqlalchemy[asyncio]==2.0.38
     # via llama-index-core
 streamlit==1.43.1
     # via -r requirements/requirements-browser.in
-sympy==1.13.3
+sympy==1.13.1
     # via torch
 tenacity==9.0.0
     # via
@@ -439,7 +441,7 @@ tokenizers==0.21.0
     #   transformers
 toml==0.10.2
     # via streamlit
-torch==2.2.2
+torch==2.6.0
     # via
     #   -r requirements/requirements-help.in
     #   sentence-transformers

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -62,7 +62,7 @@ narwhals==1.29.1
     # via
     #   -c requirements/common-constraints.txt
     #   altair
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   pandas

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -86,7 +86,7 @@ nodeenv==1.9.1
     # via
     #   -c requirements/common-constraints.txt
     #   pre-commit
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   contourpy

--- a/requirements/requirements-help.in
+++ b/requirements/requirements-help.in
@@ -1,9 +1,9 @@
 llama-index-core
 llama-index-embeddings-huggingface
 
-# Because sentence-transformers doesn't like >=2
-numpy<2
+# Pin below 2.1.0 to retain Python 3.9 compatibility
+numpy>=2,<2.1.0
 
-# Mac x86 only supports 2.2.2
-# https://discuss.pytorch.org/t/why-no-macosx-x86-64-build-after-torch-2-2-2-cp39-none-macosx-10-9-x86-64-whl/204546/2
-torch==2.2.2
+# Mac x86 only supports torch 2.2.2, but NumPy 2 requires torch 2.3 or newer
+# https://discuss.pytorch.org/t/why-no-macosx-x86-64-build-after-torch-2-2-2-cp39-no
+torch>=2.3.0

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -154,7 +154,7 @@ nltk==3.9.1
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-help.in
@@ -222,6 +222,10 @@ sentence-transformers==3.4.1
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-embeddings-huggingface
+setuptools==75.8.2
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 sniffio==1.3.1
     # via
     #   -c requirements/common-constraints.txt
@@ -230,7 +234,7 @@ sqlalchemy[asyncio]==2.0.38
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-sympy==1.13.3
+sympy==1.13.1
     # via
     #   -c requirements/common-constraints.txt
     #   torch
@@ -250,7 +254,7 @@ tokenizers==0.21.0
     # via
     #   -c requirements/common-constraints.txt
     #   transformers
-torch==2.2.2
+torch==2.6.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-help.in


### PR DESCRIPTION
Commit 66c24fa pinned NumPy to v1.x due to an upstream incompatibility in sentence-transformers.

In September 2024, [Aider picked up sentence-transformers v3.1.1](https://github.com/Aider-AI/aider/commit/2ca093fb8406f0d1383ff655a9afce2d53cb7cf2), which contains [a fix](https://github.com/UKPLab/sentence-transformers/pull/2937) for the NumPy 2 incompatibility. So it’s now safe to use NumPy 2.

To help unblock Python 3.13 compatibility (#3037), bump NumPy to v2.0.2, the most recent version still compatible to Python 3.9.
