### PR TITLE
Fix: Handle missing tiktoken dependency in LazyLiteLLM

### DIFF
--- a/aider/llm.py
+++ b/aider/llm.py
@@ -34,7 +34,20 @@ class LazyLiteLLM:
         if VERBOSE:
             print("Loading litellm...")
 
-        self._lazy_module = importlib.import_module("litellm")
+        try:
+            self._lazy_module = importlib.import_module("litellm")
+        except (ImportError, ModuleNotFoundError) as e:
+            # Handle missing dependencies for litellm (e.g., tiktoken)
+            if "tiktoken" in str(e):
+                raise ModuleNotFoundError(
+                    "Missing required dependency 'tiktoken' for litellm. "
+                    "Please reinstall aider with: pip install --upgrade --force-reinstall aider-chat"
+                ) from e
+            else:
+                raise ModuleNotFoundError(
+                    f"Failed to import litellm due to missing dependency: {e}. "
+                    "Please reinstall aider with: pip install --upgrade --force-reinstall aider-chat"
+                ) from e
 
         self._lazy_module.suppress_debug_info = True
         self._lazy_module.set_verbose = False


### PR DESCRIPTION
## Problem

Users encounter uncaught ModuleNotFoundError for 'tiktoken' when aider tries to load litellm during model sanity checks (issue #4848). This results in a cryptic stack trace that doesn't provide actionable guidance.

## Root Cause

The LazyLiteLLM._load_litellm() method imports litellm without error handling. When litellm's dependencies (like tiktoken) are missing, the import fails with an unhelpful stack trace.

## Solution

Added proper error handling in _load_litellm() to:
- Catch ImportError and ModuleNotFoundError during litellm import
- Provide specific, helpful error message for tiktoken missing case
- Give generic helpful message for other missing dependencies  
- Suggest reinstallation command to resolve the issue

## Changes

- Modified aider/llm.py: Added try-except block around importlib.import_module('litellm')
- Specific error handling for tiktoken dependency
- Clear error messages with installation instructions

## Testing

Verified the fix handles both tiktoken-specific errors and general import errors gracefully, providing actionable error messages instead of stack traces.

Fixes #4848