### PR TITLE
Support loading config from XDG_CONFIG paths

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -791,8 +791,8 @@ def get_parser(default_config_files, git_root):
         is_config_file=True,
         metavar="CONFIG_FILE",
         help=(
-            "Specify the config file (default: search for .aider.conf.yml in git root, cwd"
-            " or home directory)"
+            "Specify the config file (default: search for .aider.conf.yml in git root, cwd, home"
+            " dir, and for conf.yml in ~/.config/aider)"
         ),
     ).complete = shtab.FILE
     # This is a duplicate of the argument in the preparser and is a no-op by this time of

--- a/aider/args_formatter.py
+++ b/aider/args_formatter.py
@@ -93,7 +93,7 @@ class YamlHelpFormatter(argparse.HelpFormatter):
 ##########################################################
 # Sample .aider.conf.yml
 # This file lists *all* the valid configuration entries.
-# Place in your home dir, or at the root of your git repo.
+# Place in your home dir, git repo root, or $XDG_CONFIG_HOME/aider/conf.yml.
 ##########################################################
 
 # Note: You can only put OpenAI and Anthropic API keys in the YAML

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -6,14 +6,15 @@ description: How to configure aider with a YAML config file.
 
 # YAML config file
 
-Most of aider's options can be set in an `.aider.conf.yml` file.
-Aider will look for a this file in these locations:
+Most of aider's options can be set in a YAML config file.
+Aider will look for config files in these locations:
 
-- Your home directory.
-- The root of your git repo.
-- The current directory.
+- Your home directory (`~/.aider.conf.yml`).
+- Your XDG config home in `$XDG_CONFIG_HOME/aider/`. Aider will look for `conf.yml` and `.aider.conf.yml`. If `$XDG_CONFIG_HOME` is not set, it defaults to `~/.config`.
+- The root of your git repo (`.aider.conf.yml`).
+- The current directory (`.aider.conf.yml`).
 
-If the files above exist, they will be loaded in that order. Files loaded last will take priority.
+If the files above exist, they will be loaded in that order. Settings from files loaded later take priority.
 
 You can also specify the `--config <filename>` parameter, which will only load the one config file.
 


### PR DESCRIPTION
Fixes #216 

Adds support for all config to be loaded from `$XDG_CONFIG_HOME/aider/`. When loading from this directory prefixing the individual files with `.aider.` is optional, so the main config file will also be detected if placed in `$XDG_CONFIG_HOME/aider/conf.yml`.

This PR does NOT include support for XDG_CACHE_HOME (mentioned as well in the issue), if this is merged I will open a new issue to track XDG_CACHE_HOME support