### PR TITLE
Remove `google-generativeai` as a dependency.

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -82,10 +82,6 @@ class LiteLLMExceptions:
         import litellm
 
         if ex.__class__ is litellm.APIConnectionError:
-            if "google.auth" in str(ex):
-                return ExInfo(
-                    "APIConnectionError", False, "You need to: pip install google-generativeai"
-                )
             if "boto3" in str(ex):
                 return ExInfo("APIConnectionError", False, "You need to: pip install boto3")
             if "OpenrouterException" in str(ex) and "'choices'" in str(ex):

--- a/aider/website/docs/llms/gemini.md
+++ b/aider/website/docs/llms/gemini.md
@@ -35,15 +35,3 @@ aider --model gemini-exp
 aider --list-models gemini/
 ```
 
-You may need to install the `google-generativeai` package. 
-
-```bash
-# If you installed with aider-install or `uv tool`
-uv tool run --from aider-chat pip install google-generativeai
-
-# Or with pipx...
-pipx inject aider-chat google-generativeai
-
-# Or with pip
-pip install -U google-generativeai
-```

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,10 +41,6 @@ beautifulsoup4==4.14.3
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-cachetools==6.2.4
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-auth
 certifi==2025.11.12
     # via
     #   -c requirements/common-constraints.txt
@@ -110,55 +106,14 @@ gitpython==3.1.45
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-google-ai-generativelanguage==0.6.15
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-generativeai
-google-api-core[grpc]==2.28.1
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-generativeai
-google-api-python-client==2.187.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-generativeai
-google-auth==2.45.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
-    #   google-generativeai
-google-auth-httplib2==0.3.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-api-python-client
-google-generativeai==0.8.6
-    # via
-    #   -c requirements/common-constraints.txt
-    #   -r requirements/requirements.in
-googleapis-common-protos==1.72.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-api-core
-    #   grpcio-status
 grep-ast==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-grpcio==1.67.1
+grpcio==1.76.0
     # via
     #   -c requirements/common-constraints.txt
-    #   google-api-core
-    #   grpcio-status
     #   litellm
-grpcio-status==1.67.1
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-api-core
 h11==0.16.0
     # via
     #   -c requirements/common-constraints.txt
@@ -171,11 +126,6 @@ httpcore==1.0.9
     # via
     #   -c requirements/common-constraints.txt
     #   httpx
-httplib2==0.31.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-api-python-client
-    #   google-auth-httplib2
 httpx==0.28.1
     # via
     #   -c requirements/common-constraints.txt
@@ -304,20 +254,6 @@ propcache==0.4.1
     #   -c requirements/common-constraints.txt
     #   aiohttp
     #   yarl
-proto-plus==1.27.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-ai-generativelanguage
-    #   google-api-core
-protobuf==5.29.5
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-generativeai
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   proto-plus
 psutil==7.1.3
     # via
     #   -c requirements/common-constraints.txt
@@ -326,15 +262,6 @@ ptyprocess==0.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   pexpect
-pyasn1==0.6.1
-    # via
-    #   -c requirements/common-constraints.txt
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.2
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-auth
 pycodestyle==2.14.0
     # via
     #   -c requirements/common-constraints.txt
@@ -346,7 +273,6 @@ pycparser==2.23
 pydantic==2.12.5
     # via
     #   -c requirements/common-constraints.txt
-    #   google-generativeai
     #   litellm
     #   mixpanel
     #   openai
@@ -370,10 +296,6 @@ pypandoc==1.16.2
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-pyparsing==3.2.5
-    # via
-    #   -c requirements/common-constraints.txt
-    #   httplib2
 pyperclip==1.11.0
     # via
     #   -c requirements/common-constraints.txt
@@ -403,7 +325,6 @@ regex==2025.11.3
 requests==2.32.5
     # via
     #   -c requirements/common-constraints.txt
-    #   google-api-core
     #   huggingface-hub
     #   mixpanel
     #   posthog
@@ -417,10 +338,6 @@ rpds-py==0.30.0
     #   -c requirements/common-constraints.txt
     #   jsonschema
     #   referencing
-rsa==4.9.1
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-auth
 scipy==1.15.3
     # via
     #   -c requirements/common-constraints.txt
@@ -469,7 +386,6 @@ tokenizers==0.22.1
 tqdm==4.67.1
     # via
     #   -c requirements/common-constraints.txt
-    #   google-generativeai
     #   huggingface-hub
     #   openai
     # via
@@ -494,25 +410,18 @@ tree-sitter-yaml==0.7.2
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   beautifulsoup4
-    #   google-generativeai
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   posthog
     #   pydantic
     #   pydantic-core
-    #   referencing
     #   typing-inspection
 typing-inspection==0.4.2
     # via
     #   -c requirements/common-constraints.txt
     #   pydantic
-uritemplate==4.2.0
-    # via
-    #   -c requirements/common-constraints.txt
-    #   google-api-python-client
 urllib3==2.6.2
     # via
     #   -c requirements/common-constraints.txt

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -123,36 +123,21 @@ gitpython==3.1.45
     # via
     #   -r requirements/requirements.in
     #   streamlit
-google-ai-generativelanguage==0.6.15
-    # via google-generativeai
 google-api-core[grpc]==2.28.1
     # via
-    #   google-ai-generativelanguage
-    #   google-api-python-client
     #   google-cloud-bigquery
     #   google-cloud-core
-    #   google-generativeai
-google-api-python-client==2.187.0
-    # via google-generativeai
 google-auth==2.45.0
     # via
-    #   google-ai-generativelanguage
     #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
     #   google-cloud-bigquery
     #   google-cloud-core
-    #   google-generativeai
-google-auth-httplib2==0.3.0
-    # via google-api-python-client
 google-cloud-bigquery==3.39.0
     # via -r requirements/requirements-dev.in
 google-cloud-core==2.5.0
     # via google-cloud-bigquery
 google-crc32c==1.8.0
     # via google-resumable-media
-google-generativeai==0.8.6
-    # via -r requirements/requirements.in
 google-resumable-media==2.8.0
     # via google-cloud-bigquery
 googleapis-common-protos==1.72.0
@@ -167,12 +152,12 @@ grep-ast==0.9.0
     # via -r requirements/requirements.in
 griffe==1.15.0
     # via banks
-grpcio==1.67.1
+grpcio==1.76.0
     # via
     #   google-api-core
     #   grpcio-status
     #   litellm
-grpcio-status==1.67.1
+grpcio-status==1.76.0
     # via google-api-core
 h11==0.16.0
     # via httpcore
@@ -180,10 +165,6 @@ hf-xet==1.2.0
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
-httplib2==0.31.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
 httpx==0.28.1
     # via
     #   litellm
@@ -300,6 +281,45 @@ numpy==1.26.4
     #   soundfile
     #   streamlit
     #   transformers
+nvidia-cublas-cu12==12.8.4.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.8.90
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.8.93
+    # via torch
+nvidia-cuda-runtime-cu12==12.8.90
+    # via torch
+nvidia-cudnn-cu12==9.10.2.21
+    # via torch
+nvidia-cufft-cu12==11.3.3.83
+    # via torch
+nvidia-cufile-cu12==1.13.1.3
+    # via torch
+nvidia-curand-cu12==10.3.9.90
+    # via torch
+nvidia-cusolver-cu12==11.7.3.90
+    # via torch
+nvidia-cusparse-cu12==12.5.8.93
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cusparselt-cu12==0.7.1
+    # via torch
+nvidia-nccl-cu12==2.27.5
+    # via torch
+nvidia-nvjitlink-cu12==12.8.93
+    # via
+    #   nvidia-cufft-cu12
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+    #   torch
+nvidia-nvshmem-cu12==3.3.20
+    # via torch
+nvidia-nvtx-cu12==12.8.90
+    # via torch
 openai==2.13.0
     # via litellm
 oslex==0.1.3
@@ -356,14 +376,10 @@ propcache==0.4.1
     #   aiohttp
     #   yarl
 proto-plus==1.27.0
+    # via google-api-core
+protobuf==6.33.4
     # via
-    #   google-ai-generativelanguage
     #   google-api-core
-protobuf==5.29.5
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-generativeai
     #   googleapis-common-protos
     #   grpcio-status
     #   proto-plus
@@ -387,7 +403,6 @@ pycparser==2.23
 pydantic==2.12.5
     # via
     #   banks
-    #   google-generativeai
     #   litellm
     #   llama-index-core
     #   llama-index-instrumentation
@@ -411,9 +426,7 @@ pygments==2.19.2
 pypandoc==1.16.2
     # via -r requirements/requirements.in
 pyparsing==3.2.5
-    # via
-    #   httplib2
-    #   matplotlib
+    # via matplotlib
 pyperclip==1.11.0
     # via -r requirements/requirements.in
 pyproject-hooks==1.2.0
@@ -539,7 +552,6 @@ tornado==6.5.4
     # via streamlit
 tqdm==4.67.1
     # via
-    #   google-generativeai
     #   huggingface-hub
     #   llama-index-core
     #   nltk
@@ -558,15 +570,15 @@ tree-sitter-language-pack==0.13.0
     # via grep-ast
 tree-sitter-yaml==0.7.2
     # via tree-sitter-language-pack
+triton==3.5.1
+    # via torch
 typer==0.20.0
     # via -r requirements/requirements-dev.in
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   altair
-    #   anyio
     #   beautifulsoup4
-    #   google-generativeai
+    #   grpcio
     #   huggingface-hub
     #   llama-index-core
     #   llama-index-workflows
@@ -575,7 +587,6 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pyee
-    #   referencing
     #   sentence-transformers
     #   sqlalchemy
     #   streamlit
@@ -591,14 +602,14 @@ typing-inspection==0.4.2
     # via pydantic
 tzdata==2025.3
     # via pandas
-uritemplate==4.2.0
-    # via google-api-python-client
 urllib3==2.6.2
     # via requests
 uv==0.9.18
     # via -r requirements/requirements-dev.in
 virtualenv==20.35.4
     # via pre-commit
+watchdog==6.0.0
+    # via streamlit
 watchfiles==1.1.1
     # via -r requirements/requirements.in
 wcwidth==0.2.14

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -81,7 +81,7 @@ pillow==12.0.0
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-protobuf==5.29.5
+protobuf==6.33.4
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -143,7 +143,6 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
     #   altair
-    #   referencing
     #   streamlit
 tzdata==2025.3
     # via
@@ -153,3 +152,7 @@ urllib3==2.6.2
     # via
     #   -c requirements/common-constraints.txt
     #   requests
+watchdog==6.0.0
+    # via
+    #   -c requirements/common-constraints.txt
+    #   streamlit

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -85,12 +85,12 @@ googleapis-common-protos==1.72.0
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.67.1
+grpcio==1.76.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.67.1
+grpcio-status==1.76.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
@@ -179,7 +179,7 @@ proto-plus==1.27.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
-protobuf==5.29.5
+protobuf==6.33.4
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
@@ -268,6 +268,7 @@ typer==0.20.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
+    #   grpcio
     #   typer
 tzdata==2025.3
     # via

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -192,6 +192,72 @@ numpy==1.26.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu12==12.8.4.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.8.90
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-nvrtc-cu12==12.8.93
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-runtime-cu12==12.8.90
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cudnn-cu12==9.10.2.21
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cufft-cu12==11.3.3.83
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cufile-cu12==1.13.1.3
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-curand-cu12==10.3.9.90
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusolver-cu12==11.7.3.90
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusparse-cu12==12.5.8.93
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cusparselt-cu12==0.7.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-nccl-cu12==2.27.5
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-nvjitlink-cu12==12.8.93
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cufft-cu12
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+    #   torch
+nvidia-nvshmem-cu12==3.3.20
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-nvtx-cu12==12.8.90
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 packaging==25.0
     # via
     #   -c requirements/common-constraints.txt
@@ -304,11 +370,13 @@ transformers==4.57.3
     # via
     #   -c requirements/common-constraints.txt
     #   sentence-transformers
+triton==3.5.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   huggingface-hub
     #   llama-index-core
     #   llama-index-workflows

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -29,7 +29,6 @@ socksio
 pillow
 shtab
 oslex
-google-generativeai
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps


### PR DESCRIPTION
The `google-generativeai` package is deprecated, and emits warnings when it's imported. I'm doing some cleanup work to remove it from popular surfacess, so here's a PR :)

I'll note that `litellm` uses direct HTTP requests for the API, so it does not use `google-genai` (except for type checking) or `google-generativeai` (except for a deprecated PaLM codepath).