### PR TITLE
fix: add missing parameters to posthog on_error callback

### DIFF
--- a/aider/analytics.py
+++ b/aider/analytics.py
@@ -203,9 +203,8 @@ class Analytics:
             return model.name.split("/")[0] + "/REDACTED"
         return None
 
-    def posthog_error(self):
+    def posthog_error(self, error=None, batch=None):
         """disable posthog if we get an error"""
-        print("X" * 100)
         # https://github.com/PostHog/posthog-python/blob/9e1bb8c58afaa229da24c4fb576c08bb88a75752/posthog/consumer.py#L86
         # https://github.com/Aider-AI/aider/issues/2532
         self.ph = None


### PR DESCRIPTION
## Bug description

Posthog's consumer thread calls `on_error(error, batch)` with [two positional arguments](https://github.com/PostHog/posthog-python/blob/9e1bb8c58afaa229da24c4fb576c08bb88a75752/posthog/consumer.py#L86), but `Analytics.posthog_error()` only accepts `self`.

When a Posthog error occurs (network failure, server error, etc.):
1. `on_error(error, batch)` is called with 2 args
2. `posthog_error(self)` receives 3 positional args (self + error + batch)
3. **TypeError** is raised inside Posthog's consumer thread
4. `self.ph = None` never executes — Posthog is never disabled
5. Failed requests continue to be retried indefinitely

## Fix

Accept the two optional parameters that Posthog passes:

```python
def posthog_error(self, error=None, batch=None):
```

Also removes a `print("X" * 100)` debug statement that was left in.

## References

- Posthog consumer source: https://github.com/PostHog/posthog-python/blob/9e1bb8c58afaa229da24c4fb576c08bb88a75752/posthog/consumer.py#L86
- Related: #2532

## Affected files

- `aider/analytics.py` (L206) — 1 line change