### PR TITLE
Skip invalid tree-sitter queries in repo map generation

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -16,7 +16,7 @@ from grep_ast import TreeContext, filename_to_lang
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Token
 from tqdm import tqdm
-from tree_sitter import Query
+from tree_sitter import Query, QueryError
 
 from aider.dump import dump
 from aider.special import filter_important_files
@@ -298,8 +298,12 @@ class RepoMap:
             return
         tree = parser.parse(bytes(code, "utf-8"))
 
-        # Run the tags queries
-        captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        # Skip files whose installed parser and scm query are out of sync.
+        try:
+            captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        except QueryError as err:
+            print(f"Skipping file {fname}: {err}")
+            return
 
         captures_by_tag = defaultdict(list)
         matches = []

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,8 +4,10 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
+from tree_sitter import QueryError
 
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
@@ -271,6 +273,28 @@ print(my_function(3, 4))
             self.assertIn("test_file4.json", result)
 
             # close the open cache files, so Windows won't error
+            del repo_map
+
+    def test_get_repo_map_skips_query_compile_failures(self):
+        with IgnorantTemporaryDirectory() as temp_dir:
+            broken_file = os.path.join(temp_dir, "broken.py")
+            healthy_file = os.path.join(temp_dir, "healthy.md")
+
+            with open(broken_file, "w", encoding="utf-8") as f:
+                f.write("def broken():\n    return 1\n")
+
+            with open(healthy_file, "w", encoding="utf-8") as f:
+                f.write("# healthy\n")
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
+
+            with patch("aider.repomap.Query", side_effect=QueryError("boom")):
+                result = repo_map.get_repo_map([], [broken_file, healthy_file])
+
+            self.assertIn("broken.py", result)
+            self.assertIn("healthy.md", result)
+
             del repo_map
 
 


### PR DESCRIPTION
## Summary
Prevent repo map generation from crashing when a tree-sitter tag query cannot be compiled for a file.

## Problem
`RepoMap.get_tags_raw()` currently lets `tree_sitter.QueryError` bubble out of `Query(language, query_scm)`. When a `.scm` query and the installed parser are out of sync, a single file can crash repo map generation for the entire run.

## Root cause
`get_tags_raw()` already treats parser initialization failures as file-level skips, but query compilation failures were not handled the same way. That meant an invalid query was not isolated to the file that triggered it.

## Fix
- catch `QueryError` around query compilation/capture execution
- skip the affected file the same way parser setup failures are skipped
- add a regression test that patches `Query(...)` to fail and verifies `get_repo_map()` still returns a repo map instead of crashing

## Validation
- `./.venv311/bin/python -m pytest tests/basic/test_repomap.py -q`
- `./.venv311/bin/python -m flake8 aider/repomap.py tests/basic/test_repomap.py`

Fixes #4919.
