### PR TITLE
fix: Revert grpcio and protobuf to versions compatible with litellm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ grep-ast==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-grpcio==1.76.0
+grpcio==1.67.1
     # via
     #   -c requirements/common-constraints.txt
     #   litellm

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -152,12 +152,12 @@ grep-ast==0.9.0
     # via -r requirements/requirements.in
 griffe==1.15.0
     # via banks
-grpcio==1.76.0
+grpcio==1.67.1
     # via
     #   google-api-core
     #   grpcio-status
     #   litellm
-grpcio-status==1.76.0
+grpcio-status==1.67.1
     # via google-api-core
 h11==0.16.0
     # via httpcore
@@ -377,7 +377,7 @@ propcache==0.4.1
     #   yarl
 proto-plus==1.27.0
     # via google-api-core
-protobuf==6.33.4
+protobuf==5.29.5
     # via
     #   google-api-core
     #   googleapis-common-protos

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -85,12 +85,12 @@ googleapis-common-protos==1.72.0
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.76.0
+grpcio==1.67.1
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.76.0
+grpcio-status==1.67.1
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
@@ -179,7 +179,7 @@ proto-plus==1.27.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
-protobuf==6.33.4
+protobuf==5.29.5
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core


### PR DESCRIPTION
## Motivation

The recent removal of `google-generativeai` (commit d91c02c2) inadvertently bumped `grpcio` to `1.76.0` and `protobuf` to `6.33.4`. This caused a dependency conflict because `litellm` and `grpcio-status` require earlier versions, breaking the Docker build and installation. See error below when running `./benchmark/docker_build.sh`:

```
[+] Building 11.3s (15/17)                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 1.88kB                                                                                        0.0s
 => [internal] load metadata for docker.io/library/buildpack-deps:jammy                                                       2.2s
 => [internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 101B                                                                                             0.0s
 => [ 1/12] FROM docker.io/library/buildpack-deps:jammy@sha256:48db12716df6987b308b5c8e15f85c34674ba39c78e1db306f4af1faf13bc  0.0s
 => => resolve docker.io/library/buildpack-deps:jammy@sha256:48db12716df6987b308b5c8e15f85c34674ba39c78e1db306f4af1faf13bc6d  0.0s
 => [ 5/12] ADD https://sh.rustup.rs /tmp/rustup.sh                                                                           0.2s
 => [internal] load build context                                                                                             0.7s
 => => transferring context: 223.33MB                                                                                         0.7s
 => CACHED [ 2/12] RUN apt-get update && apt-get install -y     software-properties-common     cmake     libboost-all-dev     0.0s
 => CACHED [ 3/12] RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1                           0.0s
 => CACHED [ 4/12] RUN ARCH=$(uname -m) &&     if [ "$ARCH" = "x86_64" ]; then         GOARCH="amd64";     elif [ "$ARCH" =   0.0s
 => CACHED [ 5/12] ADD https://sh.rustup.rs /tmp/rustup.sh                                                                    0.0s
 => CACHED [ 6/12] RUN chmod +x /tmp/rustup.sh && /tmp/rustup.sh -y && rm /tmp/rustup.sh                                      0.0s
 => CACHED [ 7/12] RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - &&     apt-get install -y nodejs &&     rm   0.0s
 => [ 8/12] COPY . /aider                                                                                                     0.5s
 => [ 9/12] RUN pip3 install --no-cache-dir --upgrade pip uv                                                                  4.3s
 => ERROR [10/12] RUN uv pip install --system --no-cache-dir -e /aider[dev]                                                   3.3s
------
 > [10/12] RUN uv pip install --system --no-cache-dir -e /aider[dev]:
0.284 Using Python 3.11.14 environment at: /usr
3.266   × No solution found when resolving dependencies:
3.266   ╰─▶ Because litellm==1.80.10 depends on grpcio{python_full_version <
3.266       '3.14'}>=1.62.3,<1.68.0 and aider-chat==0.86.2.dev57+g4bf56b771
3.266       depends on grpcio==1.76.0, we can conclude that
3.266       aider-chat==0.86.2.dev57+g4bf56b771 and litellm==1.80.10 are
3.266       incompatible.
3.266       And because aider-chat==0.86.2.dev57+g4bf56b771
3.266       depends on litellm==1.80.10, we can conclude that
3.266       aider-chat==0.86.2.dev57+g4bf56b771 cannot be used.
3.266       And because only aider-chat[dev]==0.86.2.dev57+g4bf56b771 is available
3.266       and you require aider-chat[dev], we can conclude that your requirements
3.266       are unsatisfiable.
------
Dockerfile:62
--------------------
  60 |     COPY . /aider
  61 |     RUN pip3 install --no-cache-dir --upgrade pip uv
  62 | >>> RUN uv pip install --system --no-cache-dir -e /aider[dev]
  63 |     RUN git config --global --add safe.directory /aider
  64 |     WORKDIR /aider
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c uv pip install --system --no-cache-dir -e /aider[dev]" did not complete successfully: exit code: 1
```

## Modifications

This PR reverts:
- `grpcio` to `1.67.1`
- `grpcio-status` to `1.67.1`
- `protobuf` to `5.29.5`

## Tests

Verified that `./benchmark/docker_build.sh` now completes successfully.

cc @paul-gauthier