### PR TITLE
Add MCP support

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -546,40 +546,11 @@ def get_parser(default_config_files, git_root):
     #########
     group = parser.add_argument_group("Model Context Protocol (MCP)")
     group.add_argument(
-        "--mcp",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Enable/disable Model Context Protocol (MCP) support (default: False)",
-    )
-    group.add_argument(
-        "--mcp-servers",
-        action="append",
-        metavar="SERVER_NAME",
-        help="Specify MCP server names to enable (can be used multiple times)",
-        default=[],
-    )
-    group.add_argument(
-        "--mcp-server-command",
-        action="append",
-        metavar="SERVER_NAME:COMMAND",
-        help="Specify the command to execute for an MCP server (can be used multiple times)",
-        default=[],
+        "--mcp-configuration",
+        default=None,
+        help="Specify the MCP configuration file (default: None)",
     )
 
-    group.add_argument(
-        "--mcp-server-env",
-        action="append",
-        metavar="SERVER_NAME:ENV_VAR=VALUE",
-        help="Specify environment variables for an MCP server (can be used multiple times)",
-        default=[],
-    )
-    group.add_argument(
-        "--mcp-tool-permission",
-        action="append",
-        metavar="SERVER_NAME:TOOL_NAME=PERMISSION",
-        help="Specify permission ('manual' or 'auto') for an MCP tool (can be used multiple times)",
-        default=[],
-    )
     group.add_argument(
         "--list-mcp-servers",
         action="store_true",
@@ -591,12 +562,6 @@ def get_parser(default_config_files, git_root):
         action="store_true",
         help="List all available MCP tools and exit",
         default=False,
-    )
-    group.add_argument(
-        "--mcp-wait-for-stdio",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Wait for STDIO MCP clients to complete tool discovery (default: False)",
     )
 
     #########

--- a/aider/args.py
+++ b/aider/args.py
@@ -544,6 +544,62 @@ def get_parser(default_config_files, git_root):
     )
 
     #########
+    group = parser.add_argument_group("Model Context Protocol (MCP)")
+    group.add_argument(
+        "--mcp",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable/disable Model Context Protocol (MCP) support (default: False)",
+    )
+    group.add_argument(
+        "--mcp-servers",
+        action="append",
+        metavar="SERVER_NAME",
+        help="Specify MCP server names to enable (can be used multiple times)",
+        default=[],
+    )
+    group.add_argument(
+        "--mcp-server-command",
+        action="append",
+        metavar="SERVER_NAME:COMMAND",
+        help="Specify the command to execute for an MCP server (can be used multiple times)",
+        default=[],
+    )
+
+    group.add_argument(
+        "--mcp-server-env",
+        action="append",
+        metavar="SERVER_NAME:ENV_VAR=VALUE",
+        help="Specify environment variables for an MCP server (can be used multiple times)",
+        default=[],
+    )
+    group.add_argument(
+        "--mcp-tool-permission",
+        action="append",
+        metavar="SERVER_NAME:TOOL_NAME=PERMISSION",
+        help="Specify permission ('manual' or 'auto') for an MCP tool (can be used multiple times)",
+        default=[],
+    )
+    group.add_argument(
+        "--list-mcp-servers",
+        action="store_true",
+        help="List all configured MCP servers and exit",
+        default=False,
+    )
+    group.add_argument(
+        "--list-mcp-tools",
+        action="store_true",
+        help="List all available MCP tools and exit",
+        default=False,
+    )
+    group.add_argument(
+        "--mcp-wait-for-stdio",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Wait for STDIO MCP clients to complete tool discovery (default: False)",
+    )
+
+    #########
     group = parser.add_argument_group("Upgrading")
     group.add_argument(
         "--just-check-update",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1108,11 +1108,6 @@ class Coder:
             )
         else:
             quad_backtick_reminder = ""
-            
-        # Add MCP tools information if MCP is enabled
-        mcp_tools_info = ""
-        if is_mcp_enabled():
-            mcp_tools_info = self.gpt_prompts.mcp_tools_prefix + "\n\n" + get_available_tools_prompt()
 
         prompt = prompt.format(
             fence=self.fence,
@@ -1126,10 +1121,10 @@ class Coder:
 
         if self.main_model.system_prompt_prefix:
             prompt = self.main_model.system_prompt_prefix + prompt
-            
+
         # Append MCP tools information to the end of the prompt
-        if mcp_tools_info:
-            prompt += "\n\n" + mcp_tools_info
+        if is_mcp_enabled():
+            prompt += "\n\n" + self.gpt_prompts.mcp_tools_prefix + "\n\n" + get_available_tools_prompt()
 
         return prompt
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1475,11 +1475,12 @@ class Coder:
                 return
 
             tool_results = self.check_for_tool_calls(content)
-            for tool_result in tool_results:
-                if self.mcp_tool_results:
-                    self.mcp_tool_results += "\n" + tool_result
-                else:
-                    self.mcp_tool_results = tool_result
+            if len(tool_results) > 1:
+                for tool_result in tool_results:
+                    if self.mcp_tool_results:
+                        self.mcp_tool_results += "\n" + tool_result
+                    else:
+                        self.mcp_tool_results = tool_result
                 return
 
             try:

--- a/aider/coders/base_prompts.py
+++ b/aider/coders/base_prompts.py
@@ -1,5 +1,25 @@
 class CoderPrompts:
     system_reminder = ""
+    
+    mcp_tools_prefix = """# MCP Tools
+
+You can use Model Context Protocol (MCP) tools to interact with external systems. To use a tool, include a tool execution request in your response using the following format:
+
+```
+<use_mcp_tool>
+<server_name>server name here</server_name>
+<tool_name>tool name here</tool_name>
+<arguments>
+{
+  "param1": "value1",
+  "param2": "value2"
+}
+</arguments>
+</use_mcp_tool>
+```
+
+The available tools will be listed below if any are connected.
+"""
 
     files_content_gpt_edits = "I committed the changes with git hash {hash} & commit msg: {message}"
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -2,6 +2,7 @@ import glob
 import os
 import re
 import subprocess
+import json
 import sys
 import tempfile
 from collections import OrderedDict
@@ -13,6 +14,7 @@ from PIL import Image, ImageGrab
 from prompt_toolkit.completion import Completion, PathCompleter
 from prompt_toolkit.document import Document
 
+from aider.mcp import list_mcp_servers, list_mcp_tools, execute_mcp_tool, stop_mcp_servers
 from aider import models, prompts, voice
 from aider.editor import pipe_editor
 from aider.format_settings import format_settings
@@ -1009,6 +1011,7 @@ class Commands:
 
     def cmd_exit(self, args):
         "Exit the application"
+        stop_mcp_servers()
         self.coder.event("exit", reason="/exit")
         sys.exit()
 
@@ -1541,6 +1544,78 @@ class Commands:
         # Output announcements
         announcements = "\n".join(self.coder.get_announcements())
         self.io.tool_output(announcements)
+
+    def cmd_mcp_servers(self, args):
+        "List all configured MCP servers"
+        servers = list_mcp_servers()
+        if servers:
+            self.io.tool_output("Configured MCP servers:")
+            for server in servers:
+                status = "Enabled" if server.enabled else "Disabled"
+                self.io.tool_output(f"  - {server.name} ({status})")
+                if server.command:
+                    self.io.tool_output(f"    Command: {server.command}")
+                if server.env_vars:
+                    self.io.tool_output("    Environment variables:")
+                    for var, value in server.env_vars.items():
+                        masked_value = "*" * len(value) if value else "(empty)"
+                        self.io.tool_output(f"      {var}={masked_value}")
+        else:
+            self.io.tool_output("No MCP servers configured.")
+
+    def cmd_mcp_tools(self, args):
+        "List all available MCP tools, optionally filtered by server name"
+        server_name = args.strip()
+        tools_by_server = list_mcp_tools()
+
+        if not tools_by_server:
+            self.io.tool_output("No MCP tools available.")
+            return
+
+        if server_name:
+            if server_name in tools_by_server:
+                self.io.tool_output(f"Tools for MCP server '{server_name}':")
+                for tool in tools_by_server[server_name]:
+                    self.io.tool_output(f"  - {tool.name} (Permission: {tool.permission})")
+                    if tool.description:
+                        self.io.tool_output(f"    Description: {tool.description}")
+            else:
+                self.io.tool_output(f"No MCP server found with name '{server_name}'.")
+        else:
+            self.io.tool_output("Available MCP tools:")
+            for server_name, tools in tools_by_server.items():
+                self.io.tool_output(f"  Server: {server_name}")
+                for tool in tools:
+                    self.io.tool_output(f"    - {tool.name} (Permission: {tool.permission})")
+                    if tool.description:
+                        self.io.tool_output(f"      Description: {tool.description}")
+
+    def cmd_mcp_execute(self, args):
+        "Execute an MCP tool with the given arguments"
+        # Parse the arguments
+        parts = args.strip().split(maxsplit=2)
+        if len(parts) < 2:
+            self.io.tool_error("Usage: /mcp-execute <server_name> <tool_name> [arguments_json]")
+            return
+
+        server_name, tool_name = parts[0], parts[1]
+        arguments = {}
+
+        if len(parts) > 2:
+            try:
+                arguments = json.loads(parts[2])
+            except json.JSONDecodeError:
+                self.io.tool_error(f"Invalid JSON arguments: {parts[2]}")
+                return
+
+        # Execute the tool
+        self.io.tool_output(f"Executing MCP tool '{tool_name}' from server '{server_name}'...")
+        try:
+            result = execute_mcp_tool(server_name, tool_name, arguments, self.io)
+            self.io.tool_output("Result:")
+            self.io.tool_output(result)
+        except Exception as e:
+            self.io.tool_error(f"Error executing MCP tool: {str(e)}")
 
     def cmd_copy_context(self, args=None):
         """Copy the current chat context as markdown, suitable to paste into a web UI"""

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1551,8 +1551,7 @@ class Commands:
         if servers:
             self.io.tool_output("Configured MCP servers:")
             for server in servers:
-                status = "Enabled" if server.enabled else "Disabled"
-                self.io.tool_output(f"  - {server.name} ({status})")
+                self.io.tool_output(f"  - {server.name}")
                 if server.command:
                     self.io.tool_output(f"    Command: {server.command}")
                 if server.env_vars:

--- a/aider/main.py
+++ b/aider/main.py
@@ -1265,3 +1265,4 @@ def load_slow_imports(swallow=True):
 
 if __name__ == "__main__":
     status = main()
+    sys.exit(status)

--- a/aider/main.py
+++ b/aider/main.py
@@ -8,6 +8,8 @@ import webbrowser
 from dataclasses import fields
 from pathlib import Path
 
+from aider import mcp
+
 try:
     import git
 except ImportError:
@@ -714,6 +716,53 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.check_update:
         check_version(io, verbose=args.verbose)
 
+    if args.list_models:
+        models.print_matching_models(io, args.list_models)
+        analytics.event("exit", reason="Listed models")
+        return 0
+
+    # Configure MCP manager
+    mcp.configure_mcp(args)
+
+    # Initialize MCP servers and discover tools
+    if mcp.is_mcp_enabled():
+        mcp.initialize_mcp_servers(io)
+
+    # Handle MCP-related commands
+    if args.list_mcp_servers:
+        servers = mcp.list_mcp_servers()
+        if servers:
+            io.tool_output("Configured MCP servers:")
+            for server in servers:
+                status = "Enabled" if server.enabled else "Disabled"
+                io.tool_output(f"  - {server.name} ({status})")
+                if server.command:
+                    io.tool_output(f"    Command: {server.command}")
+                if server.env_vars:
+                    io.tool_output("    Environment variables:")
+                    for var, value in server.env_vars.items():
+                        masked_value = "*" * len(value) if value else "(empty)"
+                        io.tool_output(f"      {var}={masked_value}")
+        else:
+            io.tool_output("No MCP servers configured.")
+        analytics.event("exit", reason="Listed MCP servers")
+        return 0
+
+    if args.list_mcp_tools:
+        tools_by_server = mcp.list_mcp_tools()
+        if tools_by_server:
+            io.tool_output("Available MCP tools:")
+            for server_name, tools in tools_by_server.items():
+                io.tool_output(f"  Server: {server_name}")
+                for tool in tools:
+                    io.tool_output(f"    - {tool.name} (Permission: {tool.permission})")
+                    if tool.description:
+                        io.tool_output(f"      Description: {tool.description}")
+        else:
+            io.tool_output("No MCP tools available.")
+        analytics.event("exit", reason="Listed MCP tools")
+        return 0
+
     if args.git:
         git_root = setup_git(git_root, io)
         if args.gitignore:
@@ -852,6 +901,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
                 io.tool_output()
             except KeyboardInterrupt:
                 analytics.event("exit", reason="Keyboard interrupt during model warnings")
+                mcp.stop_mcp_servers()
                 return 1
 
     repo = None
@@ -1215,4 +1265,3 @@ def load_slow_imports(swallow=True):
 
 if __name__ == "__main__":
     status = main()
-    sys.exit(status)

--- a/aider/main.py
+++ b/aider/main.py
@@ -734,8 +734,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         if servers:
             io.tool_output("Configured MCP servers:")
             for server in servers:
-                status = "Enabled" if server.enabled else "Disabled"
-                io.tool_output(f"  - {server.name} ({status})")
+                io.tool_output(f"  - {server.name}")
                 if server.command:
                     io.tool_output(f"    Command: {server.command}")
                 if server.env_vars:
@@ -746,6 +745,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         else:
             io.tool_output("No MCP servers configured.")
         analytics.event("exit", reason="Listed MCP servers")
+        mcp.stop_mcp_servers()
         return 0
 
     if args.list_mcp_tools:
@@ -761,6 +761,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         else:
             io.tool_output("No MCP tools available.")
         analytics.event("exit", reason="Listed MCP tools")
+        mcp.stop_mcp_servers()
         return 0
 
     if args.git:

--- a/aider/mcp/__init__.py
+++ b/aider/mcp/__init__.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+from typing import Dict, List, Tuple
+
+from aider.mcp.mcp_manager import McpManager
+from aider.mcp.mcp_server import McpServer
+from aider.mcp.mcp_tool import McpTool
+from aider.mcp.mcp_tool_parser import McpToolParser
+
+# Global instance of the MCP manager
+mcp_manager = McpManager()
+
+def configure_mcp(args) -> None:
+    """Configure the MCP manager from command-line arguments."""
+    mcp_manager.configure_from_args(args)
+
+def stop_mcp_servers() -> None:
+    """Quit all enabled MCP servers."""
+    mcp_manager.stop_servers()
+
+def is_mcp_enabled() -> bool:
+    """Check if MCP is enabled."""
+    return mcp_manager.enabled
+
+def list_mcp_servers() -> List[McpServer]:
+    """List all configured MCP servers."""
+    return mcp_manager.list_servers()
+
+def list_mcp_tools() -> Dict[str, List[McpTool]]:
+    """List all available MCP tools grouped by server."""
+    return mcp_manager.list_tools()
+
+def initialize_mcp_servers(io) -> None:
+    """Initialize and start all enabled MCP servers.
+
+    Args:
+        io: InputOutput object for logging messages
+    """
+    mcp_manager.initialize_servers(io)
+    mcp_manager.discover_tools(io)
+
+def _execute_mcp_tool(server_name: str, tool_name: str, arguments: dict, io) -> str:
+    """Execute an MCP tool with the given arguments.
+
+    Args:
+        server_name: The name of the server providing the tool
+        tool_name: The name of the tool to execute
+        arguments: A dictionary of arguments to pass to the tool
+        io: InputOutput object for logging messages
+
+    Returns:
+        The result of the tool execution as a string
+    """
+    return mcp_manager.execute_tool(server_name, tool_name, arguments, io)
+
+def execute_mcp_tool(server_name: str, tool_name: str, arguments: dict, io) -> str:
+    """Execute an MCP tool with the given arguments.
+
+    Args:
+        server_name: The name of the server providing the tool
+        tool_name: The name of the tool to execute
+        arguments: A dictionary of arguments to pass to the tool
+        io: InputOutput object for logging messages
+
+    Returns:
+        The result of the tool execution as a string
+    """
+    return _execute_mcp_tool(server_name, tool_name, arguments, io)
+
+def process_llm_tool_requests(text: str, io) -> list[Tuple[str, bool]]:
+    """
+    Process tools execution request from the LLM.
+
+    Args:
+        text: The text to parse for tool execution requests
+        io: InputOutput object for logging messages
+
+    Returns:
+        A list of (result, is_error) if a request was processed,
+    """
+    tool_requests = McpToolParser.extract_tool_requests(text)
+
+    results = []
+    for (server_name, tool_name, arguments) in tool_requests:
+        result, _ = process_llm_tool_request(server_name, tool_name, arguments, io)
+        results.append(result)
+
+    return results
+
+def process_llm_tool_request(server_name: str, tool_name: str, arguments: dict, io) -> Tuple[str, bool]:
+    """
+    Process a single tool execution request from the LLM.
+
+    Args:
+        server_name: The name of the server providing the tool
+        tool_name: The name of the tool to execute
+        arguments: A dictionary of arguments to pass to the tool
+        io: InputOutput object for logging messages
+
+    Returns:
+        A tuple containing the result of the tool execution as a string and a boolean indicating if an error
+        occurred during the execution
+    """
+    # Check if the server and tool exist
+    server = mcp_manager.get_server(server_name)
+    identifier = f"{server_name}.{tool_name}"
+    if not server:
+        error = f"MCP server '{server_name}' not found"
+        io.tool_error(error)
+        return McpToolParser.format_tool_error(identifier, error), True
+
+    if not server.enabled:
+        error = f"MCP server '{server_name}' is not enabled"
+        io.tool_error(error)
+        return McpToolParser.format_tool_error(identifier, error), True
+
+    if tool_name not in server.tools:
+        error = f"Tool '{tool_name}' not found in server '{server_name}'"
+        io.tool_error(error)
+        return McpToolParser.format_tool_error(identifier, error), True
+
+    try:
+        result = _execute_mcp_tool(server_name, tool_name, arguments, io)
+        return McpToolParser.format_tool_result(identifier, result), False
+    except Exception as e:
+        error = f"Error executing tool '{tool_name}': {str(e)}"
+        io.tool_error(error)
+        return McpToolParser.format_tool_error(identifier, error), True
+
+def get_available_tools_prompt() -> str:
+    """
+    Get a formatted string describing the available MCP tools for inclusion in the system prompt.
+
+    Returns:
+        A formatted string describing the available tools
+    """
+    tools_by_server = list_mcp_tools()
+    return McpToolParser.format_available_tools(tools_by_server)

--- a/aider/mcp/__init__.py
+++ b/aider/mcp/__init__.py
@@ -109,11 +109,6 @@ def process_llm_tool_request(server_name: str, tool_name: str, arguments: dict, 
         io.tool_error(error)
         return McpToolParser.format_tool_error(identifier, error), True
 
-    if not server.enabled:
-        error = f"MCP server '{server_name}' is not enabled"
-        io.tool_error(error)
-        return McpToolParser.format_tool_error(identifier, error), True
-
     if tool_name not in server.tools:
         error = f"Tool '{tool_name}' not found in server '{server_name}'"
         io.tool_error(error)

--- a/aider/mcp/__init__.py
+++ b/aider/mcp/__init__.py
@@ -67,7 +67,7 @@ def execute_mcp_tool(server_name: str, tool_name: str, arguments: dict, io) -> s
     """
     return _execute_mcp_tool(server_name, tool_name, arguments, io)
 
-def process_llm_tool_requests(text: str, io) -> list[Tuple[str, bool]]:
+def process_llm_tool_requests(text: str, io) -> list[str]:
     """
     Process tools execution request from the LLM.
 
@@ -76,7 +76,7 @@ def process_llm_tool_requests(text: str, io) -> list[Tuple[str, bool]]:
         io: InputOutput object for logging messages
 
     Returns:
-        A list of (result, is_error) if a request was processed,
+        A list of results from processed tool requests
     """
     tool_requests = McpToolParser.extract_tool_requests(text)
 

--- a/aider/mcp/__init__.py
+++ b/aider/mcp/__init__.py
@@ -37,7 +37,6 @@ def initialize_mcp_servers(io) -> None:
         io: InputOutput object for logging messages
     """
     mcp_manager.initialize_servers(io)
-    mcp_manager.discover_tools(io)
 
 def _execute_mcp_tool(server_name: str, tool_name: str, arguments: dict, io) -> str:
     """Execute an MCP tool with the given arguments.

--- a/aider/mcp/mcp_manager.py
+++ b/aider/mcp/mcp_manager.py
@@ -85,7 +85,6 @@ class McpManager:
 
             # Ignore messages for other servers
             if msg.server_name != server.name:
-                self.message_queue.task_done()
                 continue
 
             try:

--- a/aider/mcp/mcp_manager.py
+++ b/aider/mcp/mcp_manager.py
@@ -1,0 +1,289 @@
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+import re
+import shlex
+import threading
+import queue
+from typing import Dict, List, Optional
+import asyncio
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+from aider.mcp.mcp_server import McpServer
+from aider.mcp.mcp_tool import McpTool
+
+@dataclass
+class CallArguments:
+    server_name: str
+    function: str
+    args: dict
+
+@dataclass
+class CallResponse:
+    error: str | None
+    response: str | None
+
+class McpManager:
+    """Manages MCP servers and tools configuration."""
+
+    def __init__(self):
+        self.servers: Dict[str, McpServer] = {}
+        self.enabled: bool = False
+        self.message_queue = queue.Queue()
+        self.result_queue = queue.Queue()
+
+    def _get_event_loop(self) -> asyncio.AbstractEventLoop:
+        """Get the current event loop or create a new one if none exists."""
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            return asyncio.new_event_loop()
+
+    def _call(self, io, server_name, function, args: dict = {}):
+        """Sync call to the thread with queues."""
+
+        self.message_queue.put(CallArguments(server_name, function, args))
+        result = self.result_queue.get()
+        self.result_queue.task_done()
+
+        if result.error:
+            if io:
+                io.tool_error(result.error)
+            return None
+
+        return result.response
+
+    async def _async_server_loop(self, server: McpServer) -> None:
+        """Run the async server loop for a given server."""
+
+        # Parse the server exec command
+        command_parts = shlex.split(server.command)
+        executable = command_parts[0]
+        args = command_parts[1:]
+
+        server_params = StdioServerParameters(
+            command=executable,
+            args=args,
+            env=server.env_vars,
+        )
+
+        # Run the async server loop
+        exit_stack = AsyncExitStack()
+
+        stdio_transport = await exit_stack.enter_async_context(stdio_client(server_params))
+        stdio, write = stdio_transport
+        session = await exit_stack.enter_async_context(ClientSession(stdio, write))
+
+        await session.initialize()
+
+        while True:
+            msg: CallArguments = self.message_queue.get()
+
+            # Exit the loop if the exit message is received
+            if msg.function == "exit":
+                break
+
+            # Ignore messages for other servers
+            if msg.server_name != server.name:
+                self.message_queue.task_done()
+                continue
+
+            try:
+                if msg.function == "call_tool":
+                    response = await session.call_tool(**msg.args)
+                    self.result_queue.put(CallResponse(None, response))
+                elif msg.function == "list_tools":
+                    response = await session.list_tools()
+                    self.result_queue.put(CallResponse(None, response))
+            except Exception as e:
+                self.result_queue.put(CallResponse(str(e), None))
+            finally:
+                self.message_queue.task_done()
+
+    def _server_loop(self, server: McpServer, loop: asyncio.AbstractEventLoop) -> None:
+        """Wrap the async server loop for a given server."""
+        loop.run_until_complete(self._async_server_loop(server))
+
+    def configure_from_args(self, args) -> None:
+        """Configure MCP from command-line arguments."""
+        self.enabled = args.mcp
+
+        # If MCP is not enabled, don't process further
+        if not self.enabled:
+            return
+
+        # Add servers specified in --mcp-servers
+        for server_name in args.mcp_servers:
+            self.add_server(server_name)
+            self.servers[server_name].enabled = True
+
+        # Process server commands
+        for cmd_spec in args.mcp_server_command:
+            parts = cmd_spec.split(":", 1)
+            if len(parts) != 2:
+                continue
+            server_name, command = parts
+            self.add_server(server_name)
+            self.servers[server_name].command = command
+
+        # Process server environment variables
+        for env_spec in args.mcp_server_env:
+            match = re.match(r"([^:]+):([^=]+)=(.*)", env_spec)
+            if not match:
+                continue
+            server_name, env_var, value = match.groups()
+            self.add_server(server_name)
+            self.servers[server_name].env_vars[env_var] = value
+
+        # Process tool permissions
+        for perm_spec in args.mcp_tool_permission:
+            match = re.match(r"([^:]+):([^=]+)=(.*)", perm_spec)
+            if not match:
+                continue
+            server_name, tool_name, permission = match.groups()
+            if permission not in ["manual", "auto"]:
+                continue
+            self.add_server(server_name)
+            if tool_name not in self.servers[server_name].tools:
+                self.servers[server_name].add_tool(tool_name)
+            self.servers[server_name].set_tool_permission(tool_name, permission)
+
+    def add_server(self, server_name: str) -> McpServer:
+        """Add a new server if it doesn't exist, or return the existing one."""
+        if server_name not in self.servers:
+            self.servers[server_name] = McpServer(server_name)
+        return self.servers[server_name]
+
+    def get_server(self, server_name: str) -> Optional[McpServer]:
+        """Get a server by name, or None if it doesn't exist."""
+        return self.servers.get(server_name)
+
+    def get_enabled_servers(self) -> List[McpServer]:
+        """Get a list of all enabled servers."""
+        return [server for server in self.servers.values() if server.enabled]
+
+    def list_servers(self) -> List[McpServer]:
+        """Get a list of all servers."""
+        return list(self.servers.values())
+
+    def list_tools(self) -> Dict[str, List[McpTool]]:
+        """Get a dictionary of server names to lists of tools."""
+        result = {}
+        for server_name, server in self.servers.items():
+            if server.tools:
+                result[server_name] = list(server.tools.values())
+        return result
+
+    def initialize_servers(self, io) -> None:
+        """Initialize and start all enabled MCP servers.
+
+        Args:
+            io: InputOutput object for logging messages
+        """
+        if not self.enabled:
+            return
+
+        loop = self._get_event_loop()
+
+        for server in self.get_enabled_servers():
+            if server.command:
+                t = threading.Thread(target=self._server_loop, args=(server, loop))
+                t.start()
+            else:
+                io.tool_warning(f"MCP server '{server.name}' has no command configured")
+
+
+    def discover_tools(self, io) -> None:
+        """Discover tools from all enabled servers.
+
+        Args:
+            io: InputOutput object for logging messages
+        """
+        if not self.enabled:
+            return
+
+        for server in self.get_enabled_servers():
+            # Check if the server configuration is valid
+            if not server.is_valid():
+                if io:
+                    io.tool_warning(f"Cannot discover tools for server '{server.name}': Invalid configuration (must have a command)")
+                continue
+
+            response = self._call(io, server.name, "list_tools", {})
+
+            # Process the tools
+            for tool in response.tools:
+                name = tool.name
+                description = tool.description
+                input_schema = tool.inputSchema
+
+                # Get the permission from the existing tool configuration or default to "manual"
+                permission = "manual"
+                if name in server.tools:
+                    permission = server.tools[name].permission
+
+                # Add the tool to the server configuration
+                server.add_tool(name, permission, description, input_schema)
+
+    def execute_tool(self, server_name: str, tool_name: str, arguments: dict, io) -> str:
+        """Execute an MCP tool with the given arguments.
+
+        Args:
+            server_name: The name of the server providing the tool
+            tool_name: The name of the tool to execute
+            arguments: A dictionary of arguments to pass to the tool
+            io: InputOutput object for logging messages
+
+        Returns:
+            The result of the tool execution as a string
+        """
+        if not self.enabled:
+            io.tool_error("MCP is not enabled")
+            return "MCP is not enabled"
+
+        server = self.get_server(server_name)
+        if not server:
+            io.tool_error(f"MCP server '{server_name}' not found")
+            return f"MCP server '{server_name}' not found"
+
+        if not server.enabled:
+            io.tool_error(f"MCP server '{server_name}' is not enabled")
+            return f"MCP server '{server_name}' is not enabled"
+
+        if tool_name not in server.tools:
+            io.tool_error(f"Tool '{tool_name}' not found in server '{server_name}'")
+            return f"Tool '{tool_name}' not found in server '{server_name}'"
+
+        # Get the tool permission
+        tool = server.tools[tool_name]
+        permission = tool.permission
+
+        # Check if the tool requires manual approval
+        if permission == "manual":
+            if not io.confirm_ask(f"Allow execution of tool '{tool_name}' from server '{server_name}'?"):
+                return "Tool execution denied by user"
+
+        # Execute the tool
+        try:
+            response = self._call(io, server_name, "call_tool", {
+                "name": tool_name,
+                "arguments": arguments
+            })
+
+            # Process the response
+            result = ""
+            for content_item in response.content:
+                if content_item.type == "text":
+                    result += content_item.text
+
+            io.tool_output(f"Tool '{tool_name}' executed successfully")
+
+            return result
+        except Exception as e:
+            error_msg = f"Error executing tool '{tool_name}': {str(e)}"
+            io.tool_error(error_msg)
+            return error_msg
+
+    def stop_servers(self) -> None:
+        """Stop all running MCP servers."""
+        self.message_queue.put(CallArguments("", "exit", {}))

--- a/aider/mcp/mcp_server.py
+++ b/aider/mcp/mcp_server.py
@@ -7,7 +7,7 @@ from aider.mcp.mcp_tool import McpTool
 class McpServer:
     """Represents an MCP server configuration."""
     name: str
-    command: Optional[str] = None
+    command: str
     env_vars: Dict[str, str] = field(default_factory=dict)
     tools: Dict[str, McpTool] = field(default_factory=dict)
 
@@ -17,7 +17,7 @@ class McpServer:
             permission: str = "manual",
             description: Optional[str] = None,
             input_schema: Optional[Dict[str, Any]] = None,
-    ) -> bool:
+    ):
         """Update an existing tool's description and input schema."""
         if tool_name in self.tools:
             if description is not None:

--- a/aider/mcp/mcp_server.py
+++ b/aider/mcp/mcp_server.py
@@ -11,17 +11,23 @@ class McpServer:
     env_vars: Dict[str, str] = field(default_factory=dict)
     tools: Dict[str, McpTool] = field(default_factory=dict)
 
-    def add_tool(self, tool_name: str, permission: str = "manual", description: Optional[str] = None,
-                 input_schema: Optional[Dict[str, Any]] = None) -> None:
-        """Add a tool to this server."""
-        self.tools[tool_name] = McpTool(tool_name, permission, description, input_schema)
-
-    def set_tool_permission(self, tool_name: str, permission: str) -> bool:
-        """Set the permission for a tool. Returns True if successful, False if tool not found."""
+    def set_tool(
+            self,
+            tool_name: str,
+            permission: str = "manual",
+            description: Optional[str] = None,
+            input_schema: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Update an existing tool's description and input schema."""
         if tool_name in self.tools:
-            self.tools[tool_name].permission = permission
-            return True
-        return False
+            if description is not None:
+                self.tools[tool_name].description = description
+            if input_schema is not None:
+                self.tools[tool_name].input_schema = input_schema
+            if permission is not None:
+                self.tools[tool_name].permission = permission
+        else:
+            self.tools[tool_name] = McpTool(tool_name, permission, description, input_schema)
 
     def get_env_dict(self) -> Dict[str, str]:
         """Get a dictionary of environment variables for this server."""

--- a/aider/mcp/mcp_server.py
+++ b/aider/mcp/mcp_server.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from aider.mcp.mcp_tool import McpTool
+
+@dataclass
+class McpServer:
+    """Represents an MCP server configuration."""
+    name: str
+    command: Optional[str] = None
+    env_vars: Dict[str, str] = field(default_factory=dict)
+    tools: Dict[str, McpTool] = field(default_factory=dict)
+
+    def add_tool(self, tool_name: str, permission: str = "manual", description: Optional[str] = None,
+                 input_schema: Optional[Dict[str, Any]] = None) -> None:
+        """Add a tool to this server."""
+        self.tools[tool_name] = McpTool(tool_name, permission, description, input_schema)
+
+    def set_tool_permission(self, tool_name: str, permission: str) -> bool:
+        """Set the permission for a tool. Returns True if successful, False if tool not found."""
+        if tool_name in self.tools:
+            self.tools[tool_name].permission = permission
+            return True
+        return False
+
+    def get_env_dict(self) -> Dict[str, str]:
+        """Get a dictionary of environment variables for this server."""
+        return self.env_vars
+
+    def is_valid(self) -> bool:
+        """Check if the server configuration is valid.
+        """
+        return self.command is not None

--- a/aider/mcp/mcp_tool.py
+++ b/aider/mcp/mcp_tool.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+@dataclass
+class McpTool:
+    """Represents an MCP tool with its name and permission settings."""
+    name: str
+    permission: str = "manual"  # "manual" or "auto"
+    description: Optional[str] = None
+    input_schema: Optional[Dict[str, Any]] = None

--- a/aider/mcp/mcp_tool_parser.py
+++ b/aider/mcp/mcp_tool_parser.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+import json
+import re
+from typing import Dict, Optional, Tuple, Any
+
+
+class McpToolParser:
+    """Parser for MCP tool execution requests from LLM output."""
+
+    # Regular expression pattern for extracting tool execution requests
+    TOOL_PATTERN = re.compile(
+        r'<use_mcp_tool>\s*'
+        r'<server_name>(.*?)</server_name>\s*'
+        r'<tool_name>(.*?)</tool_name>\s*'
+        r'<arguments>\s*([\s\S]*?)\s*</arguments>\s*'
+        r'</use_mcp_tool>',
+        re.DOTALL
+    )
+
+    @classmethod
+    def extract_tool_requests(cls, text: str) -> list[Tuple[str, str, Dict[str, Any]]]:
+        """
+        Extract MCP tools execution request from text.
+
+        Args:
+            text: The text to parse for tool execution requests
+
+        Returns:
+            A list of (server_name, tool_name, arguments) if a request is found,
+        """
+        match = cls.TOOL_PATTERN.findall(text)
+
+        return [
+            (
+                server_name.strip(),
+                tool_name.strip(),
+                McpToolParser.parse_arguments(arguments)
+            )
+            for server_name, tool_name, arguments in match
+        ]
+
+    @classmethod
+    def parse_arguments(cls, arguments_str: str) -> Optional[Dict[str, Any]]:
+        """
+        Parse the arguments string into a dictionary.
+
+        Args:
+            arguments_str: The arguments string to parse
+        """
+
+        try:
+            return json.loads(arguments_str.strip())
+        except json.JSONDecodeError:
+            # If JSON parsing fails, return None
+            return None
+
+    @classmethod
+    def format_tool_result(cls, identifier: str, result: str) -> str:
+        """
+        Format the result of a tool execution for the LLM.
+
+        Args:
+            identifier: The identifier for the tool execution
+            result: The result of the tool execution
+
+        Returns:
+            The formatted result
+        """
+        return f"""
+Tool execution result for {identifier}:
+```
+{result}
+```
+"""
+
+    @classmethod
+    def format_tool_error(cls, identifier: str, error: str) -> str:
+        """
+        Format an error message for the LLM.
+
+        Args:
+            identifier: The identifier for the tool execution
+            error: The error message
+
+        Returns:
+            The formatted error message
+        """
+        return f"""
+Tool execution error for {identifier}:
+```
+{error}
+```
+"""
+
+    @classmethod
+    def format_available_tools(cls, tools_by_server: Dict[str, list]) -> str:
+        """
+        Format the available tools for inclusion in the system prompt.
+
+        Args:
+            tools_by_server: A dictionary mapping server names to lists of tools
+
+        Returns:
+            A formatted string describing the available tools
+        """
+        if not tools_by_server:
+            return "No MCP tools available."
+
+        result = "# Available MCP Tools\n\n"
+        result += "You can use the following MCP tools by including a tool execution request in your response:\n\n"
+
+        for server_name, tools in tools_by_server.items():
+            result += f"## Server: {server_name}\n\n"
+
+            for tool in tools:
+                result += f"### {tool.name}\n\n"
+
+                if tool.description:
+                    result += f"{tool.description}\n\n"
+
+                result += "**Permission:** " + tool.permission + "\n\n"
+
+                if tool.input_schema:
+                    result += "**Input Schema:**\n```json\n"
+                    result += json.dumps(tool.input_schema, indent=2)
+                    result += "\n```\n\n"
+
+                result += "**Usage Example:**\n```\n"
+                result += "<use_mcp_tool>\n"
+                result += f"<server_name>{server_name}</server_name>\n"
+                result += f"<tool_name>{tool.name}</tool_name>\n"
+                result += "<arguments>\n"
+
+                # Generate example arguments based on the input schema
+                if tool.input_schema and "properties" in tool.input_schema:
+                    example_args = {}
+                    for prop_name, prop_info in tool.input_schema["properties"].items():
+                        if prop_info.get("type") == "string":
+                            example_args[prop_name] = f"example_{prop_name}"
+                        elif prop_info.get("type") == "number":
+                            example_args[prop_name] = 42
+                        elif prop_info.get("type") == "boolean":
+                            example_args[prop_name] = True
+                        elif prop_info.get("type") == "array":
+                            example_args[prop_name] = []
+                        elif prop_info.get("type") == "object":
+                            example_args[prop_name] = {}
+                        else:
+                            example_args[prop_name] = "value"
+
+                    result += json.dumps(example_args, indent=2)
+                else:
+                    result += "{\n  \"param1\": \"value1\",\n  \"param2\": \"value2\"\n}"
+
+                result += "\n</arguments>\n"
+                result += "</use_mcp_tool>\n```\n\n"
+
+        return result

--- a/aider/mcp/mcp_tool_parser.py
+++ b/aider/mcp/mcp_tool_parser.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-from typing import Dict, Optional, Tuple, Any
+from typing import Dict, Tuple, Any
 
 
 class McpToolParser:
@@ -41,7 +41,7 @@ class McpToolParser:
         ]
 
     @classmethod
-    def parse_arguments(cls, arguments_str: str) -> Optional[Dict[str, Any]]:
+    def parse_arguments(cls, arguments_str: str) -> Dict[str, Any]:
         """
         Parse the arguments string into a dictionary.
 
@@ -49,11 +49,7 @@ class McpToolParser:
             arguments_str: The arguments string to parse
         """
 
-        try:
-            return json.loads(arguments_str.strip())
-        except json.JSONDecodeError:
-            # If JSON parsing fails, return None
-            return None
+        return json.loads(arguments_str.strip())
 
     @classmethod
     def format_tool_result(cls, identifier: str, result: str) -> str:

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,6 +28,7 @@ watchfiles
 socksio
 pip
 pillow
+mcp
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,7 +28,6 @@ watchfiles
 socksio
 pip
 pillow
-mcp
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps


### PR DESCRIPTION
This is a rough implementation of MCP into Aider.
It currently support adding stdio MCP servers with this configuration in the ~/.aider.conf.yml

```yaml
mcp: true
mcp-servers:
  - git-server
mcp-server-command:
  - "git-server:uvx mcp-server-git"
mcp-tool-permission:
  - "git-server:git_status=auto"
mcp-server-env:
  - "git-server:GIT_SERVER=server"
```

# Todo:
- [ ] Add http support for remote MCP servers
- [ ] Change the way async is implemented in the mcp module ? Currently I used threading and message queue to keep everything else synchronous
- [x] Use a better structure for the config file ? I used a format that is easy to write for both the config file and the cli arguments
- [ ] Delete the command that I used to test mcp tools
- [ ] Add documentations
- [ ] Add MCP ressource
- [ ] Add MCP prompts
- [ ] Add tests
- [ ] Add anthropic's mcp dependency, since the feature depend on it. (I dont know how to add it in the requirements.txt properly)