### PR TITLE
add initial zig-tags.scm for repomap building

### DIFF
--- a/aider/queries/tree-sitter-languages/zig-tags.scm
+++ b/aider/queries/tree-sitter-languages/zig-tags.scm
@@ -1,0 +1,3 @@
+(FnProto) @name.definition.function
+(VarDecl "const" @name.definition.constant)
+(VarDecl "var"   @name.definition.variable)

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -334,6 +334,9 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_tsx(self):
         self._test_language_repo_map("tsx", "tsx", "UserProps")
 
+    def test_language_zig(self):
+        self._test_language_repo_map("zig", "zig", "add")
+
     def test_language_csharp(self):
         self._test_language_repo_map("csharp", "cs", "IGreeter")
 

--- a/tests/fixtures/languages/zig/test.zig
+++ b/tests/fixtures/languages/zig/test.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+
+pub fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("{}", .{add(2, 3)});
+}


### PR DESCRIPTION
Adds basic repomap support for zig. Beyond the included tests, here's an example of running  with these changes on an existing zig project:
```sh
❯ git clone https://github.com/BrookJeynes/jido.git
❯ cd jido
❯ AIDER_ANALYTICS_DISABLE=1 OPENAI_API_KEY=dummy \
                    aider \
                    --no-check-update \
                    --no-gitignore \
                    --show-repo-map > repomap.txt
```
[repomap.txt](https://github.com/user-attachments/files/23291152/repomap.txt)
