### PR TITLE
Update configargparse from 1.7 to 1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ click==8.1.8
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
-configargparse==1.7
+configargparse==1.7.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -523,6 +523,6 @@ zipp==3.21.0
     # via
     #   -c requirements/common-constraints.txt
     #   importlib-metadata
-    
+
 tree-sitter==0.23.2; python_version < "3.10"
 tree-sitter==0.24.0; python_version >= "3.10"

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -65,7 +65,7 @@ cogapp==3.4.1
     # via -r requirements/requirements-dev.in
 colorama==0.4.6
     # via griffe
-configargparse==1.7
+configargparse==1.7.1
     # via -r requirements/requirements.in
 contourpy==1.3.2
     # via matplotlib


### PR DESCRIPTION
Fixes the yank of 1.7 for bad python version metadata.

Fixes 

https://github.com/Aider-AI/aider/issues/4070
https://github.com/Aider-AI/aider/issues/4071
https://github.com/Aider-AI/aider/issues/4072