### PR TITLE
fix: Auto-create parent directories for chat history files

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -307,8 +307,9 @@ class InputOutput:
 
         self.yes = yes
 
+        if input_history_file is not None:
+            Path(input_history_file).mkdir(parents=True, exist_ok=True)
         self.input_history_file = input_history_file
-        Path(self.input_history_file).parent.mkdir(parents=True, exist_ok=True)
         self.llm_history_file = llm_history_file
         if chat_history_file is not None:
             self.chat_history_file = Path(chat_history_file)


### PR DESCRIPTION
This is follow up to #4257

There was a missing check for input_history_file = None case