### PR TITLE
Control chat history

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -287,6 +287,20 @@ def get_parser(default_config_files, git_root):
         help=f"Specify the chat history file (default: {default_chat_history_file})",
     ).complete = shtab.FILE
     group.add_argument(
+        "--chat-history-max-size",
+        type=int,
+        default=1024 * 1024,  # 1MB
+        metavar="SIZE",
+        help="Maximum size of a single chat history file in bytes (default: 1MB)",
+    )
+    group.add_argument(
+        "--chat-history-max-files",
+        type=int,
+        default=10,
+        metavar="NUM",
+        help="Maximum number of chat history files to keep (default: 10)",
+    )
+    group.add_argument(
         "--restore-chat-history",
         action=argparse.BooleanOptionalAction,
         default=False,

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1044,6 +1044,10 @@ class Commands:
 
     def cmd_exit(self, args):
         "Exit the application"
+        # Check and rotate chat history before exiting
+        # self.io.tool_output("Exiting, checking chat history rotation...")
+        if hasattr(self.io, 'cleanup') and callable(self.io.cleanup):
+            self.io.cleanup()
         self.coder.event("exit", reason="/exit")
         sys.exit()
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -282,7 +282,7 @@ def parse_lint_cmds(lint_cmds, io):
         if re.match(r"^[a-z]+:.*", lint_cmd):
             pieces = lint_cmd.split(":")
             lang = pieces[0]
-            cmd = lint_cmd[len(lang) + 1 :]
+            cmd = lint_cmd[len(lang) + 1:]
             lang = lang.strip()
         else:
             lang = None
@@ -554,6 +554,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             args.yes_always,
             args.input_history_file,
             args.chat_history_file,
+            args.chat_history_max_size,
+            args.chat_history_max_files,
             input=input,
             output=output,
             user_input_color=args.user_input_color,


### PR DESCRIPTION
To prevent the chat history files from becoming too large and causing side effects on the main process. In fact, chat history files can easily become very large.

usage：--chat-history-max-size(defaute 1M), --chat-history-max-files(10), or add them to config file