### PR TITLE
fix: Remove programming error exceptions from ANY_GIT_ERROR

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -27,10 +27,6 @@ ANY_GIT_ERROR += [
     OSError,
     IndexError,
     BufferError,
-    TypeError,
-    ValueError,
-    AttributeError,
-    AssertionError,
     TimeoutError,
 ]
 ANY_GIT_ERROR = tuple(ANY_GIT_ERROR)


### PR DESCRIPTION
Fixes #4932

## Problem
The l tuple in l included general Python programming errors (TypeError, ValueError, AttributeError, AssertionError) alongside actual git-related errors. This caused programming bugs to be silently swallowed instead of surfacing for debugging.

## Solution
Remove TypeError, ValueError, AttributeError, and AssertionError from ANY_GIT_ERROR. These are general Python programming errors that should not be caught by a generic git error handler.

## Impact Analysis
- Call sites that need these exceptions already add them explicitly (e.g., l)
- 21 repo tests pass
- 74 main tests pass (2 unrelated failures)
- 68 commands tests pass (2 unrelated failures)

## Changes
- l: Removed 4 exception types from ANY_GIT_ERROR

This change allows actual programming bugs to surface while maintaining the ability to catch git-specific errors.