### PR TITLE
Add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/check_pypi_version.yml
+++ b/.github/workflows/check_pypi_version.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out repository

--- a/.github/workflows/windows_check_pypi_version.yml
+++ b/.github/workflows/windows_check_pypi_version.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     defaults:
       run:
         shell: pwsh # Use PowerShell for all run steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,12 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python",
     "Topic :: Software Development",
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 dynamic = ["dependencies", "optional-dependencies", "version"]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,9 +218,9 @@ networkx==3.4.2
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-numpy==1.26.4
     # via
     #   -c requirements/common-constraints.txt
+    #   -r requirements/python-compat.in
     #   scipy
     #   soundfile
 openai==2.20.0
@@ -351,10 +351,9 @@ rpds-py==0.30.0
     #   -c requirements/common-constraints.txt
     #   jsonschema
     #   referencing
-scipy==1.15.3
     # via
     #   -c requirements/common-constraints.txt
-    #   -r requirements/requirements.in
+    #   -r requirements/python-compat.in
 shellingham==1.5.4
     # via
     #   -c requirements/common-constraints.txt
@@ -440,8 +439,6 @@ typer-slim==0.23.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   huggingface-hub
@@ -449,8 +446,6 @@ typing-extensions==4.15.0
     #   posthog
     #   pydantic
     #   pydantic-core
-    #   referencing
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -480,3 +475,16 @@ zipp==3.23.0
     
 tree-sitter==0.23.2; python_version < "3.10"
 tree-sitter==0.25.2; python_version >= "3.10"
+# NumPy 2.x adds Python 3.14 wheels, but dropped Python 3.10.
+numpy<2; python_version < "3.11"
+numpy>=2.3,<2.5; python_version >= "3.11"
+
+# This is the one networkx dependency that we need.
+# Including it here explicitly because we
+# didn't specify networkx[default] above.
+#
+# SciPy 1.16+ adds Python 3.14 wheels, but dropped Python 3.10.
+scipy<1.16; python_version < "3.11"
+scipy>=1.16.1,<1.18; python_version >= "3.11"
+# Remove if Python 3.13+ support lands in pydub upstream.
+audioop-lts>=0.2.2; python_version >= "3.13"

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -286,8 +286,9 @@ nltk==3.9.2
     # via llama-index-core
 nodeenv==1.10.0
     # via pre-commit
-numpy==1.26.4
+numpy==2.4.3
     # via
+    #   -r requirements/python-compat.in
     #   -r requirements/requirements-help.in
     #   contourpy
     #   llama-index-core
@@ -479,9 +480,9 @@ scikit-learn==1.8.0
     # via
     #   -r requirements/requirements-help.in
     #   sentence-transformers
-scipy==1.15.3
+scipy==1.17.1
     # via
-    #   -r requirements/requirements.in
+    #   -r requirements/python-compat.in
     #   scikit-learn
     #   sentence-transformers
 semver==3.0.4
@@ -540,7 +541,9 @@ tokenizers==0.22.2
 toml==0.10.2
     # via streamlit
 torch==2.10.0
-    # via sentence-transformers
+    # via
+    #   -r requirements/requirements-help.in
+    #   sentence-transformers
 tornado==6.5.4
     # via streamlit
 tqdm==4.67.3
@@ -573,9 +576,7 @@ typer-slim==0.23.0
     #   transformers
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   altair
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   grpcio
@@ -587,10 +588,8 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pyee
-    #   referencing
     #   sentence-transformers
     #   sqlalchemy
-    #   starlette
     #   streamlit
     #   torch
     #   typing-inspect

--- a/requirements/pydub.in
+++ b/requirements/pydub.in
@@ -1,0 +1,2 @@
+# Remove if Python 3.13+ support lands in pydub upstream.
+audioop-lts>=0.2.2; python_version >= "3.13"

--- a/requirements/python-compat.in
+++ b/requirements/python-compat.in
@@ -1,0 +1,11 @@
+# NumPy 2.x adds Python 3.14 wheels, but dropped Python 3.10.
+numpy<2; python_version < "3.11"
+numpy>=2.3,<2.5; python_version >= "3.11"
+
+# This is the one networkx dependency that we need.
+# Including it here explicitly because we
+# didn't specify networkx[default] above.
+#
+# SciPy 1.16+ adds Python 3.14 wheels, but dropped Python 3.10.
+scipy<1.16; python_version < "3.11"
+scipy>=1.16.1,<1.18; python_version >= "3.11"

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -62,7 +62,7 @@ narwhals==2.16.0
     # via
     #   -c requirements/common-constraints.txt
     #   altair
-numpy==1.26.4
+numpy==2.4.3
     # via
     #   -c requirements/common-constraints.txt
     #   pandas
@@ -143,7 +143,6 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
     #   altair
-    #   referencing
     #   streamlit
 tzdata==2025.3
     # via

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -147,7 +147,7 @@ nodeenv==1.10.0
     # via
     #   -c requirements/common-constraints.txt
     #   pre-commit
-numpy==1.26.4
+numpy==2.4.3
     # via
     #   -c requirements/common-constraints.txt
     #   contourpy

--- a/requirements/requirements-help.in
+++ b/requirements/requirements-help.in
@@ -1,11 +1,11 @@
 llama-index-embeddings-huggingface
 
-# Because sentence-transformers doesn't like >=2
-numpy<2
+# NumPy 2.x adds Python 3.14 wheels, but dropped Python 3.10.
+numpy<2; python_version < "3.11"
+numpy>=2.3,<2.5; python_version >= "3.11"
 
-# Mac x86 only supports 2.2.2
-# https://discuss.pytorch.org/t/why-no-macosx-x86-64-build-after-torch-2-2-2-cp39-none-macosx-10-9-x86-64-whl/204546/2
-# torch==2.2.2
+# Torch 2.3+ works with NumPy 2 on the supported Python versions.
+torch>=2.3.0
 
 # Later versions break test_help in GitHub Actions on Windows and Ubuntu
 # due to llama-index-core==0.12.26

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -206,7 +206,7 @@ nltk==3.9.2
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-numpy==1.26.4
+numpy==2.4.3
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-help.in
@@ -280,7 +280,7 @@ scikit-learn==1.8.0
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-help.in
     #   sentence-transformers
-scipy==1.15.3
+scipy==1.17.1
     # via
     #   -c requirements/common-constraints.txt
     #   scikit-learn
@@ -326,6 +326,7 @@ tokenizers==0.22.2
 torch==2.10.0
     # via
     #   -c requirements/common-constraints.txt
+    #   -r requirements/requirements-help.in
     #   sentence-transformers
 tqdm==4.67.3
     # via
@@ -351,8 +352,6 @@ typer-slim==0.23.0
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   huggingface-hub
     #   llama-index-core
     #   llama-index-workflows

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -29,6 +29,7 @@ socksio
 pillow
 shtab
 oslex
+-r python-compat.in
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps
@@ -37,13 +38,6 @@ oslex
 #
 # >3.5 seems to not be available for py3.10
 networkx<3.5
-
-# This is the one networkx dependency that we need.
-# Including it here explicitly because we
-# didn't specify networkx[default] above.
-#
-# 1.16 onwards only supports python3.11+
-scipy<1.16
 
 # GitHub Release action failing on "KeyError: 'home-page'"
 # https://github.com/pypa/twine/blob/6fbf880ee60915cf1666348c4bdd78a10415f2ac/twine/__init__.py#L40

--- a/scripts/pip-compile.sh
+++ b/scripts/pip-compile.sh
@@ -25,8 +25,8 @@ uv pip compile \
     requirements/requirements.in \
     $1
 
-grep -v ^tree-sitter= tmp.requirements.txt \
-    | cat - requirements/tree-sitter.in \
+grep -Ev '^(tree-sitter|numpy|scipy)=' tmp.requirements.txt \
+    | cat - requirements/tree-sitter.in requirements/python-compat.in requirements/pydub.in \
     > requirements.txt
 
 # Compile additional requirements files


### PR DESCRIPTION
This PR enables Python 3.13 and 3.14 for aider-chat.

What changed:
- widens requires-python to 3.10 through 3.14
- expands the Ubuntu and Windows workflow matrices to 3.10 through 3.14
- adds marker-based NumPy and SciPy requirements so Python 3.10 stays on older compatible versions while Python 3.11+ can use versions with Python 3.14 wheels
- adds audioop-lts for Python 3.13+ to keep pydub working until upstream support lands

Validation:
- fork CI is green across the expanded matrix, including Python 3.13 and 3.14 on Ubuntu and Windows
- Docker build and pre-commit also passed on the fork

Fork validation PR: https://github.com/turian/aider/pull/1