### PR TITLE
fix: catch ValueError in _get_style for invalid color formats

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -430,7 +430,14 @@ class InputOutput:
                 completion_menu_current_style
             )
 
-        return Style.from_dict(style_dict)
+        try:
+            return Style.from_dict(style_dict)
+        except ValueError as e:
+            self.console.print(
+                f"[bold red]Warning:[/bold red] Invalid color in style configuration: {e}."
+                " Falling back to default styling."
+            )
+            return Style.from_dict({})
 
     def read_image(self, filename):
         try:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -474,6 +474,19 @@ class TestInputOutputMultilineMode(unittest.TestCase):
             io.tool_output("Test message")
             mock_print.assert_called_once()
 
+    def test_get_style_invalid_color_fallback(self):
+        """Test that _get_style falls back gracefully when prompt_toolkit rejects a color"""
+        from prompt_toolkit.styles import Style
+
+        io = InputOutput(pretty=True, fancy_input=False)
+        # Manually set an invalid color that would cause Style.from_dict to raise ValueError
+        io.user_input_color = "not_a_valid_color!!!"
+
+        with patch.object(io.console, "print"):
+            # Should not raise - falls back to empty style
+            style = io._get_style()
+            self.assertIsInstance(style, Style)
+
 
 @patch("aider.io.is_dumb_terminal", return_value=False)
 @patch.dict(os.environ, {"NO_COLOR": ""})


### PR DESCRIPTION
## Summary

Fixes #2922.

When `--user-input-color` (or other color options) receive a value that passes Rich validation but fails prompt_toolkit's `Style.from_dict()` parser, aider crashes with an uncaught `ValueError`.

The existing `ensure_hash_prefix()` handles the most common case (bare hex like `bcbdbf` -> `#bcbdbf`), and `_validate_color_settings()` catches colors invalid per Rich's parser. However, `_get_style()` passes these colors to prompt_toolkit's `Style.from_dict()`, which has its own stricter parser — creating a gap where valid Rich colors can still cause an uncaught exception.

## Changes

- **`aider/io.py`**: Wrap `Style.from_dict(style_dict)` in `_get_style()` with `try/except ValueError`, falling back to an empty style dict with a warning instead of crashing.
- **`tests/basic/test_io.py`**: Add `test_get_style_invalid_color_fallback` to verify graceful fallback when prompt_toolkit rejects a color.

## Disclosure

This PR was authored by Claude (Opus 4.6), an AI assistant, with human oversight from Max Calkin. See [our project page](https://github.com/MaxwellCalkin/aider/blob/fix/user-input-color-exception-2922/AI_DISCLOSURE.md) for context on this collaboration.