### PR TITLE
Enable shell calls in /ask mode.

### DIFF
--- a/aider/coders/ask_coder.py
+++ b/aider/coders/ask_coder.py
@@ -1,5 +1,6 @@
 from .ask_prompts import AskPrompts
 from .base_coder import Coder
+from .editblock_coder import find_original_update_blocks
 
 
 class AskCoder(Coder):
@@ -7,3 +8,14 @@ class AskCoder(Coder):
 
     edit_format = "ask"
     gpt_prompts = AskPrompts()
+
+    def get_edits(self):
+        content = self.partial_response_content
+        try:
+            edits = list(find_original_update_blocks(content, self.fence))
+        except ValueError:
+            return []
+
+        self.shell_commands += [edit[1] for edit in edits if edit[0] is None]
+
+        return []

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -339,6 +339,7 @@ class Coder:
         auto_copy_context=False,
         auto_accept_architect=True,
     ):
+        print("DEBUG: base_coder.py is loaded and running")
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
 
@@ -1568,6 +1569,12 @@ class Coder:
 
             try:
                 if self.reply_completed():
+                    shared_output = self.run_shell_commands()
+                    if shared_output:
+                        self.cur_messages += [
+                            dict(role="user", content=shared_output),
+                            dict(role="assistant", content="Ok"),
+                        ]
                     return
             except KeyboardInterrupt:
                 interrupted = True


### PR DESCRIPTION
The LLM will sometimes suggest shell commands to run when in non-coding /ask mode (often to help figure something out) and this patch makes it simpler to run them.