### PR TITLE
fix: exclude symlinks-to-directories from repo map file listing

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -456,7 +456,9 @@ class GitRepo:
                         try:
                             blob = next(iterator)
                             if blob.type == "blob":  # blob is a file
-                                files.add(blob.path)
+                                full_path = Path(self.root) / blob.path
+                                if not full_path.is_symlink() or full_path.is_file():
+                                    files.add(blob.path)
                         except IndexError:
                             # Handle potential index error during tree traversal
                             # without relying on potentially unassigned 'blob'
@@ -479,7 +481,10 @@ class GitRepo:
         index = self.repo.index
         try:
             staged_files = [path for path, _ in index.entries.keys()]
-            files.update(self.normalize_path(path) for path in staged_files)
+            for path in staged_files:
+                full_path = Path(self.root) / path
+                if not full_path.is_symlink() or full_path.is_file():
+                    files.add(self.normalize_path(path))
         except ANY_GIT_ERROR as err:
             self.io.tool_error(f"Unable to read staged files: {err}")
 

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -620,6 +620,80 @@ class TestRepo(unittest.TestCase):
             self.assertNotIn(str(root_file), tracked_files)
             self.assertNotIn(str(another_subdir_file), tracked_files)
 
+    @unittest.skipIf(platform.system() == "Windows", "Symlinks may require special permissions on Windows")
+    def test_get_tracked_files_excludes_symlinks_to_directories(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            raw_repo.config_writer().set_value("user", "name", "Test User").release()
+            raw_repo.config_writer().set_value("user", "email", "test@example.com").release()
+
+            # Create a regular directory with a file
+            Path("some-dir").mkdir()
+            Path("some-dir/some-file.txt").write_text("content")
+
+            # Create a regular file
+            Path("regular-file.txt").write_text("hello")
+
+            # Create a symlink to a file
+            Path("symlink-to-file.txt").symlink_to("regular-file.txt")
+
+            # Create a symlink to a directory
+            Path("symlink-to-dir").symlink_to("some-dir")
+
+            raw_repo.git.add("-A")
+            raw_repo.git.commit("-m", "initial commit")
+
+            git_repo = GitRepo(InputOutput(), None, ".")
+            tracked_files = git_repo.get_tracked_files()
+
+            # Regular files should be included
+            self.assertIn("regular-file.txt", tracked_files)
+            self.assertIn(str(Path("some-dir/some-file.txt")), tracked_files)
+
+            # Symlink to a file should be included
+            self.assertIn("symlink-to-file.txt", tracked_files)
+
+            # Symlink to a directory should be excluded
+            for f in tracked_files:
+                self.assertFalse(
+                    f == "symlink-to-dir" or f.startswith("symlink-to-dir"),
+                    f"Symlink-to-directory path '{f}' should not appear in tracked files",
+                )
+
+    @unittest.skipIf(platform.system() == "Windows", "Symlinks may require special permissions on Windows")
+    def test_get_tracked_files_excludes_symlinks_to_directories_staged(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            raw_repo.config_writer().set_value("user", "name", "Test User").release()
+            raw_repo.config_writer().set_value("user", "email", "test@example.com").release()
+
+            # Create a directory and a symlink to it, but don't commit — only stage
+            Path("real-dir").mkdir()
+            Path("real-dir/file.txt").write_text("content")
+            Path("link-to-dir").symlink_to("real-dir")
+            Path("normal.txt").write_text("normal")
+
+            # Create a symlink to a file
+            Path("link-to-file.txt").symlink_to("normal.txt")
+
+            raw_repo.git.add("-A")
+            # Don't commit — test the staged-files path
+
+            git_repo = GitRepo(InputOutput(), None, ".")
+            tracked_files = git_repo.get_tracked_files()
+
+            self.assertIn("normal.txt", tracked_files)
+            self.assertIn(str(Path("real-dir/file.txt")), tracked_files)
+
+            # Symlink to a file should be included
+            self.assertIn("link-to-file.txt", tracked_files)
+
+            for f in tracked_files:
+                self.assertFalse(
+                    f == "link-to-dir" or f.startswith("link-to-dir"),
+                    f"Symlink-to-directory path '{f}' should not appear in tracked files",
+                )
+
     @patch("aider.models.Model.simple_send_with_retries")
     def test_noop_commit(self, mock_send):
         mock_send.return_value = '"a good commit message"'


### PR DESCRIPTION
## Problem

In repositories that contain symlinks pointing to directories, aider's repo map would incorrectly include these symlink paths as if they were regular files. This caused warnings like:

```
Repo-map can't include /path/to/repo/path/to/directory
Has it been deleted from the file system but not from git?
```

Git tracks symlinks as blob objects (storing the symlink target as content), so they appear alongside regular files when enumerating the repository. However, when Python resolves these paths, Path.is_file() returns False because the resolved target is a directory, not a file.

## How to reproduce the problem

Create new git repository with symlink-to-directory
```bash
$ mkdir example-repo
$ cd example-repo
$ git init
Initialized empty Git repository in /***/example-repo/.git/
$ mkdir some-dir
$ touch some-dir/some-file
$ mkdir some-other-dir
$ cd some-other-dir && ln -s ../some-dir symlink-to-some-dir && cd ..
$ git add .
$ git commit -m "Initial commit"
[main (root-commit) e19b059] Initial commit
 2 files changed, 1 insertion(+)
 create mode 100644 some-dir/some-file
 create mode 120000 some-other-dir/symlink-to-some-dir
```

Run aider and refresh repomap
```bash
$ aider
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Aider v0.86.2
Model: ***
Git repo: .git with 2 files
Repo-map: using 4096 tokens, auto refresh
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> /map-refresh

Repo-map can't include /***/example-repo/some-dir
Has it been deleted from the file system but not from git?
The repo map has been refreshed, use /map to view it.
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> /map

Here are summaries of some files present in my git repository.
Do not propose changes to these files, treat them as *read-only*.
If you need to edit any of these files, ask me to *add them to the chat* first.

some-dir

some-dir/some-file

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

## Root Cause

GitRepo.get_tracked_files() collects files from two sources:

 1 Committed files — via commit.tree.traverse(), filtering for blob.type == "blob"
 2 Staged files — via index.entries.keys()

Neither path checked whether a blob/entry was a symlink pointing to a directory. These entries were passed to the repo map, which then failed the Path(fname).is_file() check and emitted the misleading warning.

## Fix

Added a check in both code paths within get_tracked_files(): if a path is a symlink, it is only included if it resolves to a file (not a directory).

```python
full_path = Path(self.root) / path
if not full_path.is_symlink() or full_path.is_file():
    files.add(path)
```

This correctly:

 • Includes regular files (not symlinks) — is_symlink() is False, so the condition passes
 • Includes symlinks to files — is_symlink() is True but is_file() is also True
 • Excludes symlinks to directories — is_symlink() is True and is_file() is False