### PR TITLE
Do not lowercase the _entirety_ of the commit message

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -10,7 +10,6 @@ one-line Git commit messages based on the provided diffs.
 Review the provided context and diffs which are about to be committed to a git repo.
 Review the diffs carefully.
 Generate a one-line commit message for those changes.
-The commit message should be entirely lowercase.
 The commit message should be structured as follows: <type>: <description>
 Use these for <type>: fix, feat, build, chore, ci, docs, style, refactor, perf, test
 


### PR DESCRIPTION
The recent prompt change has unintended consequences:

- 1. Using the word `entirety` has strong consequences for the commit message, see example where `class Scraper` was written as `scraper` (extrapolate to any other term / entity that Aider may change in the future)
- 2. Conventional commits themselves do not use everything as lowercase, see: [Conventional Commits commit history](https://github.com/conventional-commits/conventionalcommits.org/commits/master/)

Folks can use [`--commit-prompt`](https://aider.chat/docs/config/options.html#--commit-prompt-prompt) to adjust to their liking. _I just think this recent change will break the default for most folks._

Example where the latest commit message fails:

What is should be (capitalized `Add` and `Scraper`):
`docs: Add docstring to Scraper class explaining its purpose and attributes`

What it is instead:
`docs: add docstring to scraper class explaining its purpose and attributes`

```
# aider chat started at 2025-04-10 19:56:56

> Install the development version of aider from the main branch?  
> /Users/pjh/.local/share/uv/tools/aider-chat/bin/python -m pip install --upgrade --upgrade-strategy only-if-needed git+https://github.com/Aider-AI/aider.git  
> Run pip install? (Y)es/(N)o [Yes]: y  

# aider chat started at 2025-04-10 19:57:06

> /Users/pjh/.local/bin/aider  
> Aider v0.81.3.dev2+g8ee33da1  
> Main model: anthropic/claude-3-7-sonnet-20250219 with diff edit format, prompt cache, infinite output  
> Weak model: anthropic/claude-3-5-haiku-20241022  
> Git repo: .git with 649 files  
> Repo-map: using 4096 tokens, files refresh  
> Added ../../.llm.txt to the chat (read-only).  
> Cost estimates may be inaccurate when using streaming and caching.  

#### Add a docstring to Scraper  
> Initial repo scan can be slow in larger repos, but only happens once.  

To add a docstring to the Scraper class, I'll need to see the content of the `aider/scrape.py` file. Based on the file summary you provided, I can see that this file contains a `Scraper` class, but I don't have the actual content to edit.

Could you please add the `aider/scrape.py` file to the chat so I can make the necessary changes?

> Tokens: 10k sent, 86 received. Cost: $0.03 message, $0.03 session.  
> aider/scrape.py  
> Add file to the chat? (Y)es/(N)o/(D)on't ask again [Yes]: y  

I'll add a docstring to the Scraper class in the aider/scrape.py file. The docstring will explain the purpose of the class and its functionality.

aider/scrape.py
```python
<<<<<<< SEARCH
class Scraper:
    pandoc_available = None
    playwright_available = None
    playwright_instructions_shown = False

    # Public API...
=======
class Scraper:
    """
    A web scraping utility that converts web content to readable markdown.
    
    This class provides methods to scrape web content using either Playwright
    (for JavaScript-heavy sites) or HTTPX (for simpler sites). It can convert
    HTML content to markdown for better readability when communicating with LLMs.
    
    Attributes:
        pandoc_available (bool): Whether pandoc is available for HTML to markdown conversion
        playwright_available (bool): Whether playwright is available for browser-based scraping
        playwright_instructions_shown (bool): Whether playwright installation instructions were shown
    """
    pandoc_available = None
    playwright_available = None
    playwright_instructions_shown = False

    # Public API...
>>>>>>> REPLACE
```

> Tokens: 9.0k sent, 228 received. Cost: $0.03 message, $0.06 session.  
> Applied edit to aider/scrape.py  
> Commit b196127 docs: add docstring to scraper class explaining its purpose and attributes  
> You can use /undo to undo and discard each aider commit.  
```

<img width="725" alt="image" src="https://github.com/user-attachments/assets/976b5f9d-f5c7-48bc-82cc-48af95829015" />
