### PR TITLE
Fix /clear command being undone when switching chat modes

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -173,6 +173,7 @@ class Coder:
                 read_only_fnames=list(from_coder.abs_read_only_fnames),  # Copy read-only files
                 done_messages=done_messages,
                 cur_messages=from_coder.cur_messages,
+                restore_chat_history=False,
                 aider_commit_hashes=from_coder.aider_commit_hashes,
                 commands=from_coder.commands.clone(),
                 total_cost=from_coder.total_cost,


### PR DESCRIPTION
When a user runs `/clear` to clear chat history and then switches to a different chat mode (e.g., `/ask`, `/code`, `/architect`), the cleared history was being restored from the chat history file, effectively undoing the /clear command.

Fix by setting `restore_chat_history=False` when creating a new coder from an existing one. This ensures the new coder respects the current chat state (including cleared history) rather than reloading from disk.

The chat history file restoration should only happen on initial startup, not when switching between chat modes within the same session.