### PR TITLE
feat: include Docker CLI in aider-full image

### DIFF
--- a/aider/website/docs/install/docker.md
+++ b/aider/website/docs/install/docker.md
@@ -50,6 +50,13 @@ git config user.email "you@example.com"
 git config user.name "Your Name"
 ```
 
+## Docker client in the aider-full image
+
+The aider-full image includes the Docker CLI. To use Docker from inside the container you must provide access to a Docker daemon — the simplest approach is to mount the host Docker socket:
+
+    docker run --rm --volume /var/run/docker.sock:/var/run/docker.sock paulgauthier/aider-full docker ps
+
+Note: mounting /var/run/docker.sock grants the container control of the host Docker daemon; only do this in trusted environments.
 
 ## Limitations
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,11 @@ ENV HOME=/app
 #########################
 FROM base AS aider-full
 
+ARG DOCKER_VERSION=29.2.1
+ADD https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz /tmp/docker.tgz
+RUN tar --strip-components=1 -xvzf /tmp/docker.tgz -C /usr/local/bin docker/docker && \
+    rm -f /tmp/docker.tgz
+
 ENV AIDER_DOCKER_IMAGE=paulgauthier/aider-full
 
 COPY . /tmp/aider


### PR DESCRIPTION
To be able to connect to run commands from aider in other docker containers, for example to run a build or test suite, we may need to connect to docker (on the host). To be able to do so, we need to install the docker client (and mount the socket).

Closes #4869