### PR TITLE
fix: don't duplicate commit prompt one-line instruction

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -19,9 +19,6 @@ Ensure the commit message:{language_instruction}
 - Does not exceed 72 characters.
 
 Reply only with the one-line commit message, without any additional text, explanations, or line breaks.
-
-Reply only with the one-line commit message, without any additional text, explanations, \
-or line breaks.
 """
 
 # COMMANDS


### PR DESCRIPTION
The duplicate was added in https://github.com/Aider-AI/aider/commit/23714d7db617a90d05d4e21362326d498e4189ad

seemed unintentional, but if it was... feel free to close!