### PR TITLE
fix: support tree-sitter 0.22.0+ API change for query captures

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -286,7 +286,13 @@ class RepoMap:
 
         # Run the tags queries
         query = language.query(query_scm)
-        captures = query.captures(tree.root_node)
+
+        # Use iter_captures for newer tree-sitter versions (0.22.0+)
+        # which removed the captures() method
+        if hasattr(query, "captures"):
+            captures = query.captures(tree.root_node)
+        else:
+            captures = query.iter_captures(tree.root_node)
 
         saw = set()
         if USING_TSL_PACK:


### PR DESCRIPTION
The py-tree-sitter library removed the `captures()` method in version 0.22.0+. This change adds a fallback to use `iter_captures()` when `captures()` is not available, maintaining backward compatibility with older versions.

Fixes AttributeError: 'tree_sitter.Query' object has no attribute 'captures'