### PR TITLE
bug: Unskip `it` tests in JS benchmark

### DIFF
--- a/benchmark/npm-test.sh
+++ b/benchmark/npm-test.sh
@@ -9,5 +9,6 @@ set -e
 
 
 sed -i 's/\bxtest(/test(/g' *.spec.js
+sed -i 's/\bxit(/it(/g' *.spec.js
 npm run test
 


### PR DESCRIPTION
While most tests in the javascript polyglot-benchmark use `test`:

https://github.com/Aider-AI/polyglot-benchmark/blob/main/javascript/exercises/practice/connect/connect.spec.js

The `grep` problem uses `it`:

https://github.com/Aider-AI/polyglot-benchmark/blob/main/javascript/exercises/practice/grep/grep.spec.js

This PR updates the npm-test.sh script to also replace `xit` with `it`, so that the grep problem tests the full test suite instead of just two tests. They're used pretty interchangeably in the JS / TS ecosystems, so I think it's worth supporting both rather than changing the `grep` source.