### PR TITLE
Make the relevant naming meaningless in the example of customizing the output format for LLM

### DIFF
--- a/aider/coders/editblock_fenced_prompts.py
+++ b/aider/coders/editblock_fenced_prompts.py
@@ -7,49 +7,46 @@ class EditBlockFencedPrompts(EditBlockPrompts):
     example_messages = [
         dict(
             role="user",
-            content="Change get_factorial() to use math.factorial",
+            content="Change do_foo() to use lib.bar",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `mathweb/flask/app.py` to:
+            content="""To make this change we need to modify `src/app.py` to:
 
-1. Import the math package.
-2. Remove the existing factorial() function.
-3. Update get_factorial() to call math.factorial instead.
+1. Import the lib package.
+2. Remove the existing bar_val() function.
+3. Update do_foo() to call lib.bar instead.
 
 Here are the *SEARCH/REPLACE* blocks:
 
 {fence[0]}python
-mathweb/flask/app.py
+src/app.py
 <<<<<<< SEARCH
-from flask import Flask
+from lib_xyz import XYZ
 =======
-import math
-from flask import Flask
+import lib
+from lib_xyz import XYZ
 >>>>>>> REPLACE
 {fence[1]}
 
 {fence[0]}python
-mathweb/flask/app.py
+src/app.py
 <<<<<<< SEARCH
-def factorial(n):
-    "compute factorial"
+def bar_val(n):
+    "compute value"
 
-    if n == 0:
-        return 1
-    else:
-        return n * factorial(n-1)
+    return n + 1
 
 =======
 >>>>>>> REPLACE
 {fence[1]}
 
 {fence[0]}python
-mathweb/flask/app.py
+src/app.py
 <<<<<<< SEARCH
-    return str(factorial(n))
+    return str(bar_val(n))
 =======
-    return str(math.factorial(n))
+    return str(lib.bar(n))
 >>>>>>> REPLACE
 {fence[1]}
 <<<<<<< HEAD
@@ -57,37 +54,37 @@ mathweb/flask/app.py
         ),
         dict(
             role="user",
-            content="Refactor hello() into its own file.",
+            content="Refactor func_abc() into its own file.",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `main.py` and make a new file `hello.py`:
+            content="""To make this change we need to modify `main.py` and make a new file `utils.py`:
 
-1. Make a new hello.py file with hello() in it.
-2. Remove hello() from main.py and replace it with an import.
+1. Make a new utils.py file with func_abc() in it.
+2. Remove func_abc() from main.py and replace it with an import.
 
 Here are the *SEARCH/REPLACE* blocks:
 
 {fence[0]}python
-hello.py
+utils.py
 <<<<<<< SEARCH
 =======
-def hello():
-    "print a greeting"
+def func_abc():
+    "perform a task"
 
-    print("hello")
+    print("done")
 >>>>>>> REPLACE
 {fence[1]}
 
 {fence[0]}python
 main.py
 <<<<<<< SEARCH
-def hello():
-    "print a greeting"
+def func_abc():
+    "perform a task"
 
-    print("hello")
+    print("done")
 =======
-from hello import hello
+from utils import func_abc
 >>>>>>> REPLACE
 {fence[1]}
 """,
@@ -97,7 +94,7 @@ from hello import hello
     system_reminder = """
 # *SEARCH/REPLACE block* Rules:
 
-Every *SEARCH/REPLACE block* must use this format:
+Every *SEARCH/REPLACE* block must use this format:
 1. The opening fence and code language, eg: {fence[0]}python
 2. The *FULL* file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc.
 3. The start of search block: <<<<<<< SEARCH

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -33,86 +33,83 @@ ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*!
     example_messages = [
         dict(
             role="user",
-            content="Change get_factorial() to use math.factorial",
+            content="Change `do_foo` to use `lib.bar`",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `mathweb/flask/app.py` to:
+            content="""To make this change we need to modify `src/app.py` to:
 
-1. Import the math package.
-2. Remove the existing factorial() function.
-3. Update get_factorial() to call math.factorial instead.
+1. Import the lib package.
+2. Remove the existing bar_val() function.
+3. Update do_foo() to call lib.bar instead.
 
 Here are the *SEARCH/REPLACE* blocks:
 
-mathweb/flask/app.py
+src/app.py
 {fence[0]}python
 <<<<<<< SEARCH
-from flask import Flask
+from lib_xyz import XYZ
 =======
-import math
-from flask import Flask
+import lib
+from lib_xyz import XYZ
 >>>>>>> REPLACE
 {fence[1]}
 
-mathweb/flask/app.py
+src/app.py
 {fence[0]}python
 <<<<<<< SEARCH
-def factorial(n):
-    "compute factorial"
+def bar_val(n):
+    "compute value"
 
-    if n == 0:
-        return 1
-    else:
-        return n * factorial(n-1)
+    return n + 1
 
 =======
 >>>>>>> REPLACE
 {fence[1]}
 
-mathweb/flask/app.py
+src/app.py
 {fence[0]}python
 <<<<<<< SEARCH
-    return str(factorial(n))
+    return str(bar_val(n))
 =======
-    return str(math.factorial(n))
+    return str(lib.bar(n))
 >>>>>>> REPLACE
 {fence[1]}
 """,
         ),
         dict(
             role="user",
-            content="Refactor hello() into its own file.",
+            content="Refactor `func_abc` into its own file.",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `main.py` and make a new file `hello.py`:
+            content="""To make this change we need to modify `main.py` and make a new file `utils.py`:
 
-1. Make a new hello.py file with hello() in it.
-2. Remove hello() from main.py and replace it with an import.
+1. Make a new utils.py file with func_abc() in it.
+2. Remove func_abc() from main.py and replace it with an import.
 
 Here are the *SEARCH/REPLACE* blocks:
 
-hello.py
+utils.py
 {fence[0]}python
 <<<<<<< SEARCH
 =======
-def hello():
-    "print a greeting"
+def func_abc():
+    "perform a task"
 
-    print("hello")
+    print("done")
 >>>>>>> REPLACE
 {fence[1]}
 
 main.py
 {fence[0]}python
 <<<<<<< SEARCH
-def hello():
-    "print a greeting"
+def func_abc():
+    "perform a task"
 
-    print("hello")
+    print("done")
 =======
-from hello import hello
+from utils import func_abc
 >>>>>>> REPLACE
 {fence[1]}
 """,

--- a/aider/coders/patch_prompts.py
+++ b/aider/coders/patch_prompts.py
@@ -41,72 +41,69 @@ Consolidate **all** edits for a given file into a single `*** [ACTION] File:` bl
         # --- Example 1 ---------------------------------------------------- #
         dict(
             role="user",
-            content="Change get_factorial() to use math.factorial",
+            content="Change do_foo() to use lib.bar",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `mathweb/flask/app.py`:
+            content="""To make this change we need to modify `src/app.py`:
 
-1. Import the `math` module.
-2. Replace the custom recursive `factorial()` helper with `math.factorial`.
-3. Update `get_factorial()` to call `math.factorial`.
+1. Import the `lib` module.
+2. Replace the custom `bar_val()` helper with `lib.bar`.
+3. Update `do_foo()` to call `lib.bar`.
 
 Here is the patch:
 
 *** Begin Patch
-*** Update File: mathweb/flask/app.py
+*** Update File: src/app.py
 @@
--from flask import Flask
+-from lib_xyz import XYZ
 -
--from flask import Flask
-+from flask import Flask
-+import math
+-from lib_xyz import XYZ
++from lib_xyz import XYZ
++import lib
 @@
--def factorial(n):
--    "compute factorial"
+-def bar_val(n):
+-    "compute value"
 -
--    if n == 0:
--        return 1
--    else:
--        return n * factorial(n-1)
-+def factorial(n):
-+    "compute factorial"
+-    return n + 1
++def bar_val(n):
++    "compute value"
 +
-+    return math.factorial(n)
-@@     def get_factorial(self, n):
--    return str(factorial(n))
-+    return str(math.factorial(n))
++    return lib.bar(n)
+@@     def do_foo(self, n):
+-    return str(bar_val(n))
++    return str(lib.bar(n))
 *** End Patch
 """,
         ),
         # --- Example 2 ---------------------------------------------------- #
         dict(
             role="user",
-            content="Refactor hello() into its own file.",
+            content="Refactor func_abc() into its own file.",
         ),
         dict(
             role="assistant",
-            content="""To make this change we need to modify `main.py` and create a new file `hello.py`:
+            content="""To make this change we need to modify `main.py` and create a new file `utils.py`:
 
-1. Create `hello.py` with the `hello()` function.
-2. Remove `hello()` from `main.py` and import it instead.
+1. Create `utils.py` with the `func_abc()` function.
+2. Remove `func_abc()` from `main.py` and import it instead.
 
 Here is the patch:
 
 *** Begin Patch
-*** Add File: hello.py
+*** Add File: utils.py
 +# A simple function
-+def hello():
-+    "print a greeting"
++def func_abc():
++    "perform a task"
 +
-+    print("hello")
++    print("done")
 *** Update File: main.py
 @@
--def hello():
--    "print a greeting"
+-def func_abc():
+-    "perform a task"
 -
--    print("hello")
-+from hello import hello
+-    print("done")
++from utils import func_abc
 *** End Patch
 """,
         ),

--- a/aider/coders/udiff_prompts.py
+++ b/aider/coders/udiff_prompts.py
@@ -21,53 +21,40 @@ For each file that needs to be changed, write out the changes similar to a unifi
     example_messages = [
         dict(
             role="user",
-            content="Replace is_prime with a call to sympy.",
+            content="Replace foo_bar with a call to lib.aaa.",
         ),
         dict(
             role="assistant",
             content="""Ok, I will:
 
-1. Add an imports of sympy.
-2. Remove the is_prime() function.
-3. Replace the existing call to is_prime() with a call to sympy.isprime().
+1. Add an imports of lib.
+2. Remove the foo_bar() function.
+3. Replace the existing call to foo_bar() with a call to lib.aaa().
 
 Here are the diffs for those changes:
 
 ```diff
---- mathweb/flask/app.py
-+++ mathweb/flask/app.py
+--- src/app.py
++++ src/app.py
 @@ ... @@
--class MathWeb:
-+import sympy
+-class App:
++import lib
 +
-+class MathWeb:
++class App:
 @@ ... @@
--def is_prime(x):
--    if x < 2:
+-def foo_bar(x):
+-    if x < 0:
 -        return False
--    for i in range(2, int(math.sqrt(x)) + 1):
--        if x % i == 0:
--            return False
 -    return True
 @@ ... @@
--@app.route('/prime/<int:n>')
--def nth_prime(n):
--    count = 0
--    num = 1
--    while count < n:
--        num += 1
--        if is_prime(num):
--            count += 1
--    return str(num)
-+@app.route('/prime/<int:n>')
-+def nth_prime(n):
-+    count = 0
-+    num = 1
-+    while count < n:
-+        num += 1
-+        if sympy.isprime(num):
-+            count += 1
-+    return str(num)
+-@app.route('/check/<int:n>')
+-def do_check(n):
+-    if foo_bar(n):
+-        return str(n)
++@app.route('/check/<int:n>')
++def do_check(n):
++    if lib.aaa(n):
++        return str(n)
 ```
 """,
         ),


### PR DESCRIPTION
Make the relevant naming meaningless in the example of customizing the output format for LLM, making it simpler and devoid of any practical meaning. In order to prevent some modes（in my case: deepseek3.2 sometimes） from being led astray by the original keywords such as "flask" etc.