### PR TITLE
Fix AttributeError in exceptions.py when litellm missing expected exceptions

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -68,10 +68,17 @@ class LiteLLMExceptions:
             # with `Error`.
             if var.endswith("Error") and issubclass(getattr(litellm, var), BaseException):
                 if var not in self.exception_info:
-                    raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
+                    if strict:
+                        raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            ex = getattr(litellm, var, None)
+            if ex is None:
+                if strict:
+                    raise ValueError(
+                        f"{var} is in aider's exceptions list but not found in litellm"
+                    )
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):


### PR DESCRIPTION
## Summary

Fixes #4742

`LiteLLMExceptions._load()` crashes with `AttributeError` when litellm doesn't have an exception class listed in aider's `EXCEPTIONS` list (e.g., after a litellm version change removes or renames an exception).

**Changes:**
- `aider/exceptions.py`: Use `getattr(litellm, var, None)` instead of `getattr(litellm, var)` and skip `None` entries so missing exceptions don't crash initialization
- Wire up the existing but unused `strict=False` parameter: when `strict=True`, missing exceptions raise `ValueError` (useful for development/CI); when `False` (default), they're silently skipped
- `tests/basic/test_exceptions.py`: Add three tests:
  - `test_missing_litellm_exception_skipped` — mocks litellm without `BadGatewayError`, verifies `LiteLLMExceptions()` initializes, `exceptions_tuple()` returns valid tuple, `get_ex_info()` returns default for unknown
  - `test_strict_mode_raises_for_missing_exception` — verifies `strict=True` raises for exception in aider's list but not in litellm
  - `test_strict_mode_raises_for_unknown_litellm_exception` — verifies `strict=True` raises for exception in litellm but not in aider's list

## Test plan

- [x] `pytest tests/basic/test_exceptions.py` — all 9 tests pass
- [x] Existing tests unaffected