### PR TITLE
fix: catch NoSuchPathError in get_git_root()

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -62,7 +62,7 @@ def get_git_root():
     try:
         repo = git.Repo(search_parent_directories=True)
         return repo.working_tree_dir
-    except (git.InvalidGitRepositoryError, FileNotFoundError):
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError):
         return None
 
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -14,7 +14,7 @@ from prompt_toolkit.output import DummyOutput
 from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
-from aider.main import check_gitignore, load_dotenv_files, main, setup_git
+from aider.main import check_gitignore, get_git_root, load_dotenv_files, main, setup_git
 from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory, make_repo
 
 
@@ -1163,6 +1163,20 @@ class TestMain(TestCase):
             self.fail(f"main() raised an unexpected exception: {e}")
 
         self.assertIsNone(result, "main() should return None when called with --exit")
+
+    @patch("aider.main.git.Repo")
+    def test_get_git_root_no_such_path_error(self, mock_repo):
+        """get_git_root should return None when NoSuchPathError is raised (issue #2957)."""
+        mock_repo.side_effect = git.exc.NoSuchPathError("/nonexistent/path")
+        result = get_git_root()
+        self.assertIsNone(result)
+
+    @patch("aider.main.git.Repo")
+    def test_get_git_root_invalid_repo(self, mock_repo):
+        """get_git_root should return None when InvalidGitRepositoryError is raised."""
+        mock_repo.side_effect = git.InvalidGitRepositoryError("/some/path")
+        result = get_git_root()
+        self.assertIsNone(result)
 
     def test_reasoning_effort_option(self):
         coder = main(


### PR DESCRIPTION
## Summary

- Add `git.NoSuchPathError` to the exception handler in `get_git_root()` so paths containing special characters (like `$$` on Windows) don't cause an uncaught exception crash
- Add unit tests verifying `get_git_root()` returns `None` for both `NoSuchPathError` and `InvalidGitRepositoryError`

## Root Cause

When a directory path contains `$$` characters on Windows, GitPython's internal `os.path.expandvars()` silently corrupts the path (e.g., `F:\$$data\python\detect_programs` becomes `F:\$data\python\detect_programs`). The corrupted path doesn't exist on disk, so `git.Repo()` raises `git.exc.NoSuchPathError`. This exception was not in the `except` clause of `get_git_root()`, causing an uncaught exception crash at startup.

## Fix

One-line change: add `git.NoSuchPathError` to the existing `except` tuple in `get_git_root()`, matching the existing pattern for `git.InvalidGitRepositoryError` and `FileNotFoundError`. This allows aider to gracefully fall back when the git repo path cannot be resolved.

## Test plan

- [x] Added `test_get_git_root_no_such_path_error` - mocks `git.Repo` to raise `NoSuchPathError`, verifies `get_git_root()` returns `None`
- [x] Added `test_get_git_root_invalid_repo` - mocks `git.Repo` to raise `InvalidGitRepositoryError`, verifies existing behavior still works
- [x] Both tests pass locally

Fixes #2957