### PR TITLE
fix: replace two deprecated models, delete one

### DIFF
--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -536,7 +536,7 @@ class TestCommands(TestCase):
             io = InputOutput(pretty=False, fancy_input=False, yes=False)
             from aider.coders import Coder
 
-            coder = Coder.create(Model("claude-3-5-sonnet-20240620"), None, io)
+            coder = Coder.create(Model("claude-sonnet-4-6"), None, io)
             print(coder.get_announcements())
             commands = Commands(io, coder)
 

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -924,7 +924,7 @@ class TestCommands(TestCase):
             self.assertEqual(len(coder.abs_read_only_fnames), 0)
 
             # Test with vision model
-            vision_model = Model("gpt-4-vision-preview")
+            vision_model = Model("gpt-4o")
             vision_coder = Coder.create(vision_model, None, io)
             vision_commands = Commands(io, vision_coder)
 

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -43,9 +43,6 @@ class TestModels(unittest.TestCase):
         model = Model("gpt-4")
         self.assertEqual(model.info["max_input_tokens"], 8 * 1024)
 
-        model = Model("gpt-4-32k")
-        self.assertEqual(model.info["max_input_tokens"], 32 * 1024)
-
         model = Model("gpt-4-0613")
         self.assertEqual(model.info["max_input_tokens"], 8 * 1024)
 


### PR DESCRIPTION
Three models that the unit tests use are no longer available online:

- `gpt-4-32k` (see https://github.com/BerriAI/litellm/pull/20795 and https://github.com/BerriAI/litellm/commit/15075ef9ec881cd51831f9e40423fb2058f701f8)

- `claude-3-5-sonnet-20240620` (see https://github.com/BerriAI/litellm/pull/23400 and https://github.com/BerriAI/litellm/commit/c9f7075690173165a3a4085bd52e2dee8449063d)

- the vision model `gpt-4-vision-preview` (see https://github.com/BerriAI/litellm/pull/23400 and https://github.com/BerriAI/litellm/commit/c9f7075690173165a3a4085bd52e2dee8449063d)

The LiteLLM commits mentioned suggest suitable alternatives for the three models.  
This PR updates the unit tests accordingly.
See commit messages for details.