### PR TITLE
Add reflection mechanism to run_stream method

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -859,7 +859,18 @@ class Coder:
     def run_stream(self, user_message):
         self.io.user_input(user_message)
         self.init_before_message()
-        yield from self.send_message(user_message)
+        while user_message:
+            self.reflected_message = None
+            yield from self.send_message(user_message)
+            if not self.reflected_message:
+                break
+
+            if self.num_reflections >= self.max_reflections:
+                self.io.tool_warning(f"Only {self.max_reflections} reflections allowed, stopping.")
+                return
+
+            self.num_reflections += 1
+            user_message = self.reflected_message
 
     def init_before_message(self):
         self.aider_edited_files = set()


### PR DESCRIPTION
The run_stream method used in non-interactive mode was missing the reflection mechanism that exists in run_one (interactive mode). This change adds the reflection loop to run_stream, enabling features like lint to be triggered and executed properly in non-interactive mode.

The implementation mirrors the reflection logic from run_one:
- Loops while there are reflected messages
- Respects max_reflections limit
- Increments reflection counter appropriately