### PR TITLE
add initial haskell-tags.scm for repomap building

### DIFF
--- a/aider/queries/tree-sitter-languages/haskell-tags.scm
+++ b/aider/queries/tree-sitter-languages/haskell-tags.scm
@@ -1,0 +1,3 @@
+(function  (variable) @name.definition.function)
+(bind      (variable) @name.definition.function)
+(signature (variable) @name.definition.type)

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -302,6 +302,9 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_gleam(self):
         self._test_language_repo_map("gleam", "gleam", "greet")
 
+    def test_language_haskell(self):
+        self._test_language_repo_map("haskell", "hs", "add")
+
     def test_language_java(self):
         self._test_language_repo_map("java", "java", "Greeting")
 

--- a/tests/fixtures/languages/haskell/test.hs
+++ b/tests/fixtures/languages/haskell/test.hs
@@ -1,0 +1,7 @@
+module Main where
+
+add :: Int -> Int -> Int
+add a b = a + b
+
+main :: IO ()
+main = print (add 2 3)


### PR DESCRIPTION
Adds basic repomap support for haskell. Beyond the included tests, here's an example of running with these changes on an existing haskell project:

```shell
❯ git clone https://github.com/jaspervdj/websockets.git
❯ cd websockets
❯ AIDER_ANALYTICS_DISABLE=1 OPENAI_API_KEY=dummy \
                    aider \
                    --no-check-update \
                    --no-gitignore \
                    --show-repo-map > repomap.txt
```
[repomap.txt](https://github.com/user-attachments/files/23291212/repomap.txt)
