### PR TITLE
Added option so set custom request timeout in benchmarks.py

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -215,7 +215,7 @@ def main(
     exercises_dir: str = typer.Option(
         EXERCISES_DIR_DEFAULT, "--exercises-dir", help="Directory with exercise files"
     ),
-    timeout: Optional[int] = typer.Option(                                                                  ### ADDED THIS LINE
+    timeout: Optional[int] = typer.Option(                                                                 
         None, "--timeout", help="Per-request API timeout in seconds (passed to litellm)."
     ),
 ):
@@ -354,9 +354,9 @@ def main(
     base_coder.RETRY_TIMEOUT = LONG_TIMEOUT
     models.RETRY_TIMEOUT = LONG_TIMEOUT
 
-    # Request timeout - default is 600, increase to avoid request timed out             ### ADDED THIS LINE
-    if timeout:                                                                         ### ADDED THIS LINE
-        models.request_timeout = timeout                                                ### ADDED THIS LINE
+    # Request timeout - default is 600, increase to avoid request timed out             
+    if timeout:                                                                         
+        models.request_timeout = timeout                                               
 
     if threads == 1:
         all_results = []


### PR DESCRIPTION
Added timeout as an (optional) option in benchmarks.py. This way, even if a model takes longer to respond, the request won't timeout.

Fixes #4356 .

Usage: 

./benchmark/benchmark.py a-helpful-name-for-this-run --model gpt-3.5-turbo --edit-format whole --threads 10 --exercises-dir polyglot-benchmark --timeout 1000