### PR TITLE
fix: catch MissingStyle in display_user_input for invalid color names

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -29,6 +29,7 @@ from pygments.token import Token
 from rich.color import ColorParseError
 from rich.columns import Columns
 from rich.console import Console
+from rich.errors import MissingStyle
 from rich.markdown import Markdown
 from rich.style import Style as RichStyle
 from rich.text import Text
@@ -770,7 +771,14 @@ class InputOutput:
         else:
             style = dict()
 
-        self.console.print(Text(inp), **style)
+        try:
+            self.console.print(Text(inp), **style)
+        except (MissingStyle, ValueError):
+            self.tool_warning(
+                f"Invalid color: {self.user_input_color}, using default color."
+            )
+            self.user_input_color = None
+            self.console.print(Text(inp))
 
     def user_input(self, inp, log_only=True):
         if not log_only:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -606,5 +606,28 @@ class TestInputOutputFormatFiles(unittest.TestCase):
         )
 
 
+class TestDisplayUserInput(unittest.TestCase):
+    def test_invalid_color_ansigray(self):
+        """Test that an invalid color like 'ansigray' doesn't crash."""
+        io = InputOutput(user_input_color="ansigray", pretty=True)
+        # Should not raise MissingStyle
+        io.display_user_input("hello")
+
+    def test_hex_color(self):
+        """Test that a hex color works fine."""
+        io = InputOutput(user_input_color="#bcbdbf", pretty=True)
+        io.display_user_input("hello")
+
+    def test_valid_named_color(self):
+        """Test that a valid named color works."""
+        io = InputOutput(user_input_color="red", pretty=True)
+        io.display_user_input("hello")
+
+    def test_no_color(self):
+        """Test that None color works (no style)."""
+        io = InputOutput(user_input_color=None, pretty=True)
+        io.display_user_input("hello")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2962.

- Invalid color names like `ansigray` passed via `--user-input-color` cause `console.print()` to raise `MissingStyle`, crashing `display_user_input()`
- Wraps `console.print()` in `try/except (MissingStyle, ValueError)` — on failure, warns the user and falls back to unstyled output
- Adds 4 tests covering invalid color (`ansigray`), hex color (`#bcbdbf`), valid named color (`red`), and `None`

## Test plan

- [x] `pytest tests/basic/test_io.py::TestDisplayUserInput` — all 4 new tests pass
- [x] `pytest tests/basic/test_io.py` — full file (27 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)