### PR TITLE
fix: Include user-added files in commit message context

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -799,7 +799,10 @@ class Commands:
     def cmd_add(self, args):
         "Add files to the chat so aider can edit them or review them in detail"
 
+        from aider import prompts
+
         all_matched_files = set()
+        added_fnames = []
 
         filenames = parse_quoted_filenames(args)
         for word in filenames:
@@ -880,6 +883,7 @@ class Commands:
                     self.io.tool_output(
                         f"Moved {matched_file} from read-only to editable files in the chat"
                     )
+                    added_fnames.append(matched_file)
                 else:
                     self.io.tool_error(
                         f"Cannot add {matched_file} as it's not part of the repository"
@@ -901,6 +905,10 @@ class Commands:
                     fname = self.coder.get_rel_fname(abs_file_path)
                     self.io.tool_output(f"Added {fname} to the chat")
                     self.coder.check_added_files()
+                    added_fnames.append(fname)
+
+        if added_fnames:
+            return prompts.added_files.format(fnames=", ".join(added_fnames))
 
     def completions_drop(self):
         files = self.coder.get_inchat_relative_files()


### PR DESCRIPTION
## Problem

When files are added to the chat via the "/add" command, the commit message generator was not aware of these files because no message was being added to the chat history. The commit message generation uses "get_context_from_history(self.cur_messages)" to gather context, but since the "/add" command didn't add any message to the chat history, the commit messages didn't include information about user-added files.

## Solution

Modified "cmd_add()" in "aider/commands.py" to:
1. Track which files are successfully added to the chat
2. Return a message in the format "I added these files to the chat: {fnames}" when files are added
3. This message gets added to "cur_messages" and is included in the commit message context

This follows the same pattern used when files are added via file mentions in "check_for_file_mentions()".

## Changes

- Added "from aider import prompts" import
- Added "added_fnames" list to track added files
- Added "added_fnames.append()" calls when files are added (both new files and files promoted from read-only)
- Added return statement with the formatted message when files are added

Fixes #728