### PR TITLE
Add SELinux volume label for Docker volumes

### DIFF
--- a/benchmark/docker.sh
+++ b/benchmark/docker.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
+VOLUME_LABEL=""
+
+if [ -f "/usr/bin/getenforce" ]; then
+  if [ "$(/usr/bin/getenforce)" == "Enforcing" ]; then
+    VOLUME_LABEL=":Z"
+  fi
+fi
+
 docker run \
        -it --rm \
        --memory=12g \
        --memory-swap=12g \
        --add-host=host.docker.internal:host-gateway \
-       -v `pwd`:/aider \
-       -v `pwd`/tmp.benchmarks/.:/benchmarks \
-       -e OPENAI_API_KEY=$OPENAI_API_KEY \
+       -v `pwd`:/aider$VOLUME_LABEL \
+       -v `pwd`/tmp.benchmarks/.:/benchmarks$VOLUME_LABEL \
+       -e OPENAI_API_KEY="$OPENAI_API_KEY" \
        -e HISTFILE=/aider/.bash_history \
        -e PROMPT_COMMAND='history -a' \
        -e HISTCONTROL=ignoredups \


### PR DESCRIPTION
This changes the script that enters the benchmarking docker image to check if the system is currently in "Enforcing" mode for SELinux and if it is will apply the private volume label flag to the container.