### PR TITLE
chore: bump tree-sitter from 0.24.0 to 0.25.0

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -11,6 +11,7 @@ from collections import Counter, defaultdict, namedtuple
 from importlib import resources
 from pathlib import Path
 
+import tree_sitter
 from diskcache import Cache
 from grep_ast import TreeContext, filename_to_lang
 from pygments.lexers import guess_lexer_for_filename
@@ -285,8 +286,12 @@ class RepoMap:
         tree = parser.parse(bytes(code, "utf-8"))
 
         # Run the tags queries
-        query = language.query(query_scm)
-        captures = query.captures(tree.root_node)
+        if sys.version_info >= (3, 10):
+            query = tree_sitter.Query(language, query_scm)
+            captures = tree_sitter.QueryCursor(query).captures(tree.root_node)
+        else:
+            query = language.query(query_scm)
+            captures = query.captures(tree.root_node)
 
         saw = set()
         if USING_TSL_PACK:

--- a/requirements.txt
+++ b/requirements.txt
@@ -525,4 +525,4 @@ zipp==3.23.0
     #   importlib-metadata
     
 tree-sitter==0.23.2; python_version < "3.10"
-tree-sitter==0.24.0; python_version >= "3.10"
+tree-sitter==0.25.1; python_version >= "3.10"

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -548,7 +548,7 @@ tqdm==4.67.1
     #   transformers
 transformers==4.52.4
     # via sentence-transformers
-tree-sitter==0.24.0
+tree-sitter==0.25.1
     # via tree-sitter-language-pack
 tree-sitter-c-sharp==0.23.1
     # via tree-sitter-language-pack

--- a/requirements/tree-sitter.in
+++ b/requirements/tree-sitter.in
@@ -1,3 +1,3 @@
     
 tree-sitter==0.23.2; python_version < "3.10"
-tree-sitter==0.24.0; python_version >= "3.10"
+tree-sitter==0.25.1; python_version >= "3.10"


### PR DESCRIPTION
This PR bump tree-sitter from 0.24.0 to [0.25.0](https://github.com/tree-sitter/py-tree-sitter/releases/tag/v0.25.0)

**Highlight of changelog**: 
- Deprecation: `Language.query(source)`: use `Query(language, source)`
- Removal: `Query.captures(node, predicate)`: moved to `QueryCursor.captures(node, predicate, progress_callback)`

close #4354
close #4368