### PR TITLE
Fix regression in the LiteLLM exception list

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -29,7 +29,6 @@ EXCEPTIONS = [
         "The API provider has refused the request due to a safety policy about the content.",
     ),
     ExInfo("ContextWindowExceededError", False, None),  # special case handled in base_coder
-    ExInfo("ErrorEventError", True, None),
     ExInfo("ImageFetchError", False, "The API provider was unable to fetch one or more images."),
     ExInfo("InternalServerError", True, "The API provider's servers are down or overloaded."),
     ExInfo("InvalidRequestError", True, None),
@@ -64,7 +63,10 @@ class LiteLLMExceptions:
         import litellm
 
         for var in dir(litellm):
-            if var.endswith("Error"):
+            # Filter by BaseException because instances of non-exception classes cannot be caught.
+            # `litellm.ErrorEventError` is an example of a regular class which just happens to end
+            # with `Error`.
+            if var.endswith("Error") and issubclass(getattr(litellm, var), BaseException):
                 if var not in self.exception_info:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 


### PR DESCRIPTION
In an attempt to fix issue #4615, commit 656301c introduced a regression where running the `coder` feature raises the following error:

> TypeError: catching classes that do not inherit from BaseException is not allowed

The primary misunderstanding that caused the regression is the fact that `ErrorEventError` sounds like an error class that needs to be included in the exceptions list. In reality, however, the name `ErrorEventError` is just a coincidence and actually belongs to a regular class, which doesn’t have `BaseException` in its chain of base classes.

Current Python versions raise a `TypeError` at runtime if you try to include such a class name in an `except` clause, which explains why the error shows up.

This PR narrows down the filter so it only tries to include actual exception classes and excludes classes like `ErrorEventError`.
It also removes `ErrorEventError` from the exception list.

Fixes issue #4615 and #4724. Reverts commit 656301c.
