### PR TITLE
feat: add double-buffer context management

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -226,6 +226,24 @@ def get_parser(default_config_files, git_root):
             " If unspecified, defaults to the model's max_chat_history_tokens."
         ),
     )
+    group.add_argument(
+        "--double-buffer",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable double-buffer context management (checkpoint at 60%%, swap at 85%%)",
+    )
+    group.add_argument(
+        "--checkpoint-threshold",
+        type=float,
+        default=0.60,
+        help="Token threshold for background checkpoint as fraction of max (default: 0.60)",
+    )
+    group.add_argument(
+        "--swap-threshold",
+        type=float,
+        default=0.85,
+        help="Token threshold for buffer swap as fraction of max (default: 0.85)",
+    )
 
     ##########
     group = parser.add_argument_group("Cache settings")

--- a/aider/double_buffer.py
+++ b/aider/double_buffer.py
@@ -1,0 +1,228 @@
+"""Double-buffer context management for aider.
+
+Implements a two-phase compaction strategy:
+- Checkpoint at configurable threshold (default 60%) of max chat history tokens
+- Swap at configurable threshold (default 85%) using pre-computed summary
+
+When the front buffer approaches capacity, a background checkpoint generates
+a high-quality summary while the model still has full attention. At the swap
+threshold, the pre-computed summary replaces old history seamlessly.
+
+See: https://marklubin.me/posts/hopping-context-windows/
+"""
+
+import logging
+import threading
+from enum import Enum
+
+log = logging.getLogger(__name__)
+
+
+class Phase(Enum):
+    NORMAL = "normal"
+    CHECKPOINT_PENDING = "checkpoint_pending"
+    CONCURRENT = "concurrent"
+
+
+class DoubleBufferManager:
+    """Manages double-buffer state for a single aider session.
+
+    Integrates with aider's existing ChatSummary for summarization
+    and base_coder's done_messages/cur_messages for message management.
+    """
+
+    def __init__(
+        self,
+        checkpoint_threshold=0.60,
+        swap_threshold=0.85,
+    ):
+        if not (0 < checkpoint_threshold < swap_threshold <= 1.0):
+            raise ValueError(
+                f"Invalid thresholds: checkpoint={checkpoint_threshold}, "
+                f"swap={swap_threshold}. Must satisfy 0 < checkpoint < swap <= 1.0"
+            )
+        self.checkpoint_threshold = checkpoint_threshold
+        self.swap_threshold = swap_threshold
+
+        self.phase = Phase.NORMAL
+        self.checkpoint_summary = None
+        self.checkpoint_done_messages_len = 0
+        self.generation = 0
+
+        self._checkpoint_thread = None
+        self._checkpoint_messages_snapshot = None
+        self._checkpoint_result = None
+
+    def should_checkpoint(self, current_tokens, max_tokens):
+        """Check if a background checkpoint should start.
+
+        Args:
+            current_tokens: Current token count of done_messages.
+            max_tokens: Maximum chat history tokens (model.max_chat_history_tokens).
+
+        Returns:
+            True if checkpoint should be triggered.
+        """
+        if self.phase != Phase.NORMAL:
+            return False
+        if max_tokens <= 0:
+            return False
+
+        threshold = int(max_tokens * self.checkpoint_threshold)
+        result = current_tokens >= threshold
+        if result:
+            log.info(
+                "Checkpoint threshold reached: %d tokens >= %d (%d%% of %d)",
+                current_tokens,
+                threshold,
+                int(self.checkpoint_threshold * 100),
+                max_tokens,
+            )
+        return result
+
+    def should_swap(self, current_tokens, max_tokens):
+        """Check if buffer swap should occur.
+
+        Args:
+            current_tokens: Current token count of done_messages.
+            max_tokens: Maximum chat history tokens.
+
+        Returns:
+            True if swap should be triggered.
+        """
+        if self.phase != Phase.CONCURRENT:
+            return False
+        if self.checkpoint_summary is None:
+            return False
+        if max_tokens <= 0:
+            return False
+
+        threshold = int(max_tokens * self.swap_threshold)
+        result = current_tokens >= threshold
+        if result:
+            log.info(
+                "Swap threshold reached: %d tokens >= %d (%d%% of %d), generation=%d",
+                current_tokens,
+                threshold,
+                int(self.swap_threshold * 100),
+                max_tokens,
+                self.generation,
+            )
+        return result
+
+    def begin_checkpoint(self, done_messages, summarizer):
+        """Start a background checkpoint summarization.
+
+        Args:
+            done_messages: Current done_messages list to snapshot.
+            summarizer: ChatSummary instance for summarization.
+        """
+        self.phase = Phase.CHECKPOINT_PENDING
+        self._checkpoint_messages_snapshot = list(done_messages)
+        self.checkpoint_done_messages_len = len(done_messages)
+        self._checkpoint_result = None
+
+        log.info(
+            "Checkpoint started: %d messages to summarize",
+            len(done_messages),
+        )
+
+        self._checkpoint_thread = threading.Thread(
+            target=self._run_checkpoint,
+            args=(summarizer,),
+            daemon=True,
+        )
+        self._checkpoint_thread.start()
+
+    def _run_checkpoint(self, summarizer):
+        """Background thread that generates the checkpoint summary."""
+        try:
+            result = summarizer.summarize(self._checkpoint_messages_snapshot)
+            if result:
+                # Extract summary text from the summarized messages
+                summary_parts = []
+                for msg in result:
+                    content = msg.get("content", "")
+                    if content:
+                        summary_parts.append(content)
+                self.checkpoint_summary = "\n".join(summary_parts)
+                self._checkpoint_result = result
+                self.phase = Phase.CONCURRENT
+                self.generation += 1
+                log.info(
+                    "Checkpoint complete: generation=%d, summary=%d chars",
+                    self.generation,
+                    len(self.checkpoint_summary),
+                )
+            else:
+                log.warning("Checkpoint summarization returned empty result")
+                self.phase = Phase.NORMAL
+        except Exception as err:
+            log.error("Checkpoint summarization failed: %s", err)
+            self.phase = Phase.NORMAL
+            self.checkpoint_summary = None
+
+    def wait_for_checkpoint(self, timeout=30.0):
+        """Wait for a pending checkpoint to complete.
+
+        Args:
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            True if checkpoint completed successfully.
+        """
+        if self._checkpoint_thread is None:
+            return self.phase == Phase.CONCURRENT
+
+        self._checkpoint_thread.join(timeout=timeout)
+        if self._checkpoint_thread.is_alive():
+            log.warning("Checkpoint timed out after %.1f seconds", timeout)
+            return False
+
+        self._checkpoint_thread = None
+        return self.phase == Phase.CONCURRENT
+
+    def complete_swap(self):
+        """Complete the buffer swap.
+
+        Returns the pre-computed summarized messages to replace done_messages.
+
+        Returns:
+            List of summarized messages, or empty list on error.
+        """
+        if self.phase != Phase.CONCURRENT or self._checkpoint_result is None:
+            log.error(
+                "complete_swap called in invalid state: phase=%s, has_result=%s",
+                self.phase.value,
+                self._checkpoint_result is not None,
+            )
+            return []
+
+        result = self._checkpoint_result
+        log.info(
+            "Swap complete: generation=%d, swapped %d → %d messages",
+            self.generation,
+            self.checkpoint_done_messages_len,
+            len(result),
+        )
+
+        # Reset for next cycle
+        self.phase = Phase.NORMAL
+        self.checkpoint_summary = None
+        self.checkpoint_done_messages_len = 0
+        self._checkpoint_messages_snapshot = None
+        self._checkpoint_result = None
+
+        return result
+
+    def reset(self):
+        """Reset all state. Called on error or session end."""
+        if self._checkpoint_thread is not None:
+            self._checkpoint_thread.join(timeout=5.0)
+            self._checkpoint_thread = None
+        self.phase = Phase.NORMAL
+        self.checkpoint_summary = None
+        self.checkpoint_done_messages_len = 0
+        self._checkpoint_messages_snapshot = None
+        self._checkpoint_result = None
+        # Don't reset generation — it tracks lifetime compaction count

--- a/tests/basic/test_double_buffer.py
+++ b/tests/basic/test_double_buffer.py
@@ -1,0 +1,201 @@
+"""Tests for double-buffer context management."""
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from aider.double_buffer import DoubleBufferManager, Phase
+
+
+class TestPhaseTransitions:
+    """Test the state machine transitions."""
+
+    def test_starts_in_normal_phase(self):
+        mgr = DoubleBufferManager()
+        assert mgr.phase == Phase.NORMAL
+        assert mgr.checkpoint_summary is None
+        assert mgr.generation == 0
+
+    def test_invalid_thresholds(self):
+        with pytest.raises(ValueError):
+            DoubleBufferManager(checkpoint_threshold=0.90, swap_threshold=0.60)
+        with pytest.raises(ValueError):
+            DoubleBufferManager(checkpoint_threshold=0, swap_threshold=0.85)
+        with pytest.raises(ValueError):
+            DoubleBufferManager(checkpoint_threshold=0.60, swap_threshold=1.1)
+
+    def test_begin_checkpoint_transitions(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+
+        # Use an event to block the summarizer so we can observe CHECKPOINT_PENDING
+        gate = threading.Event()
+
+        def slow_summarize(msgs):
+            gate.wait(timeout=5.0)
+            return [
+                {"role": "user", "content": "Summary of conversation"},
+                {"role": "assistant", "content": "Ok."},
+            ]
+
+        mock_summarizer.summarize.side_effect = slow_summarize
+        mgr.begin_checkpoint(
+            [{"role": "user", "content": "hello"}],
+            mock_summarizer,
+        )
+        assert mgr.phase == Phase.CHECKPOINT_PENDING
+        gate.set()
+        mgr.wait_for_checkpoint()
+        assert mgr.phase == Phase.CONCURRENT
+        assert mgr.generation == 1
+        assert mgr.checkpoint_summary is not None
+
+    def test_complete_swap_returns_summary(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+        summarized = [
+            {"role": "user", "content": "Summary"},
+            {"role": "assistant", "content": "Ok."},
+        ]
+        mock_summarizer.summarize.return_value = summarized
+        mgr.begin_checkpoint(
+            [{"role": "user", "content": "hello"}],
+            mock_summarizer,
+        )
+        mgr.wait_for_checkpoint()
+        result = mgr.complete_swap()
+        assert result == summarized
+        assert mgr.phase == Phase.NORMAL
+        assert mgr.checkpoint_summary is None
+
+    def test_full_lifecycle(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+
+        # Use an event to block the summarizer so we can observe CHECKPOINT_PENDING
+        gate = threading.Event()
+
+        def slow_summarize(msgs):
+            gate.wait(timeout=5.0)
+            return [
+                {"role": "user", "content": "Summary"},
+                {"role": "assistant", "content": "Ok."},
+            ]
+
+        mock_summarizer.summarize.side_effect = slow_summarize
+
+        assert mgr.phase == Phase.NORMAL
+        mgr.begin_checkpoint([{"role": "user", "content": "test"}], mock_summarizer)
+        assert mgr.phase == Phase.CHECKPOINT_PENDING
+        gate.set()
+        mgr.wait_for_checkpoint()
+        assert mgr.phase == Phase.CONCURRENT
+        assert mgr.generation == 1
+        result = mgr.complete_swap()
+        assert len(result) == 2
+        assert mgr.phase == Phase.NORMAL
+        assert mgr.generation == 1  # preserved
+
+    def test_multiple_generations(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+        mock_summarizer.summarize.return_value = [
+            {"role": "user", "content": "Summary"},
+            {"role": "assistant", "content": "Ok."},
+        ]
+
+        for i in range(3):
+            mgr.begin_checkpoint([{"role": "user", "content": f"gen {i}"}], mock_summarizer)
+            mgr.wait_for_checkpoint()
+            mgr.complete_swap()
+
+        assert mgr.generation == 3
+
+
+class TestThresholdChecks:
+    """Test shouldCheckpoint and shouldSwap."""
+
+    def test_should_checkpoint_normal_phase(self):
+        mgr = DoubleBufferManager(checkpoint_threshold=0.60, swap_threshold=0.85)
+        # 600 of 1000 = 60%, should checkpoint
+        assert mgr.should_checkpoint(600, 1000) is True
+
+    def test_should_not_checkpoint_below_threshold(self):
+        mgr = DoubleBufferManager(checkpoint_threshold=0.60)
+        assert mgr.should_checkpoint(500, 1000) is False
+
+    def test_should_not_checkpoint_wrong_phase(self):
+        mgr = DoubleBufferManager(checkpoint_threshold=0.60)
+        mgr.phase = Phase.CHECKPOINT_PENDING
+        assert mgr.should_checkpoint(700, 1000) is False
+
+    def test_should_swap_concurrent_phase(self):
+        mgr = DoubleBufferManager(checkpoint_threshold=0.60, swap_threshold=0.85)
+        mgr.phase = Phase.CONCURRENT
+        mgr.checkpoint_summary = "test summary"
+        assert mgr.should_swap(850, 1000) is True
+
+    def test_should_not_swap_wrong_phase(self):
+        mgr = DoubleBufferManager(swap_threshold=0.85)
+        assert mgr.should_swap(900, 1000) is False
+
+    def test_should_not_swap_no_summary(self):
+        mgr = DoubleBufferManager(swap_threshold=0.85)
+        mgr.phase = Phase.CONCURRENT
+        mgr.checkpoint_summary = None
+        assert mgr.should_swap(900, 1000) is False
+
+    def test_should_not_checkpoint_zero_max(self):
+        mgr = DoubleBufferManager()
+        assert mgr.should_checkpoint(500, 0) is False
+
+    def test_should_not_swap_zero_max(self):
+        mgr = DoubleBufferManager()
+        mgr.phase = Phase.CONCURRENT
+        mgr.checkpoint_summary = "test"
+        assert mgr.should_swap(500, 0) is False
+
+
+class TestErrorHandling:
+    """Test failure modes."""
+
+    def test_summarization_failure_resets_to_normal(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+        mock_summarizer.summarize.side_effect = ValueError("Model failed")
+
+        mgr.begin_checkpoint([{"role": "user", "content": "test"}], mock_summarizer)
+        mgr.wait_for_checkpoint()
+
+        assert mgr.phase == Phase.NORMAL
+        assert mgr.checkpoint_summary is None
+
+    def test_empty_summarization_resets_to_normal(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+        mock_summarizer.summarize.return_value = None
+
+        mgr.begin_checkpoint([{"role": "user", "content": "test"}], mock_summarizer)
+        mgr.wait_for_checkpoint()
+
+        assert mgr.phase == Phase.NORMAL
+
+    def test_complete_swap_invalid_state(self):
+        mgr = DoubleBufferManager()
+        result = mgr.complete_swap()
+        assert result == []
+
+    def test_reset_clears_everything(self):
+        mgr = DoubleBufferManager()
+        mock_summarizer = MagicMock()
+        mock_summarizer.summarize.return_value = [
+            {"role": "user", "content": "Summary"},
+            {"role": "assistant", "content": "Ok."},
+        ]
+        mgr.begin_checkpoint([{"role": "user", "content": "test"}], mock_summarizer)
+        mgr.wait_for_checkpoint()
+        mgr.reset()
+        assert mgr.phase == Phase.NORMAL
+        assert mgr.checkpoint_summary is None
+        assert mgr.generation == 1  # preserved across reset


### PR DESCRIPTION
## Summary

Adds opt-in double-buffer context management that produces higher-quality chat history summaries by checkpointing early (at 60% of `max_chat_history_tokens`) while the model still has full attention, rather than waiting until the history is too big and attention is degraded.

**How it works:**

1. At 60% capacity, a background thread runs `ChatSummary.summarize()` on a snapshot of `done_messages`
2. Normal operation continues uninterrupted (the checkpoint is fire-and-forget)
3. At 85% capacity, instead of the standard stop-the-world summarization, the pre-computed summary is swapped in

The feature is **opt-in** via `--double-buffer` and the existing summarization flow is completely unchanged when not enabled.

**New files:**
- `aider/double_buffer.py`: `DoubleBufferManager` with background checkpoint via threading, `Phase` enum
- `tests/basic/test_double_buffer.py`: 18 tests (phase transitions, thresholds, error handling)

**Modified files:**
- `aider/coders/base_coder.py`: `summarize_start()` delegates to `_double_buffer_check()` when `--double-buffer` is enabled
- `aider/args.py`: `--double-buffer`, `--checkpoint-threshold` (default 0.60), `--swap-threshold` (default 0.85)

**Design:**
- Reuses existing `ChatSummary` for summarization (no new LLM calls)
- Background thread mirrors existing `summarizer_thread` pattern in `base_coder.py`
- Falls back to standard summarization if no double-buffer action applies

Algorithm description: https://marklubin.me/posts/hopping-context-windows/

## Test plan

- [x] 18 new unit tests pass (`pytest tests/basic/test_double_buffer.py -v`)
- [x] No regressions in existing tests
- [x] `black --line-length 100 --preview` clean
- [x] `isort --profile black` clean
- [x] `flake8` clean (no warnings)
- [ ] Manual test: run with `--double-buffer --verbose` on a long session and observe checkpoint/swap log messages