### PR TITLE
fix: emoji input crash from lone UTF-16 surrogates on Windows

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -34,6 +34,7 @@ from rich.style import Style as RichStyle
 from rich.text import Text
 
 from aider.mdstream import MarkdownStream
+from aider.utils import sanitize_surrogates
 
 from .dump import dump  # noqa: F401
 from .editor import pipe_editor
@@ -676,14 +677,14 @@ class InputOutput:
 
             except EOFError:
                 raise
+            except UnicodeEncodeError as err:
+                self.tool_error(str(err))
+                return ""
             except Exception as err:
                 import traceback
 
                 self.tool_error(str(err))
                 self.tool_error(traceback.format_exc())
-                return ""
-            except UnicodeEncodeError as err:
-                self.tool_error(str(err))
                 return ""
             finally:
                 if self.file_watcher:
@@ -730,6 +731,7 @@ class InputOutput:
                 break
 
         print()
+        inp = sanitize_surrogates(inp)
         self.user_input(inp)
         return inp
 

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -13,6 +13,24 @@ from aider.waiting import Spinner
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp", ".pdf"}
 
 
+def sanitize_surrogates(text):
+    """Replace unpaired UTF-16 surrogates with the Unicode replacement character.
+
+    On Windows, clipboard paste of emoji characters through some input methods
+    can introduce lone surrogates (U+D800-U+DFFF) into Python strings. These are
+    invalid in UTF-8 and cause UnicodeEncodeError when printed. This function
+    encodes with 'surrogatepass' to allow surrogates through as bytes, then
+    decodes with 'replace' to turn those invalid byte sequences into U+FFFD.
+    """
+    if not isinstance(text, str):
+        return text
+    try:
+        text.encode("utf-8")
+        return text
+    except UnicodeEncodeError:
+        return text.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
+
+
 class IgnorantTemporaryDirectory:
     def __init__(self):
         if sys.version_info >= (3, 10):
@@ -139,7 +157,10 @@ def format_messages(messages, title=None):
 
 def show_messages(messages, title=None, functions=None):
     formatted_output = format_messages(messages, title)
-    print(formatted_output)
+    try:
+        print(formatted_output)
+    except UnicodeEncodeError:
+        print(sanitize_surrogates(formatted_output))
 
     if functions:
         dump(functions)


### PR DESCRIPTION
## Summary

Fixes #3844 — Pasting emoji characters causes `UnicodeEncodeError` crash and display corruption on Windows Terminal.

### Root cause

On Windows, pasting emoji from the clipboard through prompt_toolkit can introduce **lone UTF-16 surrogates** (U+D800–U+DFFF) into Python strings. These are invalid in UTF-8 encoding. When the string later reaches `print()` in `show_messages()`, Python's UTF-8 encoder raises:

```
UnicodeEncodeError: 'utf-8' codec can't encode characters in position X-Y: surrogates not allowed
```

There were three sub-problems:

1. **No input sanitization** — surrogate characters from user input were never cleaned
2. **Unprotected `print()`** — `show_messages()` called `print()` without `UnicodeEncodeError` handling
3. **Unreachable handler** — in `io.py`, `except UnicodeEncodeError` was placed *after* the broader `except Exception`, making it dead code

### Changes

**`aider/utils.py`**

Added `sanitize_surrogates()` — replaces lone surrogates with U+FFFD (replacement character) using a `surrogatepass`/`replace` encoding roundtrip:

```python
def sanitize_surrogates(text):
    if not isinstance(text, str):
        return text
    try:
        text.encode("utf-8")  # fast path: no surrogates
        return text
    except UnicodeEncodeError:
        return text.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
```

Wrapped `print()` in `show_messages()` with a `UnicodeEncodeError` fallback that prints the sanitized version.

**`aider/io.py`**

- Sanitize user input immediately after collection: `inp = sanitize_surrogates(inp)`
- Moved `except UnicodeEncodeError` *before* `except Exception` so it's actually reachable

### Platform impact

| Scenario | Before | After |
|---|---|---|
| Normal text (all platforms) | Works | No change (fast-path `encode()` check, zero overhead) |
| Emoji paste on Windows | **Crash** | Surrogates replaced with U+FFFD, no crash |
| Emoji paste on Linux/macOS | Works (no surrogates) | No change (fast-path returns immediately) |

### Testing

Both modified files pass `ast.parse()` syntax validation. The `sanitize_surrogates` function was independently verified with:
- Normal strings → pass through unchanged
- Real emoji (🤖) → pass through unchanged  
- Lone surrogates (`\ud800`, `\udc00`) → replaced with U+FFFD
- Mixed content → only surrogates replaced, rest preserved
- Non-string input → returned as-is