### PR TITLE
fix: swap foreground/background colors in completion menu current item

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -422,9 +422,9 @@ class InputOutput:
         # Conditionally add 'completion-menu.completion.current' style
         completion_menu_current_style = []
         if self.completion_menu_current_bg_color:
-            completion_menu_current_style.append(self.completion_menu_current_bg_color)
+            completion_menu_current_style.append(f"bg:{self.completion_menu_current_bg_color}")
         if self.completion_menu_current_color:
-            completion_menu_current_style.append(f"bg:{self.completion_menu_current_color}")
+            completion_menu_current_style.append(self.completion_menu_current_color)
         if completion_menu_current_style:
             style_dict["completion-menu.completion.current"] = " ".join(
                 completion_menu_current_style


### PR DESCRIPTION
## Bug description

The `completion-menu.completion.current` style in `io.py` has its foreground and background colors reversed compared to the non-current `completion-menu` style.

The non-current (correct) pattern:
```python
# completion-menu — correct
f"bg:{self.completion_menu_bg_color}"     # bg: prefix → background
self.completion_menu_color                 # no prefix → foreground
```

The current-item (swapped) pattern:
```python
# completion-menu.completion.current — swapped
self.completion_menu_current_bg_color      # no bg: prefix → applied as foreground
f"bg:{self.completion_menu_current_color}" # bg: prefix → applied as background
```

## Steps to reproduce

```bash
aider --completion-menu-current-color '#FFFFFF' --completion-menu-current-bg-color '#0000FF'
```

1. Type to trigger the completion menu (Tab)
2. **Expected**: Blue background with white text on the selected item
3. **Actual**: White background with blue text (inverted)

## Fix

Apply the `bg:` prefix to `completion_menu_current_bg_color` and remove it from `completion_menu_current_color`, matching the pattern used for the non-current menu style.

## Affected files

- `aider/io.py` (L424-427) — 2 line change