### PR TITLE
fix: correct /undo prompt to match actual git reset --soft behavior

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -23,9 +23,9 @@ Reply only with the one-line commit message, without any additional text, explan
 
 # COMMANDS
 undo_command_reply = (
-    "I did `git reset --hard HEAD~1` to discard the last edits. Please wait for further"
-    " instructions before attempting that change again. Feel free to ask relevant questions about"
-    " why the changes were reverted."
+    "I did `git reset --soft HEAD~1` to undo the last commit. The changes from that commit are"
+    " now staged but uncommitted. Please wait for further instructions before attempting that"
+    " change again. Feel free to ask relevant questions about why the changes were reverted."
 )
 
 added_files = (


### PR DESCRIPTION
## Bug description

`undo_command_reply` in `prompts.py` tells the LLM that `git reset --hard HEAD~1` was executed, but `commands.py` L644 actually runs `git reset --soft HEAD~1`.

This causes the LLM to believe all changes were discarded (working tree clean), when they are actually still staged. Subsequent editing decisions are based on an incorrect understanding of the repository state.

## Fix

Update the prompt string to accurately describe the `--soft` reset and mention that changes remain staged.

## Steps to reproduce

1. Start aider and request a code edit
2. Run `/undo`
3. Ask the AI to "improve the previous change"
4. The AI starts from scratch instead of working with the staged changes, because it believes `--hard` wiped everything

## Affected files

- `aider/prompts.py` (L25-29) — 1 line change