### PR TITLE
fix: handle OSError from Path.is_dir() when filename is invalid

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -701,7 +701,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     git_dname = None
     if len(all_files) == 1:
-        if Path(all_files[0]).is_dir():
+        try:
+            is_dir = Path(all_files[0]).is_dir()
+        except OSError:
+            is_dir = False
+        if is_dir:
             if args.git:
                 git_dname = str(Path(all_files[0]).resolve())
                 fnames = []


### PR DESCRIPTION
## Summary

Fixes #4740.

- When `--system_prompt` or similar values are mistakenly treated as filenames, `Path(all_files[0]).is_dir()` in `main.py` line 704 can raise `OSError` (e.g. "File name too long"), crashing aider
- Wraps the call in `try/except OSError`, treating the exception as "not a directory"
- Adds a test that mocks `Path.is_dir()` to raise `OSError` for a specific filename and verifies `main()` handles it gracefully

## Test plan

- [x] `pytest tests/basic/test_main.py::TestMain::test_main_oserror_on_is_dir` passes
- [x] Existing test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)