### PR TITLE
Handle variable MultiDiGraph out-edge tuple shapes in repo map

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -537,9 +537,12 @@ class RepoMap:
                 progress(f"{UPDATING_REPO_MAP_MESSAGE}: {src}")
 
             src_rank = ranked[src]
-            total_weight = sum(data["weight"] for _src, _dst, data in G.out_edges(src, data=True))
+            out_edges = list(G.out_edges(src, data=True))
+            total_weight = sum(edge[-1]["weight"] for edge in out_edges)
             # dump(src, src_rank, total_weight)
-            for _src, dst, data in G.out_edges(src, data=True):
+            for edge in out_edges:
+                dst = edge[1]
+                data = edge[-1]
                 data["rank"] = src_rank * data["weight"] / total_weight
                 ident = data["ident"]
                 ranked_definitions[(dst, ident)] += data["rank"]

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,8 +4,10 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
+import networkx as nx
 
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
@@ -271,6 +273,45 @@ print(my_function(3, 4))
             self.assertIn("test_file4.json", result)
 
             # close the open cache files, so Windows won't error
+            del repo_map
+
+    def test_get_repo_map_handles_keyed_out_edges(self):
+        original_multidigraph = nx.MultiDiGraph
+
+        class KeyedOutEdgesMultiDiGraph(original_multidigraph):
+            @property
+            def out_edges(self):
+                base_view = original_multidigraph.out_edges.__get__(self, type(self))
+
+                def keyed_out_edges(nbunch=None, data=False, default=None):
+                    return base_view(
+                        nbunch=nbunch,
+                        data=data,
+                        default=default,
+                        keys=True if data else False,
+                    )
+
+                return keyed_out_edges
+
+        with GitTemporaryDirectory() as temp_dir:
+            with open(os.path.join(temp_dir, "defs.py"), "w", encoding="utf-8") as f:
+                f.write("def shared_name():\n    return 1\n")
+
+            with open(os.path.join(temp_dir, "refs.py"), "w", encoding="utf-8") as f:
+                f.write("from defs import shared_name\n\nshared_name()\nshared_name()\n")
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
+            other_files = [
+                os.path.join(temp_dir, "defs.py"),
+                os.path.join(temp_dir, "refs.py"),
+            ]
+
+            with patch("networkx.MultiDiGraph", KeyedOutEdgesMultiDiGraph):
+                result = repo_map.get_repo_map([], other_files)
+
+            self.assertIn("shared_name", result)
+
             del repo_map
 
 


### PR DESCRIPTION
## Summary
Handle repo map graph edge tuples without assuming a fixed tuple length.

## Problem
`get_ranked_tags()` currently unpacks each `MultiDiGraph.out_edges(..., data=True)` item as `(src, dst, data)`. In environments where the multiedge view includes an edge key, that assumption breaks and repo map generation crashes with a `ValueError` while distributing rank across outgoing edges.

## Root cause
The code assumed a fixed edge tuple shape even though `MultiDiGraph` edge views can vary depending on how the view is produced. The actual logic only needs the destination node and the edge data, not the exact tuple layout.

## Fix
- materialize the outgoing edge view once per source node
- read `dst` and `data` positionally so both 3-item and 4-item edge tuples work
- add a regression test that patches `networkx.MultiDiGraph` to expose keyed out-edges and verifies repo map generation still succeeds

## Validation
- `./.venv311/bin/python -m pytest tests/basic/test_repomap.py -q`
- `./.venv311/bin/python -m flake8 aider/repomap.py tests/basic/test_repomap.py`

Fixes #4917.
