### PR TITLE
Fix UnicodeDecodeError in load_gitignores()

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -56,7 +56,7 @@ def load_gitignores(gitignore_paths: list[Path]) -> Optional[PathSpec]:
     ]  # Always ignore
     for path in gitignore_paths:
         if path.exists():
-            with open(path) as f:
+            with open(path, encoding="utf-8", errors="replace") as f:
                 patterns.extend(f.readlines())
 
     return PathSpec.from_lines(GitWildMatchPattern, patterns) if patterns else None


### PR DESCRIPTION
## Summary

Fixes #2888 / #3076

`load_gitignores()` in `aider/watch.py` crashes with `UnicodeDecodeError` when a `.gitignore` file contains non-UTF-8 byte sequences. This adds `encoding="utf-8"` and `errors="replace"` to the `open()` call so invalid bytes are replaced with the Unicode replacement character instead of raising an exception.

## Changes

- `aider/watch.py`: Add `encoding="utf-8", errors="replace"` to `open(path)` in `load_gitignores()`
- `tests/basic/test_watch.py`: Add `test_gitignore_unicode_handling` covering both valid UTF-8 non-ASCII content and invalid byte sequences

## Test plan

- [x] `pytest tests/basic/test_watch.py::test_gitignore_unicode_handling` passes
- [x] Existing `test_gitignore_patterns` still passes
- [x] Full test suite passes