### PR TITLE
feat: Add native EUrouter provider support

### DIFF
--- a/aider/eurouter.py
+++ b/aider/eurouter.py
@@ -1,0 +1,128 @@
+"""
+EUrouter model metadata caching and lookup.
+
+This module keeps a local cached copy of the EUrouter model list
+(downloaded from ``https://api.eurouter.ai/api/v1/models``) and exposes a
+helper class that returns metadata for a given model in a format compatible
+with litellm's ``get_model_info``.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict
+
+import requests
+
+
+def _cost_per_token(val: str | None) -> float | None:
+    """Convert a price string (USD per token) to a float."""
+    if val in (None, "", "0"):
+        return 0.0 if val == "0" else None
+    try:
+        return float(val)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+class EURouterModelManager:
+    MODELS_URL = "https://api.eurouter.ai/api/v1/models"
+    CACHE_TTL = 60 * 60 * 24  # 24 h
+
+    def __init__(self) -> None:
+        self.cache_dir = Path.home() / ".aider" / "caches"
+        self.cache_file = self.cache_dir / "eurouter_models.json"
+        self.content: Dict | None = None
+        self.verify_ssl: bool = True
+        self._cache_loaded = False
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                         #
+    # ------------------------------------------------------------------ #
+    def set_verify_ssl(self, verify_ssl: bool) -> None:
+        """Enable/disable SSL verification for API requests."""
+        self.verify_ssl = verify_ssl
+
+    def get_model_info(self, model: str) -> Dict:
+        """
+        Return metadata for *model* or an empty ``dict`` when unknown.
+
+        ``model`` should use the aider naming convention, e.g.
+        ``eurouter/claude-opus-4-6`` or ``eurouter/deepseek-r1:free``.
+        """
+        self._ensure_content()
+        if not self.content or "data" not in self.content:
+            return {}
+
+        route = self._strip_prefix(model)
+
+        # Consider both the exact id and id without any ":suffix".
+        candidates = {route}
+        if ":" in route:
+            candidates.add(route.split(":", 1)[0])
+
+        record = next((item for item in self.content["data"] if item.get("id") in candidates), None)
+        if not record:
+            return {}
+
+        context_len = (
+            record.get("top_provider", {}).get("context_length")
+            or record.get("context_length")
+            or None
+        )
+
+        pricing = record.get("pricing", {})
+        return {
+            "max_input_tokens": context_len,
+            "max_tokens": context_len,
+            "max_output_tokens": context_len,
+            "input_cost_per_token": _cost_per_token(pricing.get("prompt")),
+            "output_cost_per_token": _cost_per_token(pricing.get("completion")),
+            "litellm_provider": "eurouter",
+        }
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                   #
+    # ------------------------------------------------------------------ #
+    def _strip_prefix(self, model: str) -> str:
+        return model[len("eurouter/") :] if model.startswith("eurouter/") else model
+
+    def _ensure_content(self) -> None:
+        self._load_cache()
+        if not self.content:
+            self._update_cache()
+
+    def _load_cache(self) -> None:
+        if self._cache_loaded:
+            return
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            if self.cache_file.exists():
+                cache_age = time.time() - self.cache_file.stat().st_mtime
+                if cache_age < self.CACHE_TTL:
+                    try:
+                        self.content = json.loads(self.cache_file.read_text())
+                    except json.JSONDecodeError:
+                        self.content = None
+        except OSError:
+            # Cache directory might be unwritable; ignore.
+            pass
+
+        self._cache_loaded = True
+
+    def _update_cache(self) -> None:
+        try:
+            response = requests.get(self.MODELS_URL, timeout=10, verify=self.verify_ssl)
+            if response.status_code == 200:
+                self.content = response.json()
+                try:
+                    self.cache_file.write_text(json.dumps(self.content, indent=2))
+                except OSError:
+                    pass  # Non-fatal if we can't write the cache
+        except Exception as ex:  # noqa: BLE001
+            print(f"Failed to fetch EUrouter model list: {ex}")
+            try:
+                self.cache_file.write_text("{}")
+            except OSError:
+                pass

--- a/aider/onboarding.py
+++ b/aider/onboarding.py
@@ -49,6 +49,11 @@ def try_to_select_default_model():
     Returns:
         The name of the selected model, or None if no suitable default is found.
     """
+    # EUrouter
+    eurouter_key = os.environ.get("EUROUTER_API_KEY")
+    if eurouter_key:
+        return "eurouter/claude-sonnet-4-5"
+
     # Special handling for OpenRouter
     openrouter_key = os.environ.get("OPENROUTER_API_KEY")
     if openrouter_key:

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -2716,3 +2716,45 @@
   use_repo_map: true
   use_temperature: false
   accepts_settings: ["reasoning_effort"]
+
+# EUrouter models
+- name: eurouter/claude-sonnet-4-5
+  edit_format: diff
+  weak_model_name: eurouter/claude-haiku-4-5
+  use_repo_map: true
+  examples_as_sys_msg: false
+  extra_params:
+    max_tokens: 64000
+  editor_model_name: eurouter/claude-sonnet-4-5
+  editor_edit_format: editor-diff
+  accepts_settings: ["thinking_tokens"]
+
+- name: eurouter/claude-opus-4-6
+  edit_format: diff
+  weak_model_name: eurouter/claude-haiku-4-5
+  use_repo_map: true
+  examples_as_sys_msg: false
+  extra_params:
+    max_tokens: 128000
+  editor_model_name: eurouter/claude-sonnet-4-5
+  editor_edit_format: editor-diff
+  accepts_settings: ["thinking_tokens"]
+
+- name: eurouter/claude-haiku-4-5
+  edit_format: diff
+  weak_model_name: eurouter/claude-haiku-4-5
+  use_repo_map: true
+  examples_as_sys_msg: false
+  extra_params:
+    max_tokens: 64000
+
+- name: eurouter/deepseek-r1
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  use_temperature: false
+  reasoning_tag: think
+
+- name: eurouter/mistral-large-3
+  edit_format: diff
+  use_repo_map: true

--- a/aider/website/docs/config/api-keys.md
+++ b/aider/website/docs/config/api-keys.md
@@ -71,7 +71,8 @@ is a great place to store your API keys and other provider API environment varia
 ```bash
 GEMINI_API_KEY=foo
 OPENROUTER_API_KEY=bar
-DEEPSEEK_API_KEY=baz
+EUROUTER_API_KEY=baz
+DEEPSEEK_API_KEY=qux
 ```
 
 #### YAML config file
@@ -85,6 +86,7 @@ via the `api-key` entry:
 api-key:
 - gemini=foo      # Sets env var GEMINI_API_KEY=foo
 - openrouter=bar  # Sets env var OPENROUTER_API_KEY=bar
-- deepseek=baz    # Sets env var DEEPSEEK_API_KEY=baz
+- eurouter=baz    # Sets env var EUROUTER_API_KEY=baz
+- deepseek=qux    # Sets env var DEEPSEEK_API_KEY=qux
 ```
 

--- a/aider/website/docs/llms/eurouter.md
+++ b/aider/website/docs/llms/eurouter.md
@@ -5,26 +5,18 @@ nav_order: 500
 
 # EUrouter
 
-Aider can connect to the 100+ models available on [EUrouter](https://eurouter.ai),
-a European AI routing API with GDPR-compliant EU data residency by default.
-
+Aider can connect to [models provided by EUrouter](https://eurouter.ai):
 You'll need an [EUrouter API key](https://eurouter.ai).
 
 First, install aider:
 
 {% include install.md %}
 
-Then configure your API keys:
+Then configure your API key:
 
 ```
-# Mac/Linux:
-export OPENAI_API_BASE=https://api.eurouter.ai/api/v1
-export EUROUTER_API_KEY=eur-...
-
-# Windows:
-setx OPENAI_API_BASE https://api.eurouter.ai/api/v1
-setx EUROUTER_API_KEY eur-...
-# ... restart shell after setx commands
+export EUROUTER_API_KEY=<key> # Mac/Linux
+setx   EUROUTER_API_KEY <key> # Windows, restart shell after setx
 ```
 
 Start working with aider and EUrouter on your codebase:
@@ -33,19 +25,67 @@ Start working with aider and EUrouter on your codebase:
 # Change directory into your codebase
 cd /to/your/project
 
-# Use any model available on EUrouter
-aider --model openai/claude-opus-4-6
-aider --model openai/mistral-large-3
-aider --model openai/deepseek-r1
-aider --model openai/gpt-5-mini
-aider --model openai/gpt-oss-120b
-aider --model openai/green-r
-aider --model openai/kimi-k2.5
+# Use any EUrouter model
+aider --model eurouter/<model>
+
+# List models available from EUrouter
+aider --list-models eurouter/
 ```
 
-Since EUrouter uses the OpenAI-compatible API format, it works with aider's
-existing OpenAI provider by setting the base URL. All requests are routed
-through EU infrastructure.
+For example:
+
+```bash
+aider --model eurouter/claude-opus-4-6
+aider --model eurouter/deepseek-r1
+aider --model eurouter/mistral-large-3
+```
+
+## Model variants
+
+EUrouter supports model variants that control provider selection.
+Append a variant suffix to any model name:
+
+```bash
+aider --model eurouter/claude-opus-4-6:floor  # Cheapest provider
+aider --model eurouter/claude-opus-4-6:nitro  # Fastest provider
+aider --model eurouter/deepseek-r1:free       # Free providers only
+```
+
+## Controlling provider routing
+
+EUrouter routes each request to an optimal provider based on health, price,
+and availability. You can control which providers are used for your requests
+by configuring "provider routing" in a `.aider.model.settings.yml` file.
+
+Place that file in your home directory or the root of your git project, with
+entries like this:
+
+```yaml
+- name: eurouter/claude-opus-4-6
+  extra_params:
+    extra_body:
+      provider:
+        # Only use these providers, in this order
+        order: ["anthropic", "scaleway"]
+        # Don't fall back to other providers
+        allow_fallbacks: false
+        # Skip providers that may train on inputs
+        data_collection: "deny"
+        # Only use providers supporting all parameters
+        require_parameters: true
+        # Only process in EU/EEA regions
+        data_residency: "eu"
+        # Only use EU-headquartered providers (Scaleway, OVHcloud, IONOS, GreenPT)
+        eu_owned: true
+```
+
+EUrouter routes through EU infrastructure by default. The `data_residency`
+and `eu_owned` options provide stricter control for compliance requirements.
+
+See [EUrouter's provider routing docs](https://eurouter.ai/docs/provider-routing) for full details on these settings.
+
+See [Advanced model settings](https://aider.chat/docs/config/adv-model-settings.html#model-settings)
+for more details about model settings files.
 
 See the [model warnings](warnings.html)
 section for information on warnings which will occur

--- a/tests/basic/test_eurouter.py
+++ b/tests/basic/test_eurouter.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+from aider.eurouter import EURouterModelManager
+from aider.models import ModelInfoManager
+
+
+class DummyResponse:
+    """Minimal stand-in for requests.Response used in tests."""
+
+    def __init__(self, json_data):
+        self.status_code = 200
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+def test_eurouter_get_model_info_from_cache(monkeypatch, tmp_path):
+    """
+    EURouterModelManager should return correct metadata taken from the
+    downloaded (and locally cached) models JSON payload.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "claude-opus-4-6",
+                "context_length": 200000,
+                "pricing": {"prompt": "0.000015", "completion": "0.000075"},
+                "top_provider": {"context_length": 200000},
+            }
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = EURouterModelManager()
+    info = manager.get_model_info("eurouter/claude-opus-4-6")
+
+    assert info["max_input_tokens"] == 200000
+    assert info["input_cost_per_token"] == 0.000015
+    assert info["output_cost_per_token"] == 0.000075
+    assert info["litellm_provider"] == "eurouter"
+
+
+def test_eurouter_model_with_variant(monkeypatch, tmp_path):
+    """
+    EURouterModelManager should handle :variant suffixes correctly,
+    falling back to the base model ID.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "claude-opus-4-6",
+                "context_length": 200000,
+                "pricing": {"prompt": "0.000015", "completion": "0.000075"},
+                "top_provider": {"context_length": 200000},
+            }
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = EURouterModelManager()
+    info = manager.get_model_info("eurouter/claude-opus-4-6:floor")
+
+    assert info["max_input_tokens"] == 200000
+    assert info["litellm_provider"] == "eurouter"
+
+
+def test_model_info_manager_uses_eurouter_manager(monkeypatch):
+    """
+    ModelInfoManager should delegate to EURouterModelManager when litellm
+    provides no data for a eurouter/-prefixed model.
+    """
+    monkeypatch.setattr("aider.models.litellm.get_model_info", lambda *a, **k: {})
+
+    stub_info = {
+        "max_input_tokens": 200000,
+        "max_tokens": 200000,
+        "max_output_tokens": 200000,
+        "input_cost_per_token": 0.000015,
+        "output_cost_per_token": 0.000075,
+        "litellm_provider": "eurouter",
+    }
+
+    monkeypatch.setattr(
+        "aider.models.EURouterModelManager.get_model_info",
+        lambda self, model: stub_info,
+    )
+
+    mim = ModelInfoManager()
+    info = mim.get_model_info("eurouter/claude-opus-4-6")
+
+    assert info == stub_info


### PR DESCRIPTION
## Summary
- Adds first-class `eurouter/` model prefix support, matching the existing `openrouter/` integration
- Users can now use `aider --model eurouter/<model>` with just `EUROUTER_API_KEY` set
- [EUrouter](https://eurouter.ai) is a European AI routing API with sovereign, GDPR-compliant access to 100+ AI models with EU data residency by default

## Changes
- **`aider/eurouter.py`** (new): `EURouterModelManager` for model metadata caching from EUrouter API
- **`aider/models.py`**: Key validation, model info fallback, `is_openrouter_compatible()` helper for shared reasoning format, `send_completion` rewriting (`eurouter/` → `openai/` + api_base + api_key for litellm)
- **`aider/onboarding.py`**: Auto-model selection when `EUROUTER_API_KEY` is set
- **`aider/resources/model-settings.yml`**: Pre-configured settings for popular EUrouter models
- **`aider/website/docs/llms/eurouter.md`**: Provider docs page with native `eurouter/` prefix
- **`aider/website/docs/config/api-keys.md`**: Added EUrouter to API key examples
- **`tests/basic/test_eurouter.py`** (new): Unit tests for model manager and integration

## Configuration
```bash
export EUROUTER_API_KEY=eur-...

aider --model eurouter/claude-opus-4-6
```

## Test plan
- [x] Unit tests pass (`python -m pytest tests/basic/test_eurouter.py -v`)
- [x] OpenRouter tests still pass (no regressions)
- [x] Integration tests verify: key validation, model settings, reasoning format, model rewriting, onboarding auto-selection
- [ ] End-to-end test with real EUrouter API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)