### PR TITLE
Allow adding read-only files to editable with git: false.

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -864,7 +864,13 @@ class Commands:
                 self.io.tool_error(f"{matched_file} is already in the chat as an editable file")
                 continue
             elif abs_file_path in self.coder.abs_read_only_fnames:
-                if self.coder.repo and self.coder.repo.path_in_repo(matched_file):
+                # Determine if file can be promoted to editable
+                if self.coder.repo:
+                    can_edit = self.coder.repo.path_in_repo(matched_file)
+                else:
+                    can_edit = abs_file_path.startswith(self.coder.root)
+
+                if can_edit:
                     self.coder.abs_read_only_fnames.remove(abs_file_path)
                     self.coder.abs_fnames.add(abs_file_path)
                     self.io.tool_output(

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -571,7 +571,8 @@ class GitRepo:
             return
 
         tracked_files = set(self.get_tracked_files())
-        return self.normalize_path(path) in tracked_files
+        normalized = self.normalize_path(path)
+        return normalized in tracked_files
 
     def abs_root_path(self, path):
         res = Path(self.root) / path


### PR DESCRIPTION
When `git: false` is configured, aider won't promote a read-only file in the repo to editable:

> Cannot add /home/chrism/dev/runprompt/README.md as it's not part of the repository

This patch fixes that behaviour so it can promote the file to editable just as if it had been /add'ed.