### PR TITLE
chore: version DeepSeek name and fix cost calculation

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -1,5 +1,5 @@
 {
-    "deepseek-reasoner": {
+    "deepseek/deepseek-reasoner": {
         "max_tokens": 64000,
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -12,10 +12,10 @@
         "mode": "chat",
         //"supports_function_calling": true,
         "supports_assistant_prefill": true,
-        //"supports_tool_choice": true,
+        "supports_tool_choice": false,
         "supports_prompt_caching": true
     },
-    "deepseek-chat": {
+    "deepseek/deepseek-chat": {
         "max_tokens": 8192,
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,

--- a/aider/website/_data/polyglot_leaderboard.yml
+++ b/aider/website/_data/polyglot_leaderboard.yml
@@ -1801,7 +1801,7 @@
 
 - dirname: 2025-10-03-09-45-34--deepseek-v3.2-reasoner
   test_cases: 225
-  model: deepseek/deepseek-reasoner
+  model: DeepSeek-V3.2-Exp (Reasoner)
   edit_format: diff
   commit_hash: cbb5376
   pass_rate_1: 39.6
@@ -1825,11 +1825,11 @@
   date: 2025-10-03
   versions: 0.86.2.dev
   seconds_per_case: 291.2
-  total_cost: 4.3854
+  total_cost: 1.3045
 
 - dirname: 2025-10-03-09-21-36--deepseek-v3.2-chat
   test_cases: 225
-  model: deepseek/deepseek-chat
+  model: DeepSeek-V3.2-Exp (Chat)
   edit_format: diff
   commit_hash: cbb5376
   pass_rate_1: 38.7
@@ -1853,4 +1853,4 @@
   date: 2025-10-03
   versions: 0.86.2.dev
   seconds_per_case: 104.0
-  total_cost: 1.0493
+  total_cost: 0.8756


### PR DESCRIPTION
The previous result had costs that don't match up with the cost update that was included, and don't align with what I was actually charged. I suspect the model metadata file was incorrect to begin with and that's why my update didn't have any affect.

This fixes the leaderboard to have the correct costs.

It also versions the model names, as the API endpoints tend to evolve with model updates.

![IMG_3394](https://github.com/user-attachments/assets/e00a55f0-b3ea-4814-b0b5-833a6d8a3e00)
