### PR TITLE
fix: Uncaught UnicodeDecodeError in cp1252.py line 23

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -56,7 +56,7 @@ def load_gitignores(gitignore_paths: list[Path]) -> Optional[PathSpec]:
     ]  # Always ignore
     for path in gitignore_paths:
         if path.exists():
-            with open(path) as f:
+            with open(path, encoding="utf-8", errors="ignore") as f:
                 patterns.extend(f.readlines())
 
     return PathSpec.from_lines(GitWildMatchPattern, patterns) if patterns else None


### PR DESCRIPTION
Fixes #2888

`load_gitignores` in `aider/watch.py` crashed with a `UnicodeDecodeError` when reading `.gitignore` files containing non-UTF-8 encoded characters (e.g. Windows cp1252 encoding). The root cause was that `open(path)` used the system default encoding, which fails on non-ASCII bytes in certain locales. Changes `open(path)` to `open(path, encoding="utf-8", errors="ignore")` in `aider/watch.py:59`, silently skipping undecodable bytes rather than raising. Verified by the existing test suite and manual reproduction on a Windows system with a cp1252-encoded `.gitignore`.