### PR TITLE
fix: add missing PermissionDeniedError to litellm exceptions list

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -36,6 +36,11 @@ EXCEPTIONS = [
     ExInfo("NotFoundError", False, None),
     ExInfo("OpenAIError", True, None),
     ExInfo(
+        "PermissionDeniedError",
+        False,
+        "The API provider denied access. Check your API key permissions.",
+    ),
+    ExInfo(
         "RateLimitError",
         True,
         "The API provider has rate limited you. Try again later or check your quotas.",

--- a/tests/basic/test_exceptions.py
+++ b/tests/basic/test_exceptions.py
@@ -65,6 +65,27 @@ def test_context_window_error():
     assert ex_info.retry is False
 
 
+def test_permission_denied_error():
+    """Test specific handling of PermissionDeniedError"""
+    ex = LiteLLMExceptions()
+    from litellm import PermissionDeniedError
+
+    import httpx
+
+    mock_request = httpx.Request("GET", "https://api.openai.com/v1/chat/completions")
+    mock_response = httpx.Response(status_code=403, request=mock_request)
+    perm_error = PermissionDeniedError(
+        message="Permission denied",
+        llm_provider="openai",
+        model="gpt-4",
+        response=mock_response,
+    )
+    ex_info = ex.get_ex_info(perm_error)
+    assert ex_info.name == "PermissionDeniedError"
+    assert ex_info.retry is False
+    assert "denied" in ex_info.description.lower()
+
+
 def test_openrouter_error():
     """Test specific handling of OpenRouter API errors"""
     ex = LiteLLMExceptions()


### PR DESCRIPTION
## Problem

`LiteLLMExceptions.__init__()` crashes with a `ValueError` when litellm includes exception classes not present in aider's `EXCEPTIONS` list:

```
ValueError: PermissionDeniedError is in litellm but not in aider's exceptions list
```

This is the same class of bug reported in #4829. The `_load()` method iterates `dir(litellm)` and raises `ValueError` for any `*Error` class that is a `BaseException` subclass but missing from aider's hardcoded list.

## Fix

- Added `PermissionDeniedError` to the `EXCEPTIONS` list as **non-retryable** (HTTP 403 — the user needs to fix their API key permissions, retrying won't help)
- Added a descriptive message: *"The API provider denied access. Check your API key permissions."*
- Added a test for the new exception

## Testing

All 7 tests in `tests/basic/test_exceptions.py` pass, including the new `test_permission_denied_error` test.

Fixes #4829