### PR TITLE
Clear chat history on model-specific max_done_messages option

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1419,9 +1419,6 @@ class Coder:
     def send_message(self, inp):
         self.event("message_send_starting")
 
-        # Notify IO that LLM processing is starting
-        self.io.llm_started()
-
         # Check if we need to clear old messages
         if (self.main_model.max_done_messages > 0 and 
             len(self.done_messages) >= self.main_model.max_done_messages):
@@ -1429,6 +1426,9 @@ class Coder:
                 f"Chat history has {len(self.done_messages)} messages (max is {self.main_model.max_done_messages}). Clear old messages?"
             ):
                 self.done_messages = []
+
+        # Notify IO that LLM processing is starting
+        self.io.llm_started()
 
         self.cur_messages += [
             dict(role="user", content=inp),

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1422,6 +1422,14 @@ class Coder:
         # Notify IO that LLM processing is starting
         self.io.llm_started()
 
+        # Check if we need to clear old messages
+        if (self.main_model.max_done_messages > 0 and 
+            len(self.done_messages) > self.main_model.max_done_messages):
+            if self.io.confirm_ask(
+                f"Chat history has {len(self.done_messages)} messages (max is {self.main_model.max_done_messages}). Clear old messages?"
+            ):
+                self.done_messages = []
+
         self.cur_messages += [
             dict(role="user", content=inp),
         ]

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1424,7 +1424,7 @@ class Coder:
 
         # Check if we need to clear old messages
         if (self.main_model.max_done_messages > 0 and 
-            len(self.done_messages) > self.main_model.max_done_messages):
+            len(self.done_messages) >= self.main_model.max_done_messages):
             if self.io.confirm_ask(
                 f"Chat history has {len(self.done_messages)} messages (max is {self.main_model.max_done_messages}). Clear old messages?"
             ):

--- a/aider/models.py
+++ b/aider/models.py
@@ -129,7 +129,7 @@ class ModelSettings:
     remove_reasoning: Optional[str] = None  # Deprecated alias for reasoning_tag
     system_prompt_prefix: Optional[str] = None
     accepts_settings: Optional[list] = None
-    max_done_messages: int = 0  # Maximum number of done messages to keep before clearing
+    max_done_messages: int = 0
 
 
 # Load model settings from package resource

--- a/aider/models.py
+++ b/aider/models.py
@@ -129,6 +129,7 @@ class ModelSettings:
     remove_reasoning: Optional[str] = None  # Deprecated alias for reasoning_tag
     system_prompt_prefix: Optional[str] = None
     accepts_settings: Optional[list] = None
+    max_done_messages: int = 0  # Maximum number of done messages to keep before clearing
 
 
 # Load model settings from package resource


### PR DESCRIPTION
This PR adds a max_done_messages key to ModelSettings. If it's greater than 0 then older messages will be removed after user confirmation.

**Use case:** I am using aider with a local model. My context size is limited (only 16k), so I had to use /clear to wipe the chat history every time I want to make multiple edits to the same file. This patch helps me to not forget to clear the context before submitting a prompt.