### PR TITLE
Add new error types for API exceptions

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -20,6 +20,7 @@ EXCEPTIONS = [
         "The API provider is not able to authenticate you. Check your API key.",
     ),
     ExInfo("AzureOpenAIError", True, None),
+    ExInfo("BadGatewayError", True, "The API provider's gateway is down or overloaded."),
     ExInfo("BadRequestError", False, None),
     ExInfo("BudgetExceededError", True, None),
     ExInfo(
@@ -28,6 +29,8 @@ EXCEPTIONS = [
         "The API provider has refused the request due to a safety policy about the content.",
     ),
     ExInfo("ContextWindowExceededError", False, None),  # special case handled in base_coder
+    ExInfo("ErrorEventError", True, "The API provider encountered an error event."),
+    ExInfo("ImageFetchError", True, "Failed to fetch image from the provided URL."),
     ExInfo("InternalServerError", True, "The API provider's servers are down or overloaded."),
     ExInfo("InvalidRequestError", True, None),
     ExInfo("JSONSchemaValidationError", True, None),


### PR DESCRIPTION
I was running `aider-benchmark` with `llama-server` and I was following the guidance in README

These 3 errors are added so that I could continue with the testing process.

Attached here with the error message.

```
Traceback (most recent call last):                                                                                                                                                                                              
  File "/aider/./benchmark/benchmark.py", line 668, in run_test                                                                                                                                                                 
    return run_test_real(original_dname, testdir, *args, **kwargs)                                                                                                                                                              
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              
  File "/aider/./benchmark/benchmark.py", line 863, in run_test_real                                                                                                                                                            
    response = coder.run(with_message=instructions, preproc=False)                                                                                                                                                              
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              
  File "/aider/aider/exceptions.py", line 58, in __init__                                                                                                                                                                       
    self._load()                                                                                                                                                                                                                
  File "/aider/./benchmark/benchmark.py", line 668, in run_test                                                                                                                                                                 
    return run_test_real(original_dname, testdir, *args, **kwargs)                                                                                                                                                              
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              
  File "/aider/./benchmark/benchmark.py", line 863, in run_test_real                                                                                                                                                            
    response = coder.run(with_message=instructions, preproc=False)                                                                                                                                                              
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              
  File "/aider/aider/coders/base_coder.py", line 880, in run                                                                                                                                                                    
    self.run_one(with_message, preproc)                                                                                                                                                                                         
  File "/aider/aider/exceptions.py", line 66, in _load                                                                                                                                                                          
    raise ValueError(f"{var} is in litellm but not in aider's exceptions list")                                                                                                                                                 
  File "/aider/./benchmark/benchmark.py", line 863, in run_test_real                                                                                                                                                            
    response = coder.run(with_message=instructions, preproc=False)                                                                                                                                                              
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              
  File "/aider/aider/coders/base_coder.py", line 880, in run                                                                                                                                                                    
    self.run_one(with_message, preproc)                                                                                                                                                                                         
  File "/aider/aider/coders/base_coder.py", line 934, in run_one                                                                                                                                                                
    list(self.send_message(message))                                                                                                                                                                                            
ValueError: BadGatewayError is in litellm but not in aider's exceptions list                                                                                                                                                    
  File "/aider/aider/coders/base_coder.py", line 880, in run                                                                                                                                                                    
    self.run_one(with_message, preproc)                                                                                                                                                                                         
  File "/aider/aider/coders/base_coder.py", line 934, in run_one                                                                                                                                                                
    list(self.send_message(message))                                                                                                                                                                                            
  File "/aider/aider/coders/base_coder.py", line 934, in run_one                                                                                                                                                                
    list(self.send_message(message))                                                                                                                                                                                            
  File "/aider/aider/coders/base_coder.py", line 1451, in send_message                                                                                                                                                          
    litellm_ex = LiteLLMExceptions()                                                                                                                                                                                            
                 ^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                            
  File "/aider/aider/coders/base_coder.py", line 1451, in send_message                                                                                                                                                          
    litellm_ex = LiteLLMExceptions()                                                                                                                                                                                            
                 ^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                            
  File "/aider/aider/exceptions.py", line 58, in __init__                                                                                                                                                                       
    self._load()                                                                                                                                                                                                                
  File "/aider/aider/exceptions.py", line 58, in __init__                                                                                                                                                                       
    self._load()                                                                                                                                                                                                                
  File "/aider/aider/coders/base_coder.py", line 1451, in send_message                                                                                                                                                          
    litellm_ex = LiteLLMExceptions()                                                                                                                                                                                            
                 ^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                            
  File "/aider/aider/exceptions.py", line 66, in _load                                                                                                                                                                          
    raise ValueError(f"{var} is in litellm but not in aider's exceptions list")                                                                                                                                                 
  File "/aider/aider/exceptions.py", line 58, in __init__                                                                                                                                                                       
    self._load()                                                                                                                                                                                                                
ValueError: BadGatewayError is in litellm but not in aider's exceptions list                                                                                                                                                    
  File "/aider/aider/exceptions.py", line 66, in _load                                                                                                                                                                          
    raise ValueError(f"{var} is in litellm but not in aider's exceptions list")                                                                                                                                                 
  File "/aider/aider/exceptions.py", line 66, in _load                                                                                                                                                                          
    raise ValueError(f"{var} is in litellm but not in aider's exceptions list")                                                                                                                                                 
ValueError: BadGatewayError is in litellm but not in aider's exceptions list                                                                                                                                                    
ValueError: BadGatewayError is in litellm but not in aider's exceptions list   
```