### PR TITLE
fix: handle symlink loops in safe_abs_path()

### DIFF
--- a/aider/utils.py
+++ b/aider/utils.py
@@ -95,7 +95,10 @@ def is_image_file(file_name):
 
 def safe_abs_path(res):
     "Gives an abs path, which safely returns a full (not 8.3) windows path"
-    res = Path(res).resolve()
+    try:
+        res = Path(res).resolve()
+    except (RuntimeError, OSError):
+        res = Path(res).absolute()
     return str(res)
 
 

--- a/tests/basic/test_utils.py
+++ b/tests/basic/test_utils.py
@@ -1,0 +1,15 @@
+import os
+
+from aider.utils import safe_abs_path
+
+
+def test_safe_abs_path_symlink_loop(tmp_path):
+    # Create circular symlink: a -> b -> a
+    link_a = tmp_path / "link_a"
+    link_b = tmp_path / "link_b"
+    link_a.symlink_to(link_b)
+    link_b.symlink_to(link_a)
+
+    # safe_abs_path must not raise, and must return an absolute path
+    result = safe_abs_path(str(link_a))
+    assert os.path.isabs(result)


### PR DESCRIPTION
## Summary

- Fixes #4711 — `Path.resolve()` raises `RuntimeError` when encountering circular symlinks (e.g. `v8/v8 -> v8/v8`), crashing aider during repo map generation.
- Wraps the `Path.resolve()` call in `safe_abs_path()` with a try/except for `RuntimeError` and `OSError`, falling back to `Path.absolute()` which doesn't follow symlinks.

## Test plan

- [x] New test `test_safe_abs_path_symlink_loop` creates a circular symlink pair and verifies `safe_abs_path()` returns an absolute path without raising
- [x] `pytest tests/basic/test_utils.py` passes