### PR TITLE
Add client-side filters and sortable columns to leaderboard

### DIFF
--- a/aider/website/_includes/leaderboard_table.js
+++ b/aider/website/_includes/leaderboard_table.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const allMainRows = document.querySelectorAll('tr[id^="main-row-"]');
   const allDetailsRows = document.querySelectorAll('tr[id^="details-"]');
   const searchInput = document.getElementById('editSearchInput');
+  const editFormatFilter = document.getElementById('editFormatFilter');
   const modeViewButton = document.getElementById('mode-view-btn');
   const modeDetailButton = document.getElementById('mode-detail-btn');
   const modeSelectButton = document.getElementById('mode-select-btn');
@@ -15,14 +16,94 @@ document.addEventListener('DOMContentLoaded', function() {
   const defaultTitle = "Aider polyglot coding leaderboard";
   const filteredTitle = "Aider polyglot coding benchmark results (selected)";
 
-  function applySearchFilter() {
-    const searchTerm = searchInput.value.toLowerCase();
+  // Filter state separate from mode state
+  const filterState = { search: '', editFormat: '', sortColumn: 2, sortAsc: false };
+
+  // Populate edit format dropdown from table data
+  if (editFormatFilter) {
+    const formats = new Set();
+    allMainRows.forEach(row => {
+      const cell = row.querySelector('td.col-edit-format');
+      if (cell) {
+        const val = cell.textContent.trim();
+        if (val) formats.add(val);
+      }
+    });
+    Array.from(formats).sort().forEach(fmt => {
+      const opt = document.createElement('option');
+      opt.value = fmt;
+      opt.textContent = fmt;
+      editFormatFilter.appendChild(opt);
+    });
+  }
+
+  function getSortValue(row, colIndex) {
+    const cell = row.children[colIndex];
+    if (!cell) return '';
+    // Cost column: use data attribute for precision
+    if (cell.classList.contains('cost-bar-cell')) {
+      const costBar = cell.querySelector('.cost-bar');
+      return costBar ? parseFloat(costBar.dataset.cost || '0') : 0;
+    }
+    const text = (cell.querySelector('span') || cell).textContent.trim();
+    const num = parseFloat(text.replace(/[$%,]/g, ''));
+    if (!isNaN(num)) return num;
+    return text.toLowerCase();
+  }
+
+  function sortTable() {
+    const tbody = document.querySelector('table tbody');
+    const colIndex = filterState.sortColumn;
+    const asc = filterState.sortAsc;
+
+    const pairs = Array.from(allMainRows).map(mainRow => {
+      const idx = mainRow.id.replace('main-row-', '');
+      const detailRow = document.getElementById('details-' + idx);
+      return { mainRow, detailRow, val: getSortValue(mainRow, colIndex) };
+    });
+
+    pairs.sort((a, b) => {
+      if (a.val < b.val) return asc ? -1 : 1;
+      if (a.val > b.val) return asc ? 1 : -1;
+      return 0;
+    });
+
+    pairs.forEach(({ mainRow, detailRow }) => {
+      tbody.appendChild(mainRow);
+      if (detailRow) tbody.appendChild(detailRow);
+    });
+
+    updateSortIndicators();
+  }
+
+  function updateSortIndicators() {
+    document.querySelectorAll('th.sortable .sort-indicator').forEach(el => el.remove());
+    const headers = document.querySelectorAll('table thead th');
+    const th = headers[filterState.sortColumn];
+    if (th && th.classList.contains('sortable')) {
+      const indicator = document.createElement('span');
+      indicator.className = 'sort-indicator';
+      indicator.textContent = filterState.sortAsc ? ' ▲' : ' ▼';
+      th.appendChild(indicator);
+    }
+  }
+
+  function applyFilters() {
     allMainRows.forEach(row => {
       const textContent = row.textContent.toLowerCase();
       const detailsRow = document.getElementById(row.id.replace('main-row-', 'details-'));
-      const matchesSearch = textContent.includes(searchTerm);
 
-      if (matchesSearch) {
+      // Text search match
+      const matchesSearch = !filterState.search || textContent.includes(filterState.search);
+
+      // Edit format match
+      let matchesFormat = true;
+      if (filterState.editFormat) {
+        const formatCell = row.querySelector('td.col-edit-format');
+        matchesFormat = formatCell && formatCell.textContent.trim() === filterState.editFormat;
+      }
+
+      if (matchesSearch && matchesFormat) {
         row.classList.remove('hidden-by-search');
         if (detailsRow) detailsRow.classList.remove('hidden-by-search');
       } else {
@@ -30,12 +111,14 @@ document.addEventListener('DOMContentLoaded', function() {
         if (detailsRow) detailsRow.classList.add('hidden-by-search');
       }
     });
-    // After applying search filter, re-apply view mode filter and update select-all state
+    // After applying filters, re-apply view mode filter and update select-all state
     updateTableView(currentMode);
     if (currentMode === 'select') {
         updateSelectAllCheckboxState();
     }
-    
+
+    sortTable();
+
     // Update cost bars and ticks since visible rows may have changed
     updateCostBars();
     updateCostTicks();
@@ -379,7 +462,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Update table view and apply filters
         updateTableView(newMode);
-        applySearchFilter(); // Re-apply search filter when mode changes
+        applyFilters(); // Re-apply filters when mode changes
       }
     });
   });
@@ -443,7 +526,35 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   // Listener for search input
-  searchInput.addEventListener('input', applySearchFilter);
+  searchInput.addEventListener('input', function() {
+    filterState.search = this.value.toLowerCase();
+    applyFilters();
+  });
+
+  // Listener for edit format filter
+  if (editFormatFilter) {
+    editFormatFilter.addEventListener('change', function() {
+      filterState.editFormat = this.value;
+      applyFilters();
+    });
+  }
+
+  // Listener for sortable column headers
+  document.querySelectorAll('th.sortable').forEach(th => {
+    th.addEventListener('click', function() {
+      const colIndex = Array.from(this.parentNode.children).indexOf(this);
+      if (filterState.sortColumn === colIndex) {
+        filterState.sortAsc = !filterState.sortAsc;
+      } else {
+        filterState.sortColumn = colIndex;
+        // Default: descending for numbers, ascending for text
+        filterState.sortAsc = this.dataset.sortType === 'text';
+      }
+      sortTable();
+      updateCostBars();
+      updateCostTicks();
+    });
+  });
 
   // Add toggle functionality for details (Modified to respect modes)
   const toggleButtons = document.querySelectorAll('.toggle-details');
@@ -504,7 +615,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // --- Initial Setup ---
   updateTableView('view'); // Initialize view to 'view' mode
-  applySearchFilter(); // Apply initial search filter (if any text is pre-filled or just to set initial state)
+  applyFilters(); // Apply initial filters (if any text is pre-filled or just to set initial state)
 
 // Close button functionality
 const closeControlsBtn = document.getElementById('close-controls-btn');

--- a/aider/website/docs/leaderboards/index.md
+++ b/aider/website/docs/leaderboards/index.md
@@ -18,6 +18,9 @@ human intervention.
 
 <div id="controls-container" style="display: flex; align-items: center; width: 100%; max-width: 800px; margin: 10px auto; gap: 10px; box-sizing: border-box; padding: 0 5px; position: relative;">
   <input type="text" id="editSearchInput" placeholder="Search..." style="flex-grow: 1; padding: 8px; border: 1px solid #ddd; border-radius: 4px;">
+  <select id="editFormatFilter" style="padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; height: 38px; box-sizing: border-box; cursor: pointer;">
+    <option value="">All formats</option>
+  </select>
   <div id="view-mode-toggle" style="display: inline-flex; border: 1px solid #ccc; border-radius: 4px;">
     <button id="mode-view-btn" class="mode-button active" data-mode="view" style="padding: 8px 8px; border: none; border-radius: 3px 0 0 3px; cursor: pointer; font-size: 14px; line-height: 1.5; min-width: 50px;">View</button>
     <button id="mode-select-btn" class="mode-button" data-mode="select" style="padding: 8px 8px; border: none; background-color: #f8f9fa; border-radius: 0; cursor: pointer; border-left: 1px solid #ccc; font-size: 14px; line-height: 1.5; min-width: 50px;">Select</button>
@@ -32,12 +35,12 @@ human intervention.
       <th style="padding: 8px; width: 40px; text-align: center; vertical-align: middle;">
         <input type="checkbox" id="select-all-checkbox" style="display: none; cursor: pointer; vertical-align: middle;">
       </th> <!-- Header checkbox added here -->
-      <th style="padding: 8px; text-align: left;">Model</th>
-      <th style="padding: 8px; text-align: center; width: 25%">Percent correct</th>
-      <th style="padding: 8px; text-align: center; width: 25%">Cost</th>
+      <th class="sortable" data-sort-type="text" style="padding: 8px; text-align: left;">Model</th>
+      <th class="sortable" data-sort-type="number" style="padding: 8px; text-align: center; width: 25%">Percent correct</th>
+      <th class="sortable" data-sort-type="number" style="padding: 8px; text-align: center; width: 25%">Cost</th>
       <th style="padding: 8px; text-align: left;" class="col-command">Command</th>
-      <th style="padding: 8px; text-align: center; width: 10%" class="col-conform">Correct edit format</th>
-      <th style="padding: 8px; text-align: left; width: 10%" class="col-edit-format">Edit Format</th>
+      <th class="sortable col-conform" data-sort-type="number" style="padding: 8px; text-align: center; width: 10%">Correct edit format</th>
+      <th class="sortable col-edit-format" data-sort-type="text" style="padding: 8px; text-align: left; width: 10%">Edit Format</th>
     </tr>
   </thead>
   <tbody>
@@ -243,6 +246,20 @@ human intervention.
   }
   .mode-button:not(.active):hover {
     background-color: #e2e6ea; /* Slightly darker grey on hover */
+  }
+
+  /* --- Sortable Column Styles --- */
+  th.sortable {
+    cursor: pointer;
+    user-select: none;
+  }
+  th.sortable:hover {
+    background-color: #e9ecef;
+  }
+  .sort-indicator {
+    font-size: 10px;
+    margin-left: 2px;
+    color: #666;
   }
 
   /* Style for highlighted rows in view mode */


### PR DESCRIPTION
## Summary

Adds a client-side dropdown filter for edit format to the polyglot leaderboard, letting users quickly filter to compare models using the same edit format (diff, whole, diff-fenced, architect).

## Changes

- Add an "Edit Format" `<select>` dropdown in the leaderboard controls bar
- Replace the narrow `applySearchFilter()` with a generalized `applyFilters()` function that combines text search and dropdown filters via a small `filterState` object
- Dropdown options are derived from table row data at runtime (no hardcoded values)
- Default experience is unchanged when no filter is active ("All formats" selected)

## Screenshots
<img width="1044" height="711" alt="Default view with edit format dropdown" src="https://github.com/user-attachments/assets/85e49897-85bb-46b3-b02f-9026e9a63195" />
<img width="1039" height="687" alt="Filtered by format and sorted by column descending" src="https://github.com/user-attachments/assets/7244a101-2200-451f-b92b-23dc4b32ec9c" />
<img width="1037" height="709" alt="Filtered by format and sorted by column descending" src="https://github.com/user-attachments/assets/d4bb58a2-3704-40b1-b32b-13c157de5bf4" />
