### PR TITLE
feat: Add openssh-client to Docker image dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm AS base
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential git libportaudio2 pandoc && \
+    apt-get install --no-install-recommends -y build-essential git libportaudio2 openssh-client pandoc && \
     rm -rf /var/lib/apt/lists/*
 
 # Create app user with UID 1000


### PR DESCRIPTION
To be able to sign commits with ssh keys (user.signingKey) we need ssh-keygen, supplied by openssh-client.

Note that supplying ssh keys (mounting .ssh) and a git config using it (or mounting gitconfig) are still needed.