### PR TITLE
fix: use str.replace instead of str.format for commit prompt language instruction

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -336,7 +336,7 @@ class GitRepo:
         language_instruction = ""
         if user_language:
             language_instruction = f"\n- Is written in {user_language}."
-        system_content = system_content.format(language_instruction=language_instruction)
+        system_content = system_content.replace("{language_instruction}", language_instruction)
 
         commit_message = None
         for model in self.models:


### PR DESCRIPTION
## Summary

Fixes #4719.

When users set a custom `--commit-prompt` containing curly braces (e.g. `{message}`), the `str.format()` call in `get_commit_message()` raises a `KeyError` because it tries to interpolate all `{...}` placeholders — not just `{language_instruction}`.

This PR replaces `str.format(language_instruction=...)` with `str.replace("{language_instruction}", ...)` so that only the intended placeholder is substituted and any other curly-brace text in the prompt is left intact.

## Changes

- **aider/repo.py**: Replace `system_content.format(language_instruction=language_instruction)` with `system_content.replace("{language_instruction}", language_instruction)`
- **tests/basic/test_repo.py**: Add `test_get_commit_message_custom_prompt_with_extra_braces` — verifies that a custom prompt containing both `{language_instruction}` and an unrelated `{message}` placeholder does not raise a `KeyError`, and that only `{language_instruction}` is substituted.

## Test plan

- [x] `pytest tests/basic/test_repo.py::TestRepo::test_get_commit_message_custom_prompt_with_extra_braces` passes
- [x] Full test suite passes