### PR TITLE
Make run_stream handle reflections like run_one

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -828,7 +828,14 @@ class Coder:
     def run_stream(self, user_message):
         self.io.user_input(user_message)
         self.init_before_message()
-        yield from self.send_message(user_message)
+        while True:
+            yield from self.send_message(user_message)
+            if not self.reflected_message:
+                break
+            if self.num_reflections >= self.max_reflections:
+                self.io.tool_warning(f"Only {self.max_reflections} reflections allowed, stopping.")
+                break
+            self.num_reflections += 1
 
     def init_before_message(self):
         self.aider_edited_files = set()


### PR DESCRIPTION
The run_stream method would not handle reflected_message, so aider would just ignore them when using the browser gui. This change makes the reflected_message behavior equivalent between the browser gui and cli versions of aider.