### PR TITLE
fix: add missing f-string prefix in voice.py file size warning

### DIFF
--- a/aider/voice.py
+++ b/aider/voice.py
@@ -146,7 +146,7 @@ class Voice:
         # Check file size and offer to convert to mp3 if too large
         file_size = os.path.getsize(temp_wav)
         if file_size > 24.9 * 1024 * 1024 and self.audio_format == "wav":
-            print("\nWarning: {temp_wav} is too large, switching to mp3 format.")
+            print(f"\nWarning: {temp_wav} is too large, switching to mp3 format.")
             use_audio_format = "mp3"
 
         filename = temp_wav


### PR DESCRIPTION
## Bug description

In `voice.py` L149, the warning message uses `{temp_wav}` placeholder syntax but is missing the `f` prefix:

```python
print("\nWarning: {temp_wav} is too large, switching to mp3 format.")
```

This prints the literal string `{temp_wav}` instead of the actual file path.

## Fix

Add the `f` prefix to make it an f-string:

```python
print(f"\nWarning: {temp_wav} is too large, switching to mp3 format.")
```

## Affected files

- `aider/voice.py` (L149) — 1 character change