### PR TITLE
fix: respect use_repo_map in model settings

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -308,7 +308,7 @@ class Coder:
         auto_commits=True,
         dirty_commits=True,
         dry_run=False,
-        map_tokens=1024,
+        map_tokens=None,
         verbose=False,
         stream=True,
         use_git=True,
@@ -485,8 +485,10 @@ class Coder:
                     self.io.tool_warning(f"Error: Read-only file {fname} does not exist. Skipping.")
 
         if map_tokens is None:
-            use_repo_map = main_model.use_repo_map
             map_tokens = 1024
+
+        if main_model.use_repo_map is not None:
+            use_repo_map = main_model.use_repo_map
         else:
             use_repo_map = map_tokens > 0
 

--- a/aider/models.py
+++ b/aider/models.py
@@ -111,7 +111,7 @@ class ModelSettings:
     name: str
     edit_format: str = "whole"
     weak_model_name: Optional[str] = None
-    use_repo_map: bool = False
+    use_repo_map: Optional[bool] = None
     send_undo_reply: bool = False
     lazy: bool = False
     overeager: bool = False

--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -139,7 +139,7 @@ cog.out("```\n")
 - name: (default values)
   edit_format: whole
   weak_model_name: null
-  use_repo_map: false
+  use_repo_map: null
   send_undo_reply: false
   lazy: false
   overeager: false


### PR DESCRIPTION
Closes #4188 

Adds a check if `use_repo_map` was set in model's config
In order to avoid nasty surprises also changes default value from `False` to `None` to keep current behavior for default configs 