### PR TITLE
`o4-mini` was repeated multiple times and prevented applying custom configs

### DIFF
--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -1157,12 +1157,12 @@
   #  extra_body:
   #    reasoning_effort: high
 
-- name: openai/o4-mini
+- name: o4-mini
   edit_format: diff
-  weak_model_name: openai/gpt-4.1-mini
+  weak_model_name: gpt-4.1-mini
   use_repo_map: true
   use_temperature: false
-  editor_model_name: openai/gpt-4.1
+  editor_model_name: gpt-4.1
   editor_edit_format: editor-diff
   system_prompt_prefix: "Formatting re-enabled. "
   accepts_settings: ["reasoning_effort"]
@@ -1170,34 +1170,7 @@
   #extra_params:
   #  extra_body:
   #   reasoning_effort: high
-
-- name: openrouter/openai/o4-mini
-  edit_format: diff
-  weak_model_name: openrouter/openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openrouter/openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
-- name: azure/o4-mini
-  edit_format: diff
-  weak_model_name: azure/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: azure/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
+      
 
 - name: openai/o3
   streaming: false
@@ -1213,48 +1186,6 @@
   #  extra_body:
   #    reasoning_effort: high
 
-- name: openai/o4-mini
-  edit_format: diff
-  weak_model_name: openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
-- name: openrouter/openai/o4-mini
-  edit_format: diff
-  weak_model_name: openrouter/openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openrouter/openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
-- name: azure/o4-mini
-  edit_format: diff
-  weak_model_name: azure/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: azure/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
 - name: openrouter/openai/o3
   streaming: false
   edit_format: diff
@@ -1268,48 +1199,6 @@
   #extra_params:
   #  extra_body:
   #    reasoning_effort: high
-
-- name: openai/o4-mini
-  edit_format: diff
-  weak_model_name: openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
-- name: openrouter/openai/o4-mini
-  edit_format: diff
-  weak_model_name: openrouter/openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openrouter/openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-
-- name: azure/o4-mini
-  edit_format: diff
-  weak_model_name: azure/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: azure/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
 
 - name: azure/o3
   streaming: false
@@ -1325,53 +1214,6 @@
   #  extra_body:
   #    reasoning_effort: high
 
-- name: openai/o4-mini
-  edit_format: diff
-  weak_model_name: openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-
-- name: openrouter/openai/o4-mini
-  edit_format: diff
-  weak_model_name: openrouter/openai/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: openrouter/openai/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-
-- name: azure/o4-mini
-  edit_format: diff
-  weak_model_name: azure/gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: azure/gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-
-- name: o4-mini
-  edit_format: diff
-  weak_model_name: gpt-4.1-mini
-  use_repo_map: true
-  use_temperature: false
-  editor_model_name: gpt-4.1
-  editor_edit_format: editor-diff
-  system_prompt_prefix: "Formatting re-enabled. "
-  accepts_settings: ["reasoning_effort"]
-  examples_as_sys_msg: true
-  #extra_params:
-  #  extra_body:
-  #   reasoning_effort: high
-      
 - name: gemini/gemini-2.5-flash-preview-04-17
   edit_format: diff
   use_repo_map: true
@@ -1764,4 +1606,3 @@
   editor_model_name: openrouter/anthropic/claude-sonnet-4
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]
-


### PR DESCRIPTION
Currently, custom configs are applied to the first model having a specific name found in `MODEL_SETTINGS`.

However, it's not obvious that it's the same model that will be picked up for chatting.

I noticed this for `o4-mini`, but it may happen for other models also.

Another solution could be transforming the list into a dict.