### PR TITLE
user preference Color added And added API Key

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -242,11 +242,11 @@ class InputOutput:
         chat_history_file=None,
         input=None,
         output=None,
-        user_input_color="blue",
+        user_input_color=None,
         tool_output_color=None,
-        tool_error_color="red",
-        tool_warning_color="#FFA500",
-        assistant_output_color="blue",
+        tool_error_color=None,
+        tool_warning_color=None,
+        assistant_output_color=None,
         completion_menu_color=None,
         completion_menu_bg_color=None,
         completion_menu_current_color=None,
@@ -264,6 +264,33 @@ class InputOutput:
         notifications=False,
         notifications_command=None,
     ):
+        # Prompt user for color choices at every run
+
+        from rich.console import Console
+        color_options = ["blue", "green", "red", "yellow", "magenta", "cyan", "white", "orange", "purple", "lime"]
+        preview_console = Console()
+
+        def ask_color(role, default):
+            while True:
+                preview_console.print(f"Select a color for [bold]{role}[/bold] (default: {default}):")
+                for color in color_options:
+                    preview_console.print(f"  [bold {color}]{color}[/bold {color}]", end="  ")
+                preview_console.print("\nOr enter any valid color name or hex code (e.g., #ff8800):")
+                choice = input(f"{role} color: ").strip()
+                if not choice:
+                    choice = default
+                # Try to preview the color
+                try:
+                    preview_console.print(f"Preview: [bold {choice}]{choice}[/bold {choice}]\n")
+                    return choice
+                except Exception:
+                    preview_console.print(f"[red]Invalid color:[/red] {choice}. Please try again.\n")
+
+        user_input_color = ask_color("user input", "blue")
+        assistant_output_color = ask_color("assistant output", "green")
+        tool_error_color = ask_color("error messages", "red")
+        tool_warning_color = ask_color("warning messages", "yellow")
+
         self.placeholder = None
         self.interrupted = False
         self.never_prompts = set()
@@ -284,7 +311,7 @@ class InputOutput:
         self.tool_output_color = ensure_hash_prefix(tool_output_color) if pretty else None
         self.tool_error_color = ensure_hash_prefix(tool_error_color) if pretty else None
         self.tool_warning_color = ensure_hash_prefix(tool_warning_color) if pretty else None
-        self.assistant_output_color = ensure_hash_prefix(assistant_output_color)
+        self.assistant_output_color = ensure_hash_prefix(assistant_output_color) if pretty else None
         self.completion_menu_color = ensure_hash_prefix(completion_menu_color) if pretty else None
         self.completion_menu_bg_color = (
             ensure_hash_prefix(completion_menu_bg_color) if pretty else None


### PR DESCRIPTION
I modified the Aider bot to allow users to customize their preferred colors for input, assistant output, errors, and warnings. Users are now prompted to select colors at startup, enhancing readability and personalization. Additionally, I added a .env file to store a free API key securely, simplifying configuration for new users.


<img width="827" height="111" alt="Screenshot 2025-10-10 094803" src="https://github.com/user-attachments/assets/cbd2c49e-1fde-4ff9-a3eb-94e6f0046fe9" />

<img width="891" height="246" alt="Screenshot 2025-10-10 094947" src="https://github.com/user-attachments/assets/3c2ac572-aeef-4230-8887-2ca01aaa72ad" />

<img width="925" height="898" alt="Screenshot 2025-10-10 095127" src="https://github.com/user-attachments/assets/0b4100b5-966d-4bc8-95db-f00a60bc6a09" />
