### PR TITLE
Remove the leading and trailing spaces from the user input content

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -253,7 +253,8 @@ class Commands:
         ]
 
     def is_command(self, inp):
-        return inp[0] in "/!"
+        inp = inp.lstrip()
+        return len(inp) > 0 and inp[0] in "/!"
 
     def get_raw_completions(self, cmd):
         assert cmd.startswith("/")
@@ -303,13 +304,17 @@ class Commands:
             return
 
         first_word = words[0]
-        rest_inp = inp[len(words[0]) :].strip()
+        rest_inp = inp[len(words[0]):].strip()
 
         all_commands = self.get_commands()
         matching_commands = [cmd for cmd in all_commands if cmd.startswith(first_word)]
         return matching_commands, first_word, rest_inp
 
     def run(self, inp):
+        inp = inp.strip()
+        if not inp:
+            return
+        
         if inp.startswith("!"):
             self.coder.event("command_run")
             return self.do_run("run", inp[1:])

--- a/aider/io.py
+++ b/aider/io.py
@@ -691,6 +691,7 @@ class InputOutput:
                 if self.clipboard_watcher:
                     self.clipboard_watcher.stop()
 
+            line = line.strip()
             if line.strip("\r\n") and not multiline_input:
                 stripped = line.strip("\r\n")
                 if stripped == "{":
@@ -711,7 +712,7 @@ class InputOutput:
                     inp = line
                     break
                 continue
-            elif multiline_input and line.strip():
+            elif multiline_input and line:
                 if multiline_tag:
                     # Check if line is exactly "tag}"
                     if line.strip("\r\n") == f"{multiline_tag}}}":
@@ -886,7 +887,9 @@ class InputOutput:
                     res = default
                     break
 
-                if not res:
+                if res and res.strip():
+                    res = res.strip()
+                else:
                     res = default
                     break
                 res = res.lower()


### PR DESCRIPTION
Resove: 1. '     /xxx' and '     ' (all spaces)will sent as a request;     2. '     Y' will return error when need user confirm