### PR TITLE
Add LLMAPI as an LLM provider

### DIFF
--- a/aider/llmapi.py
+++ b/aider/llmapi.py
@@ -1,0 +1,115 @@
+"""
+LLM API model metadata caching and lookup.
+
+This module keeps a local cached copy of the LLM API model list
+(downloaded from ``https://api.llmapi.ai/v1/models``) and exposes a
+helper class that returns metadata for a given model in a format compatible
+with litellm's ``get_model_info``.
+
+Authorization is NOT required for the models endpoint.
+"""
+import json
+import time
+from pathlib import Path
+
+
+class LLMApiModelManager:
+    MODELS_URL = "https://api.llmapi.ai/v1/models"
+    CACHE_TTL = 60 * 60 * 24  # 24 h
+    PREFIX = "llmapi/"
+
+    def __init__(self):
+        self.cache_dir = Path.home() / ".aider" / "caches"
+        self.cache_file = self.cache_dir / "llmapi_models.json"
+        self.content = None
+        self.verify_ssl = True
+        self._cache_loaded = False
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+    def set_verify_ssl(self, verify_ssl):
+        """Enable/disable SSL verification for API requests."""
+        self.verify_ssl = verify_ssl
+
+    def get_model_info(self, model):
+        """
+        Return metadata for *model* or an empty ``dict`` when unknown.
+
+        ``model`` should use the aider naming convention, e.g.
+        ``llmapi/gpt-4o``.
+        """
+        self._ensure_content()
+        if not self.content or "data" not in self.content:
+            return {}
+
+        model_id = self._strip_prefix(model)
+
+        record = next(
+            (item for item in self.content["data"] if item.get("id") == model_id),
+            None,
+        )
+        if not record:
+            return {}
+
+        context_len = record.get("context_window") or record.get("context_length") or None
+
+        return {
+            "max_input_tokens": context_len,
+            "max_tokens": context_len,
+            "max_output_tokens": context_len,
+            "litellm_provider": "openai",
+        }
+
+    def get_available_models(self):
+        """Return a list of ``llmapi/<id>`` model names available on the API."""
+        self._ensure_content()
+        if not self.content or "data" not in self.content:
+            return []
+        return [self.PREFIX + item["id"] for item in self.content["data"] if item.get("id")]
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                    #
+    # ------------------------------------------------------------------ #
+    def _strip_prefix(self, model):
+        return model[len(self.PREFIX) :] if model.startswith(self.PREFIX) else model
+
+    def _ensure_content(self):
+        self._load_cache()
+        if not self.content:
+            self._update_cache()
+
+    def _load_cache(self):
+        if self._cache_loaded:
+            return
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            if self.cache_file.exists():
+                cache_age = time.time() - self.cache_file.stat().st_mtime
+                if cache_age < self.CACHE_TTL:
+                    try:
+                        self.content = json.loads(self.cache_file.read_text())
+                    except json.JSONDecodeError:
+                        self.content = None
+        except OSError:
+            pass
+
+        self._cache_loaded = True
+
+    def _update_cache(self):
+        try:
+            import requests
+
+            response = requests.get(self.MODELS_URL, timeout=10, verify=self.verify_ssl)
+            if response.status_code == 200:
+                self.content = response.json()
+                try:
+                    self.cache_file.write_text(json.dumps(self.content, indent=2))
+                except OSError:
+                    pass
+        except Exception as ex:  # noqa: BLE001
+            print(f"Failed to fetch LLM API model list: {ex}")
+            try:
+                self.cache_file.write_text("{}")
+            except OSError:
+                pass

--- a/aider/models.py
+++ b/aider/models.py
@@ -19,6 +19,7 @@ from PIL import Image
 from aider import __version__
 from aider.dump import dump  # noqa: F401
 from aider.llm import litellm
+from aider.llmapi import LLMApiModelManager
 from aider.openrouter import OpenRouterModelManager
 from aider.sendchat import ensure_alternating_roles, sanity_check_messages
 from aider.utils import check_pip_install_extra
@@ -164,10 +165,15 @@ class ModelInfoManager:
         # Manager for the cached OpenRouter model database
         self.openrouter_manager = OpenRouterModelManager()
 
+        # Manager for the cached LLM API model database
+        self.llmapi_manager = LLMApiModelManager()
+
     def set_verify_ssl(self, verify_ssl):
         self.verify_ssl = verify_ssl
         if hasattr(self, "openrouter_manager"):
             self.openrouter_manager.set_verify_ssl(verify_ssl)
+        if hasattr(self, "llmapi_manager"):
+            self.llmapi_manager.set_verify_ssl(verify_ssl)
 
     def _load_cache(self):
         if self._cache_loaded:
@@ -258,6 +264,11 @@ class ModelInfoManager:
             openrouter_info = self.fetch_openrouter_model_info(model)
             if openrouter_info:
                 return openrouter_info
+
+        if not cached_info and model.startswith("llmapi/"):
+            llmapi_info = self.llmapi_manager.get_model_info(model)
+            if llmapi_info:
+                return llmapi_info
 
         return cached_info
 
@@ -713,6 +724,7 @@ class Model(ModelSettings):
             anthropic="ANTHROPIC_API_KEY",
             groq="GROQ_API_KEY",
             fireworks_ai="FIREWORKS_API_KEY",
+            llmapi="LLMAPI_API_KEY",
         )
         var = None
         if model in OPENAI_MODELS:
@@ -1008,6 +1020,16 @@ class Model(ModelSettings):
             dump(kwargs)
         kwargs["messages"] = messages
 
+        # For llmapi, translate prefix and route through OpenAI-compatible endpoint
+        if self.name.startswith("llmapi/"):
+            kwargs["model"] = "openai/" + self.name[len("llmapi/") :]
+            kwargs["api_base"] = "https://api.llmapi.ai/v1"
+            if "LLMAPI_API_KEY" in os.environ:
+                kwargs["api_key"] = os.environ["LLMAPI_API_KEY"]
+            if "extra_headers" not in kwargs:
+                kwargs["extra_headers"] = {}
+            kwargs["extra_headers"]["x-source"] = "aider"
+
         # Are we using github copilot?
         if "GITHUB_COPILOT_TOKEN" in os.environ:
             if "extra_headers" not in kwargs:
@@ -1215,6 +1237,10 @@ def fuzzy_match_models(name):
     chat_models = set()
     model_metadata = list(litellm.model_cost.items())
     model_metadata += list(model_info_manager.local_model_metadata.items())
+
+    # Include dynamically fetched LLM API models
+    for llmapi_model in model_info_manager.llmapi_manager.get_available_models():
+        model_metadata.append((llmapi_model, {"mode": "chat", "litellm_provider": "llmapi"}))
 
     for orig_model, attrs in model_metadata:
         model = orig_model.lower()

--- a/aider/website/docs/llms/llmapi.md
+++ b/aider/website/docs/llms/llmapi.md
@@ -1,0 +1,45 @@
+---
+parent: Connecting to LLMs
+nav_order: 510
+---
+
+# LLM API
+
+[LLM API](https://llmapi.ai) is an OpenAI-compatible gateway that provides access to
+models from OpenAI, Anthropic, Google, and other providers through a single endpoint.
+
+You'll need an [LLM API key](https://llmapi.ai).
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your API key:
+
+```bash
+export LLMAPI_API_KEY=<key> # Mac/Linux
+setx   LLMAPI_API_KEY <key> # Windows, restart shell after setx
+```
+
+Start working with aider and LLM API on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# GPT-4o via LLM API
+aider --model llmapi/gpt-4o
+
+# Claude 3.5 Sonnet via LLM API
+aider --model llmapi/claude-3-5-sonnet-20241022
+
+# List all models available from LLM API
+aider --list-models llmapi/
+```
+
+## Optional config file (`~/.aider.conf.yml`)
+
+```yaml
+model: llmapi/gpt-4o
+weak-model: llmapi/gpt-4o-mini
+```

--- a/tests/basic/test_llmapi.py
+++ b/tests/basic/test_llmapi.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+from aider.llmapi import LLMApiModelManager
+from aider.models import ModelInfoManager
+
+
+class DummyResponse:
+    """Minimal stand-in for requests.Response used in tests."""
+
+    def __init__(self, json_data):
+        self.status_code = 200
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+def test_llmapi_get_model_info_from_cache(monkeypatch, tmp_path):
+    """
+    LLMApiModelManager should return correct metadata taken from the
+    downloaded (and locally cached) models JSON payload.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "gpt-4o",
+                "context_window": 128000,
+            },
+            {
+                "id": "claude-3-5-sonnet",
+                "context_window": 200000,
+            },
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = LLMApiModelManager()
+    info = manager.get_model_info("llmapi/gpt-4o")
+
+    assert info["max_input_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+    assert info["litellm_provider"] == "openai"
+
+
+def test_llmapi_get_available_models(monkeypatch, tmp_path):
+    """
+    LLMApiModelManager.get_available_models should return prefixed model names.
+    """
+    payload = {
+        "data": [
+            {"id": "gpt-4o"},
+            {"id": "claude-3-5-sonnet"},
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = LLMApiModelManager()
+    models = manager.get_available_models()
+
+    assert "llmapi/gpt-4o" in models
+    assert "llmapi/claude-3-5-sonnet" in models
+
+
+def test_llmapi_unknown_model_returns_empty(monkeypatch, tmp_path):
+    """
+    LLMApiModelManager should return an empty dict for unknown models.
+    """
+    payload = {"data": [{"id": "gpt-4o", "context_window": 128000}]}
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = LLMApiModelManager()
+    info = manager.get_model_info("llmapi/does-not-exist")
+
+    assert info == {}
+
+
+def test_model_info_manager_uses_llmapi_manager(monkeypatch):
+    """
+    ModelInfoManager should delegate to LLMApiModelManager when litellm
+    provides no data for a llmapi-prefixed model.
+    """
+    monkeypatch.setattr("aider.models.litellm.get_model_info", lambda *a, **k: {})
+
+    stub_info = {
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "max_output_tokens": 128000,
+        "litellm_provider": "openai",
+    }
+
+    monkeypatch.setattr(
+        "aider.models.LLMApiModelManager.get_model_info",
+        lambda self, model: stub_info,
+    )
+
+    mim = ModelInfoManager()
+    info = mim.get_model_info("llmapi/gpt-4o")
+
+    assert info == stub_info


### PR DESCRIPTION
Adds [llmapi.ai](https://llmapi.ai) as a native LLM provider via the `llmapi/` model prefix.

LLM API is an OpenAI-compatible gateway (drop-in replacement) that routes
requests to OpenAI, Anthropic, Google, and other providers through a single endpoint.

## Changes

- `aider/llmapi.py` — new `LLMApiModelManager`: fetches and caches the model
  list from `https://api.llmapi.ai/v1/models` (no auth required), 24 h TTL
- `aider/models.py`:
  - `ModelInfoManager` delegates `llmapi/` model info to `LLMApiModelManager`
  - `fast_validate_environment` keymap: `llmapi → LLMAPI_API_KEY`
  - `send_completion`: translates `llmapi/<model>` → `openai/<model>` with
    `api_base=https://api.llmapi.ai/v1` and `api_key` from env
  - `fuzzy_match_models`: includes live llmapi models so `--list-models llmapi/` works
- `aider/website/docs/llms/llmapi.md` — provider documentation
- `tests/basic/test_llmapi.py` — 4 unit tests

## Usage

```bash
export LLMAPI_API_KEY=<key>
aider --model llmapi/gpt-4o
aider --list-models llmapi/
```

cc @paul-gauthier
