### PR TITLE
Add opt-in union-find chat history summarizer

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -226,6 +226,17 @@ def get_parser(default_config_files, git_root):
             " If unspecified, defaults to the model's max_chat_history_tokens."
         ),
     )
+    group.add_argument(
+        "--chat-history-summarizer",
+        default="recursive",
+        choices=["recursive", "union-find"],
+        help=(
+            "Chat history summarization backend."
+            " 'recursive' (default) uses the existing recursive summarizer."
+            " 'union-find' groups messages into topic clusters by TF-IDF similarity"
+            " and summarizes each cluster independently."
+        ),
+    )
 
     ##########
     group = parser.add_argument_group("Cache settings")

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -59,7 +59,7 @@ class ChatSummaryUF(ChatSummary):
 
     def summarize(self, messages, depth=0):
         if not self.too_big(messages):
-            return messages
+            return super().summarize(messages, depth)
 
         chat_msgs = self._chat_messages(messages)
 
@@ -103,12 +103,8 @@ class ChatSummaryUF(ChatSummary):
         if hot_count > 0 and hot_count < len(rendered):
             cold_parts = rendered[:-hot_count]
             summary_text = prompts.summary_prefix + "\n\n".join(cold_parts)
-            all_fed = self._get_fed_indices(messages)
-            if hot_count <= len(all_fed):
-                hot_start = all_fed[-hot_count]
-                hot_messages = messages[hot_start:]
-            else:
-                hot_messages = messages[-hot_count:]
+            hot_start = self._get_hot_start(messages, hot_count)
+            hot_messages = messages[hot_start:]
             result = [
                 {"role": "user", "content": summary_text},
                 {"role": "assistant", "content": "Ok."},
@@ -137,6 +133,28 @@ class ChatSummaryUF(ChatSummary):
             if msg.get("role", "").upper() in ("USER", "ASSISTANT")
             and msg.get("content", "")
         ]
+
+    @classmethod
+    def _get_hot_start(cls, messages, hot_count):
+        """Map the hot user/assistant boundary back to the original message list."""
+        all_fed = cls._get_fed_indices(messages)
+        if hot_count <= 0 or hot_count > len(all_fed):
+            return max(0, len(messages) - hot_count)
+
+        hot_start = all_fed[-hot_count]
+
+        # Include boundary system/tool messages immediately before the first hot turn.
+        while hot_start > 0:
+            role = messages[hot_start - 1].get("role", "").upper()
+            if role in ("USER", "ASSISTANT"):
+                break
+            hot_start -= 1
+
+        # Match the base summarizer behavior: hot tail should begin on a user turn.
+        while hot_start > 0 and messages[hot_start].get("role", "").upper() != "USER":
+            hot_start -= 1
+
+        return hot_start
 
     def summarize_all(self, messages):
         return super().summarize_all(messages)

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -17,7 +17,7 @@ class ChatSummaryUF(ChatSummary):
 
     def __init__(self, models=None, max_tokens=1024):
         super().__init__(models, max_tokens)
-        self._fed_count = 0
+        self._fed_messages = []
         self._init_context_window()
 
     def _init_context_window(self):
@@ -28,25 +28,51 @@ class ChatSummaryUF(ChatSummary):
             max_cold_clusters=10,
             merge_threshold=0.15,
         )
-        self._fed_count = 0
+        self._fed_messages = []
+
+    @staticmethod
+    def _chat_messages(messages):
+        """Extract user/assistant messages with non-empty content."""
+        return [
+            msg for msg in messages
+            if msg.get("role", "").upper() in ("USER", "ASSISTANT")
+            and msg.get("content", "")
+        ]
+
+    def _starts_with_fed(self, chat_msgs):
+        """Check if chat_msgs starts with our previously fed messages."""
+        if len(chat_msgs) < len(self._fed_messages):
+            return False
+        for i, msg in enumerate(self._fed_messages):
+            if chat_msgs[i] != msg:
+                return False
+        return True
+
+    def _rebuild(self, chat_msgs):
+        """Rebuild context window from scratch when state is stale."""
+        self._init_context_window()
+        for msg in chat_msgs:
+            role = msg.get("role", "").upper()
+            content = msg.get("content", "")
+            self.context_window.append(f"# {role}\n{content}")
+        self._fed_messages = list(chat_msgs)
 
     def summarize(self, messages, depth=0):
         if not self.too_big(messages):
             return messages
 
-        # Stale detection: messages shrank → previous result applied → rebuild
-        if self._fed_count > len(messages):
-            self._init_context_window()
+        chat_msgs = self._chat_messages(messages)
 
-        # Feed only new user/assistant messages, tracking their indices
-        for i, msg in enumerate(messages[self._fed_count:], start=self._fed_count):
-            role = msg.get("role", "").upper()
-            if role not in ("USER", "ASSISTANT"):
-                continue
-            content = msg.get("content", "")
-            if content:
+        # Prefix-based stale detection: rebuild if messages changed
+        if not self._starts_with_fed(chat_msgs):
+            self._rebuild(chat_msgs)
+        else:
+            # Feed only new messages
+            for msg in chat_msgs[len(self._fed_messages):]:
+                role = msg.get("role", "").upper()
+                content = msg.get("content", "")
                 self.context_window.append(f"# {role}\n{content}")
-        self._fed_count = len(messages)
+            self._fed_messages = list(chat_msgs)
 
         # Token-aware graduation: keep only as many hot messages as fit
         # in 25% of the token budget. Graduate the rest to cold clusters.

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -50,6 +50,11 @@ class ChatSummaryUF(ChatSummary):
                 fed_indices.append(i)
         self._fed_count = len(messages)
 
+        # If no cold clusters yet, force-graduate the oldest half of hot zone.
+        # This breaks the deadlock where too_big fires before graduate_at is reached.
+        if self.context_window.cold_count == 0 and self.context_window.hot_count > 4:
+            self.context_window.force_graduate(keep_hot=max(4, self.context_window.hot_count // 2))
+
         # Resolve dirty clusters, then render fresh summaries
         try:
             self.context_window.resolve_dirty()

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -1,0 +1,85 @@
+"""ChatSummaryUF — drop-in replacement for aider's ChatSummary.
+
+Uses union-find context compaction instead of recursive summarization.
+Falls back to recursive when union-find can't improve on the input.
+"""
+
+from aider.history import ChatSummary
+from aider import prompts
+
+from aider.context_window import ContextWindow
+from aider.embedding_service import TFIDFEmbedder
+from aider.cluster_summarizer import ClusterSummarizer
+
+
+class ChatSummaryUF(ChatSummary):
+    """Union-find context compaction, subclassing aider's ChatSummary."""
+
+    def __init__(self, models=None, max_tokens=1024):
+        super().__init__(models, max_tokens)
+        self._fed_count = 0
+        self._init_context_window()
+
+    def _init_context_window(self):
+        self.context_window = ContextWindow(
+            embedder=TFIDFEmbedder(),
+            summarizer=ClusterSummarizer(self.models),
+            graduate_at=26,
+            evict_at=30,
+            max_cold_clusters=10,
+            merge_threshold=0.15,
+        )
+        self._fed_count = 0
+
+    def summarize(self, messages, depth=0):
+        if not self.too_big(messages):
+            return messages
+
+        # Stale detection: messages shrank → previous result applied → rebuild
+        if self._fed_count > len(messages):
+            self._init_context_window()
+
+        # Feed only new user/assistant messages
+        for msg in messages[self._fed_count:]:
+            role = msg.get("role", "").upper()
+            if role not in ("USER", "ASSISTANT"):
+                continue
+            content = msg.get("content", "")
+            if content:
+                self.context_window.append(f"# {role}\n{content}")
+        self._fed_count = len(messages)
+
+        # Resolve dirty clusters, then render fresh summaries
+        self.context_window.resolve_dirty()
+        rendered = self.context_window.render()
+
+        # Format output
+        hot_count = self.context_window.hot_count
+        if hot_count > 0 and hot_count < len(rendered):
+            cold_parts = rendered[:-hot_count]
+            summary_text = prompts.summary_prefix + "\n\n".join(cold_parts)
+            hot_messages = messages[-hot_count:]
+            result = [
+                {"role": "user", "content": summary_text},
+                {"role": "assistant", "content": "Ok."},
+                *hot_messages,
+            ]
+        else:
+            # Not enough messages to form cold clusters.
+            # Fall back to recursive — don't return unchanged.
+            return super().summarize(messages, depth)
+
+        # Budget safety: must fit max_tokens AND be smaller than input
+        result_tokens = sum(self.token_count(m) for m in result)
+        if result_tokens > self.max_tokens:
+            return super().summarize(messages, depth)
+        input_tokens = sum(self.token_count(m) for m in messages)
+        if result_tokens >= input_tokens:
+            return super().summarize(messages, depth)
+
+        if result and result[-1]["role"] != "assistant":
+            result.append({"role": "assistant", "content": "Ok."})
+        return result
+
+    def summarize_all(self, messages):
+        return super().summarize_all(messages)

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -39,7 +39,6 @@ class ChatSummaryUF(ChatSummary):
             self._init_context_window()
 
         # Feed only new user/assistant messages, tracking their indices
-        fed_indices = []
         for i, msg in enumerate(messages[self._fed_count:], start=self._fed_count):
             role = msg.get("role", "").upper()
             if role not in ("USER", "ASSISTANT"):
@@ -47,19 +46,27 @@ class ChatSummaryUF(ChatSummary):
             content = msg.get("content", "")
             if content:
                 self.context_window.append(f"# {role}\n{content}")
-                fed_indices.append(i)
         self._fed_count = len(messages)
 
-        # If no cold clusters yet, force-graduate the oldest half of hot zone.
-        # This breaks the deadlock where too_big fires before graduate_at is reached.
-        if self.context_window.cold_count == 0 and self.context_window.hot_count > 4:
-            self.context_window.force_graduate(keep_hot=max(4, self.context_window.hot_count // 2))
+        # Token-aware graduation: keep only as many hot messages as fit
+        # in 25% of the token budget. Graduate the rest to cold clusters.
+        if self.context_window.hot_count > 2:
+            hot_budget = self.max_tokens // 4
+            keep = 0
+            for content in reversed(self.context_window.hot_messages()):
+                cost = self.token_count({"role": "user", "content": content})
+                if hot_budget - cost < 0 and keep >= 2:
+                    break
+                hot_budget -= cost
+                keep += 1
+            keep = max(2, keep)
+            if keep < self.context_window.hot_count:
+                self.context_window.force_graduate(keep_hot=keep)
 
         # Resolve dirty clusters, then render fresh summaries
         try:
             self.context_window.resolve_dirty()
         except (ValueError, Exception):
-            # Cluster summarization failed — fall back to recursive
             return super().summarize(messages, depth)
         rendered = self.context_window.render()
 
@@ -70,7 +77,6 @@ class ChatSummaryUF(ChatSummary):
         if hot_count > 0 and hot_count < len(rendered):
             cold_parts = rendered[:-hot_count]
             summary_text = prompts.summary_prefix + "\n\n".join(cold_parts)
-            # Find the original message index where hot zone starts
             all_fed = self._get_fed_indices(messages)
             if hot_count <= len(all_fed):
                 hot_start = all_fed[-hot_count]
@@ -83,8 +89,6 @@ class ChatSummaryUF(ChatSummary):
                 *hot_messages,
             ]
         else:
-            # Not enough messages to form cold clusters.
-            # Fall back to recursive — don't return unchanged.
             return super().summarize(messages, depth)
 
         # Budget safety: must fit max_tokens AND be smaller than input

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -39,14 +39,16 @@ class ChatSummaryUF(ChatSummary):
         if self._fed_count > len(messages):
             self._init_context_window()
 
-        # Feed only new user/assistant messages
-        for msg in messages[self._fed_count:]:
+        # Feed only new user/assistant messages, tracking their indices
+        fed_indices = []
+        for i, msg in enumerate(messages[self._fed_count:], start=self._fed_count):
             role = msg.get("role", "").upper()
             if role not in ("USER", "ASSISTANT"):
                 continue
             content = msg.get("content", "")
             if content:
                 self.context_window.append(f"# {role}\n{content}")
+                fed_indices.append(i)
         self._fed_count = len(messages)
 
         # Resolve dirty clusters, then render fresh summaries
@@ -54,11 +56,19 @@ class ChatSummaryUF(ChatSummary):
         rendered = self.context_window.render()
 
         # Format output
+        # hot_count is based on fed user/assistant messages, not all messages.
+        # Map back to original message indices to get the right tail.
         hot_count = self.context_window.hot_count
         if hot_count > 0 and hot_count < len(rendered):
             cold_parts = rendered[:-hot_count]
             summary_text = prompts.summary_prefix + "\n\n".join(cold_parts)
-            hot_messages = messages[-hot_count:]
+            # Find the original message index where hot zone starts
+            all_fed = self._get_fed_indices(messages)
+            if hot_count <= len(all_fed):
+                hot_start = all_fed[-hot_count]
+                hot_messages = messages[hot_start:]
+            else:
+                hot_messages = messages[-hot_count:]
             result = [
                 {"role": "user", "content": summary_text},
                 {"role": "assistant", "content": "Ok."},
@@ -80,6 +90,15 @@ class ChatSummaryUF(ChatSummary):
         if result and result[-1]["role"] != "assistant":
             result.append({"role": "assistant", "content": "Ok."})
         return result
+
+    @staticmethod
+    def _get_fed_indices(messages):
+        """Return indices of user/assistant messages with non-empty content."""
+        return [
+            i for i, msg in enumerate(messages)
+            if msg.get("role", "").upper() in ("USER", "ASSISTANT")
+            and msg.get("content", "")
+        ]
 
     def summarize_all(self, messages):
         return super().summarize_all(messages)

--- a/aider/chat_summary_uf.py
+++ b/aider/chat_summary_uf.py
@@ -25,7 +25,6 @@ class ChatSummaryUF(ChatSummary):
             embedder=TFIDFEmbedder(),
             summarizer=ClusterSummarizer(self.models),
             graduate_at=26,
-            evict_at=30,
             max_cold_clusters=10,
             merge_threshold=0.15,
         )
@@ -52,7 +51,11 @@ class ChatSummaryUF(ChatSummary):
         self._fed_count = len(messages)
 
         # Resolve dirty clusters, then render fresh summaries
-        self.context_window.resolve_dirty()
+        try:
+            self.context_window.resolve_dirty()
+        except (ValueError, Exception):
+            # Cluster summarization failed — fall back to recursive
+            return super().summarize(messages, depth)
         rendered = self.context_window.render()
 
         # Format output

--- a/aider/cluster_summarizer.py
+++ b/aider/cluster_summarizer.py
@@ -1,0 +1,56 @@
+"""Cluster summarizer wrapping aider's model API.
+
+Takes a list of text fragments (previous summary + new inputs) and produces
+a single summary via model.simple_send_with_retries(). Cascades through
+models on failure.
+"""
+
+CLUSTER_SUMMARIZE_PROMPT = """\
+Summarize the following conversation fragments into a single coherent summary.
+If a previous summary is included, integrate the new information into it.
+
+Preserve:
+- File paths and filenames
+- Function and class names
+- Library and package names
+- Error messages and stack traces
+- Key decisions and their rationale
+
+Write in first person as the user ("I asked you...").
+Do NOT include fenced code blocks in the summary.
+Be concise but preserve all technical details."""
+
+
+class ClusterSummarizer:
+    """Wraps aider's model API for per-cluster summarization."""
+
+    def __init__(self, models):
+        self.models = models if isinstance(models, list) else [models]
+
+    def summarize(self, texts):
+        """Summarize a list of text fragments into a single summary.
+
+        Args:
+            texts: List of strings (previous summary and/or raw content).
+
+        Returns:
+            Summary string.
+
+        Raises:
+            ValueError: If all models fail.
+        """
+        content = "\n\n---\n\n".join(texts)
+        messages = [
+            {"role": "system", "content": CLUSTER_SUMMARIZE_PROMPT},
+            {"role": "user", "content": content},
+        ]
+
+        for model in self.models:
+            try:
+                result = model.simple_send_with_retries(messages)
+                if result is not None:
+                    return result
+            except Exception:
+                continue
+
+        raise ValueError("cluster summarizer unexpectedly failed for all models")

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -115,15 +115,12 @@ class Forest:
         total = size_new + size_old
         emb_a = self._embedding.get(new_root, {})
         emb_b = self._embedding.get(old_root, {})
-        if emb_a and emb_b:
+        if emb_a or emb_b:
             all_keys = set(emb_a.keys()) | set(emb_b.keys())
             self._embedding[new_root] = {
                 k: (emb_a.get(k, 0.0) * size_new + emb_b.get(k, 0.0) * size_old) / total
                 for k in all_keys
             }
-        elif emb_b:
-            # Preserve the non-empty embedding
-            self._embedding[new_root] = emb_b
 
         # Update root order: remove old_root, keep new_root's position
         if old_root in self._root_order:
@@ -165,7 +162,7 @@ class Forest:
         best_sim = -1.0
 
         for root in current_roots:
-            root_emb = self._embedding.get(root, [])
+            root_emb = self._embedding.get(root, {})
             if not root_emb:
                 continue
             sim = _cosine_similarity(embedding, root_emb)
@@ -216,13 +213,14 @@ class ContextWindow:
         embedding = self._embedder.embed(content)
         self._hot.append((content, embedding))
         self._maybe_graduate()
-        self._trim_graduated()
 
     def _maybe_graduate(self):
         """Graduate oldest hot messages to cold forest when hot zone overflows."""
+        graduated_count = 0
         while len(self._hot) - self._graduated_index > self._graduate_at:
             content, embedding = self._hot[self._graduated_index]
             self._graduated_index += 1
+            graduated_count += 1
 
             # Find nearest BEFORE inserting so we don't match self
             merge_target = self._forest.nearest_root(embedding)
@@ -238,6 +236,10 @@ class ContextWindow:
 
             # Force merge closest pair if too many clusters
             self._force_merge_if_needed()
+        
+        # Trim graduated entries after the loop completes
+        if graduated_count > 0:
+            self._trim_graduated()
 
     def _force_merge_if_needed(self):
         """Force merge closest pair when cluster count exceeds max."""
@@ -251,8 +253,8 @@ class ContextWindow:
             best_pair = None
             for i in range(len(roots)):
                 for j in range(i + 1, len(roots)):
-                    emb_i = self._forest._embedding.get(roots[i], [])
-                    emb_j = self._forest._embedding.get(roots[j], [])
+                    emb_i = self._forest._embedding.get(roots[i], {})
+                    emb_j = self._forest._embedding.get(roots[j], {})
                     if emb_i and emb_j:
                         sim = _cosine_similarity(emb_i, emb_j)
                         if sim > best_sim:

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -115,12 +115,15 @@ class Forest:
         total = size_new + size_old
         emb_a = self._embedding.get(new_root, {})
         emb_b = self._embedding.get(old_root, {})
-        if emb_a or emb_b:
+        if emb_a and emb_b:
             all_keys = set(emb_a.keys()) | set(emb_b.keys())
             self._embedding[new_root] = {
                 k: (emb_a.get(k, 0.0) * size_new + emb_b.get(k, 0.0) * size_old) / total
                 for k in all_keys
             }
+        elif emb_b:
+            # Preserve the non-empty embedding
+            self._embedding[new_root] = emb_b
 
         # Update root order: remove old_root, keep new_root's position
         if old_root in self._root_order:
@@ -162,7 +165,7 @@ class Forest:
         best_sim = -1.0
 
         for root in current_roots:
-            root_emb = self._embedding.get(root, {})
+            root_emb = self._embedding.get(root, [])
             if not root_emb:
                 continue
             sim = _cosine_similarity(embedding, root_emb)
@@ -213,14 +216,13 @@ class ContextWindow:
         embedding = self._embedder.embed(content)
         self._hot.append((content, embedding))
         self._maybe_graduate()
+        self._trim_graduated()
 
     def _maybe_graduate(self):
         """Graduate oldest hot messages to cold forest when hot zone overflows."""
-        graduated_count = 0
         while len(self._hot) - self._graduated_index > self._graduate_at:
             content, embedding = self._hot[self._graduated_index]
             self._graduated_index += 1
-            graduated_count += 1
 
             # Find nearest BEFORE inserting so we don't match self
             merge_target = self._forest.nearest_root(embedding)
@@ -236,10 +238,6 @@ class ContextWindow:
 
             # Force merge closest pair if too many clusters
             self._force_merge_if_needed()
-        
-        # Trim graduated entries after the loop completes
-        if graduated_count > 0:
-            self._trim_graduated()
 
     def _force_merge_if_needed(self):
         """Force merge closest pair when cluster count exceeds max."""
@@ -253,8 +251,8 @@ class ContextWindow:
             best_pair = None
             for i in range(len(roots)):
                 for j in range(i + 1, len(roots)):
-                    emb_i = self._forest._embedding.get(roots[i], {})
-                    emb_j = self._forest._embedding.get(roots[j], {})
+                    emb_i = self._forest._embedding.get(roots[i], [])
+                    emb_j = self._forest._embedding.get(roots[j], [])
                     if emb_i and emb_j:
                         sim = _cosine_similarity(emb_i, emb_j)
                         if sim > best_sim:

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -264,6 +264,29 @@ class ContextWindow:
             else:
                 break
 
+    def force_graduate(self, keep_hot=4):
+        """Force-graduate hot messages until only keep_hot remain.
+
+        Used when too_big fires before graduate_at is reached — breaks the
+        deadlock between token-based summarization and count-based graduation.
+        """
+        while self.hot_count > keep_hot:
+            content, embedding = self._hot[self._graduated_index]
+            self._graduated_index += 1
+
+            merge_target = self._forest.nearest_root(embedding)
+
+            msg_id = self._next_msg_id()
+            self._forest.insert(msg_id, content, embedding)
+
+            if merge_target is not None:
+                nearest_root, similarity = merge_target
+                if similarity >= self._merge_threshold:
+                    self._forest.union(msg_id, nearest_root)
+
+            self._force_merge_if_needed()
+        self._trim_graduated()
+
     def _trim_graduated(self):
         """Release graduated entries from _hot to bound memory."""
         if self._graduated_index > 0:

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -7,16 +7,11 @@ import math
 
 
 def _cosine_similarity(a, b):
-    """Cosine similarity between two vectors (list or sparse dict). Returns 0.0 if either is zero."""
-    if isinstance(a, dict) and isinstance(b, dict):
-        keys = set(a.keys()) & set(b.keys())
-        dot = sum(a[k] * b[k] for k in keys)
-        norm_a = math.sqrt(sum(v * v for v in a.values()))
-        norm_b = math.sqrt(sum(v * v for v in b.values()))
-    else:
-        dot = sum(x * y for x, y in zip(a, b))
-        norm_a = math.sqrt(sum(x * x for x in a))
-        norm_b = math.sqrt(sum(x * x for x in b))
+    """Cosine similarity between two sparse dict vectors. Returns 0.0 if either is zero."""
+    keys = set(a.keys()) & set(b.keys())
+    dot = sum(a[k] * b[k] for k in keys)
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
     if norm_a == 0 or norm_b == 0:
         return 0.0
     return dot / (norm_a * norm_b)
@@ -121,17 +116,14 @@ class Forest:
         emb_a = self._embedding.get(new_root, {})
         emb_b = self._embedding.get(old_root, {})
         if emb_a and emb_b:
-            if isinstance(emb_a, dict) and isinstance(emb_b, dict):
-                all_keys = set(emb_a.keys()) | set(emb_b.keys())
-                self._embedding[new_root] = {
-                    k: (emb_a.get(k, 0.0) * size_new + emb_b.get(k, 0.0) * size_old) / total
-                    for k in all_keys
-                }
-            else:
-                self._embedding[new_root] = [
-                    (a * size_new + b * size_old) / total
-                    for a, b in zip(emb_a, emb_b)
-                ]
+            all_keys = set(emb_a.keys()) | set(emb_b.keys())
+            self._embedding[new_root] = {
+                k: (emb_a.get(k, 0.0) * size_new + emb_b.get(k, 0.0) * size_old) / total
+                for k in all_keys
+            }
+        elif emb_b:
+            # Preserve the non-empty embedding
+            self._embedding[new_root] = emb_b
 
         # Update root order: remove old_root, keep new_root's position
         if old_root in self._root_order:
@@ -189,14 +181,6 @@ class Forest:
                 ordered.append(root)
         return ordered
 
-    def is_dirty(self, node_id):
-        root = self._find(node_id)
-        return root in self._dirty
-
-    def dirty_inputs(self, node_id):
-        root = self._find(node_id)
-        return list(self._dirty_inputs.get(root, []))
-
     def cluster_count(self):
         return len(self.roots())
 
@@ -227,6 +211,7 @@ class ContextWindow:
         self._hot.append((content, embedding))
         self._maybe_graduate()
         self._maybe_evict()
+        self._trim_graduated()
 
     def _maybe_graduate(self):
         """Graduate oldest hot messages to cold forest when hot zone overflows."""
@@ -293,6 +278,12 @@ class ContextWindow:
                         self._forest.union(msg_id, nearest_root)
 
                 self._force_merge_if_needed()
+
+    def _trim_graduated(self):
+        """Release graduated entries from _hot to bound memory."""
+        if self._graduated_index > 0:
+            self._hot = self._hot[self._graduated_index:]
+            self._graduated_index = 0
 
     @property
     def hot_count(self):

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -129,6 +129,13 @@ class Forest:
         if old_root in self._root_order:
             self._root_order.remove(old_root)
 
+        # Release raw content and embeddings for non-root members.
+        # After merge, only the root's centroid and summary matter.
+        for member in self._children.get(new_root, set()):
+            if member != new_root:
+                self._content.pop(member, None)
+                self._embedding.pop(member, None)
+
         return new_root
 
     def resolve_dirty(self):

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -276,7 +276,7 @@ class ContextWindow:
 
             merge_target = self._forest.nearest_root(embedding)
 
-            msg_id = self._next_msg_id()
+            msg_id = self._gen_id()
             self._forest.insert(msg_id, content, embedding)
 
             if merge_target is not None:
@@ -302,6 +302,10 @@ class ContextWindow:
     def cold_count(self):
         """Number of clusters in the cold forest."""
         return self._forest.cluster_count()
+
+    def hot_messages(self):
+        """Return hot zone contents as a list of strings."""
+        return [content for content, _embedding in self._hot[self._graduated_index:]]
 
     def render(self):
         """Return cold summaries + hot contents as a flat list of strings."""

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -1,0 +1,328 @@
+"""Forest (union-find cluster store) and ContextWindow (hot zone + cold forest).
+
+Ported from gemini-cli's contextWindow.ts, adapted for aider's message model.
+"""
+
+import math
+
+
+def _cosine_similarity(a, b):
+    """Cosine similarity between two vectors (list or sparse dict). Returns 0.0 if either is zero."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        keys = set(a.keys()) & set(b.keys())
+        dot = sum(a[k] * b[k] for k in keys)
+        norm_a = math.sqrt(sum(v * v for v in a.values()))
+        norm_b = math.sqrt(sum(v * v for v in b.values()))
+    else:
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+class Forest:
+    """Union-find cluster store. Clusters hold content, embeddings, and summaries.
+
+    Each node has a parent pointer. Roots represent clusters.
+    Union merges two roots; resolve_dirty summarizes merged clusters via LLM.
+    """
+
+    def __init__(self, summarizer):
+        self._summarizer = summarizer
+        self._parent = {}      # node_id → parent_id (root points to self)
+        self._content = {}     # node_id → raw content string
+        self._embedding = {}   # node_id → embedding vector
+        self._summary = {}     # root_id → cached summary (None if dirty/singleton)
+        self._dirty = set()    # set of dirty root ids
+        self._dirty_inputs = {}  # root_id → list of texts to summarize
+        self._children = {}    # root_id → set of child node ids (for tracking)
+        self._root_order = []  # insertion-order tracking for stable roots()
+
+    def _find(self, node_id):
+        """Find root with path compression."""
+        path = []
+        current = node_id
+        while self._parent[current] != current:
+            path.append(current)
+            current = self._parent[current]
+        for p in path:
+            self._parent[p] = current
+        return current
+
+    def insert(self, msg_id, content, embedding):
+        """Create a singleton cluster."""
+        self._parent[msg_id] = msg_id
+        self._content[msg_id] = content
+        self._embedding[msg_id] = embedding
+        self._children[msg_id] = {msg_id}
+        self._root_order.append(msg_id)
+        # Singletons are not dirty — compact returns raw content
+
+    def union(self, id_a, id_b):
+        """Merge two clusters. Synchronous, no LLM call. Marks result dirty.
+
+        Uses weighted centroid averaging: centroids weighted by cluster size.
+        """
+        root_a = self._find(id_a)
+        root_b = self._find(id_b)
+        if root_a == root_b:
+            return root_a
+
+        # Merge smaller into larger (union by size)
+        size_a = len(self._children.get(root_a, set()))
+        size_b = len(self._children.get(root_b, set()))
+
+        if size_a >= size_b:
+            new_root, old_root = root_a, root_b
+            size_new, size_old = size_a, size_b
+        else:
+            new_root, old_root = root_b, root_a
+            size_new, size_old = size_b, size_a
+
+        self._parent[old_root] = new_root
+
+        # Merge children tracking
+        if new_root not in self._children:
+            self._children[new_root] = set()
+        if old_root in self._children:
+            self._children[new_root].update(self._children[old_root])
+            del self._children[old_root]
+
+        # Collect dirty inputs: previous summary or raw content from each side
+        inputs = []
+        # From new_root side
+        if new_root in self._summary and self._summary[new_root] is not None:
+            inputs.append(self._summary[new_root])
+        elif new_root in self._dirty_inputs and self._dirty_inputs[new_root]:
+            inputs.extend(self._dirty_inputs[new_root])
+        else:
+            inputs.append(self._content.get(new_root, ""))
+
+        # From old_root side
+        if old_root in self._summary and self._summary[old_root] is not None:
+            inputs.append(self._summary[old_root])
+        elif old_root in self._dirty_inputs and self._dirty_inputs[old_root]:
+            inputs.extend(self._dirty_inputs[old_root])
+        else:
+            inputs.append(self._content.get(old_root, ""))
+
+        self._dirty_inputs[new_root] = inputs
+
+        # Mark dirty, clear old summary
+        self._dirty.add(new_root)
+        self._dirty.discard(old_root)
+        self._summary.pop(old_root, None)
+        self._dirty_inputs.pop(old_root, None)
+
+        # Weighted centroid averaging (weight by cluster size)
+        total = size_new + size_old
+        emb_a = self._embedding.get(new_root, {})
+        emb_b = self._embedding.get(old_root, {})
+        if emb_a and emb_b:
+            if isinstance(emb_a, dict) and isinstance(emb_b, dict):
+                all_keys = set(emb_a.keys()) | set(emb_b.keys())
+                self._embedding[new_root] = {
+                    k: (emb_a.get(k, 0.0) * size_new + emb_b.get(k, 0.0) * size_old) / total
+                    for k in all_keys
+                }
+            else:
+                self._embedding[new_root] = [
+                    (a * size_new + b * size_old) / total
+                    for a, b in zip(emb_a, emb_b)
+                ]
+
+        # Update root order: remove old_root, keep new_root's position
+        if old_root in self._root_order:
+            self._root_order.remove(old_root)
+
+        return new_root
+
+    def resolve_dirty(self):
+        """Summarize all dirty roots via the summarizer. Blocking."""
+        for root_id in list(self._dirty):
+            inputs = self._dirty_inputs.get(root_id, [])
+            if inputs:
+                summary = self._summarizer.summarize(inputs)
+                self._summary[root_id] = summary
+                self._dirty_inputs[root_id] = []
+            self._dirty.discard(root_id)
+
+    def compact(self, node_id):
+        """Return cached summary for a root, or raw content for a singleton."""
+        root = self._find(node_id)
+        if root in self._summary and self._summary[root] is not None:
+            return self._summary[root]
+        return self._content.get(root, "")
+
+    def nearest_root(self, embedding):
+        """Find the closest root by cosine similarity. Returns (root_id, similarity) or None."""
+        current_roots = self.roots()
+        if not current_roots:
+            return None
+
+        best_root = None
+        best_sim = -1.0
+
+        for root in current_roots:
+            root_emb = self._embedding.get(root, [])
+            if not root_emb:
+                continue
+            sim = _cosine_similarity(embedding, root_emb)
+            if sim > best_sim:
+                best_sim = sim
+                best_root = root
+
+        if best_root is None:
+            return None
+        return (best_root, best_sim)
+
+    def roots(self):
+        """Return roots in stable insertion order."""
+        seen = set()
+        ordered = []
+        for node_id in self._root_order:
+            root = self._find(node_id)
+            if root not in seen:
+                seen.add(root)
+                ordered.append(root)
+        return ordered
+
+    def is_dirty(self, node_id):
+        root = self._find(node_id)
+        return root in self._dirty
+
+    def dirty_inputs(self, node_id):
+        root = self._find(node_id)
+        return list(self._dirty_inputs.get(root, []))
+
+    def cluster_count(self):
+        return len(self.roots())
+
+
+class ContextWindow:
+    """Hot zone + cold forest. Manages graduation and eviction."""
+
+    def __init__(self, embedder, summarizer, graduate_at=26, evict_at=30,
+                 max_cold_clusters=10, merge_threshold=0.15):
+        self._embedder = embedder
+        self._forest = Forest(summarizer=summarizer)
+        self._hot = []  # list of (content, embedding) tuples
+        self._graduated_index = 0  # index into _hot: items before this have graduated
+        self._graduate_at = graduate_at
+        self._evict_at = evict_at
+        self._max_cold_clusters = max_cold_clusters
+        self._merge_threshold = merge_threshold
+        self._next_id = 0
+
+    def _gen_id(self):
+        mid = f"msg_{self._next_id}"
+        self._next_id += 1
+        return mid
+
+    def append(self, content):
+        """Embed and push to hot zone. Graduate/evict as needed."""
+        embedding = self._embedder.embed(content)
+        self._hot.append((content, embedding))
+        self._maybe_graduate()
+        self._maybe_evict()
+
+    def _maybe_graduate(self):
+        """Graduate oldest hot messages to cold forest when hot zone overflows."""
+        while len(self._hot) - self._graduated_index > self._graduate_at:
+            content, embedding = self._hot[self._graduated_index]
+            self._graduated_index += 1
+
+            # Find nearest BEFORE inserting so we don't match self
+            merge_target = self._forest.nearest_root(embedding)
+
+            msg_id = self._gen_id()
+            self._forest.insert(msg_id, content, embedding)
+
+            # Merge with nearest cluster if above threshold
+            if merge_target is not None:
+                nearest_root, similarity = merge_target
+                if similarity >= self._merge_threshold:
+                    self._forest.union(msg_id, nearest_root)
+
+            # Force merge closest pair if too many clusters
+            self._force_merge_if_needed()
+
+    def _force_merge_if_needed(self):
+        """Force merge closest pair when cluster count exceeds max."""
+        while self._forest.cluster_count() > self._max_cold_clusters:
+            roots = self._forest.roots()
+            if len(roots) < 2:
+                break
+
+            # Find closest pair
+            best_sim = -1.0
+            best_pair = None
+            for i in range(len(roots)):
+                for j in range(i + 1, len(roots)):
+                    emb_i = self._forest._embedding.get(roots[i], [])
+                    emb_j = self._forest._embedding.get(roots[j], [])
+                    if emb_i and emb_j:
+                        sim = _cosine_similarity(emb_i, emb_j)
+                        if sim > best_sim:
+                            best_sim = sim
+                            best_pair = (roots[i], roots[j])
+
+            if best_pair:
+                self._forest.union(best_pair[0], best_pair[1])
+            else:
+                break
+
+    def _maybe_evict(self):
+        """Evict oldest hot messages when hot zone exceeds evict threshold."""
+        while len(self._hot) - self._graduated_index > self._evict_at:
+            # Graduate the oldest remaining before evicting
+            if self._graduated_index < len(self._hot):
+                content, embedding = self._hot[self._graduated_index]
+                self._graduated_index += 1
+
+                merge_target = self._forest.nearest_root(embedding)
+
+                msg_id = self._gen_id()
+                self._forest.insert(msg_id, content, embedding)
+
+                if merge_target is not None:
+                    nearest_root, similarity = merge_target
+                    if similarity >= self._merge_threshold:
+                        self._forest.union(msg_id, nearest_root)
+
+                self._force_merge_if_needed()
+
+    @property
+    def hot_count(self):
+        """Number of messages currently in the hot zone (not yet graduated)."""
+        return len(self._hot) - self._graduated_index
+
+    @property
+    def cold_count(self):
+        """Number of clusters in the cold forest."""
+        return self._forest.cluster_count()
+
+    def render(self):
+        """Return cold summaries + hot contents as a flat list of strings."""
+        if not self._hot and self._forest.cluster_count() == 0:
+            return []
+
+        parts = []
+
+        # Cold cluster summaries (rendered in stable insertion order)
+        for root in self._forest.roots():
+            summary = self._forest.compact(root)
+            if summary:
+                parts.append(summary)
+
+        # Hot zone contents (in order)
+        for content, _embedding in self._hot[self._graduated_index:]:
+            parts.append(content)
+
+        return parts
+
+    def resolve_dirty(self):
+        """Delegate to forest to summarize all dirty clusters."""
+        self._forest.resolve_dirty()

--- a/aider/context_window.py
+++ b/aider/context_window.py
@@ -188,14 +188,13 @@ class Forest:
 class ContextWindow:
     """Hot zone + cold forest. Manages graduation and eviction."""
 
-    def __init__(self, embedder, summarizer, graduate_at=26, evict_at=30,
+    def __init__(self, embedder, summarizer, graduate_at=26,
                  max_cold_clusters=10, merge_threshold=0.15):
         self._embedder = embedder
         self._forest = Forest(summarizer=summarizer)
         self._hot = []  # list of (content, embedding) tuples
         self._graduated_index = 0  # index into _hot: items before this have graduated
         self._graduate_at = graduate_at
-        self._evict_at = evict_at
         self._max_cold_clusters = max_cold_clusters
         self._merge_threshold = merge_threshold
         self._next_id = 0
@@ -206,11 +205,10 @@ class ContextWindow:
         return mid
 
     def append(self, content):
-        """Embed and push to hot zone. Graduate/evict as needed."""
+        """Embed and push to hot zone. Graduate as needed."""
         embedding = self._embedder.embed(content)
         self._hot.append((content, embedding))
         self._maybe_graduate()
-        self._maybe_evict()
         self._trim_graduated()
 
     def _maybe_graduate(self):
@@ -258,26 +256,6 @@ class ContextWindow:
                 self._forest.union(best_pair[0], best_pair[1])
             else:
                 break
-
-    def _maybe_evict(self):
-        """Evict oldest hot messages when hot zone exceeds evict threshold."""
-        while len(self._hot) - self._graduated_index > self._evict_at:
-            # Graduate the oldest remaining before evicting
-            if self._graduated_index < len(self._hot):
-                content, embedding = self._hot[self._graduated_index]
-                self._graduated_index += 1
-
-                merge_target = self._forest.nearest_root(embedding)
-
-                msg_id = self._gen_id()
-                self._forest.insert(msg_id, content, embedding)
-
-                if merge_target is not None:
-                    nearest_root, similarity = merge_target
-                    if similarity >= self._merge_threshold:
-                        self._forest.union(msg_id, nearest_root)
-
-                self._force_merge_if_needed()
 
     def _trim_graduated(self):
         """Release graduated entries from _hot to bound memory."""

--- a/aider/embedding_service.py
+++ b/aider/embedding_service.py
@@ -1,0 +1,80 @@
+"""TF-IDF embedder. Pure Python, no external dependencies.
+
+Produces sparse dict vectors {term: tfidf_weight} for cosine similarity.
+Vocabulary grows incrementally as new documents are embedded.
+"""
+
+import math
+import re
+
+# Common English stopwords to filter out
+_STOPWORDS = frozenset({
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "it", "as", "be", "was", "are",
+    "were", "been", "being", "have", "has", "had", "do", "does", "did",
+    "will", "would", "could", "should", "may", "might", "shall", "can",
+    "not", "no", "so", "if", "then", "than", "that", "this", "these",
+    "those", "i", "you", "he", "she", "we", "they", "me", "him", "her",
+    "us", "them", "my", "your", "his", "its", "our", "their", "what",
+    "which", "who", "whom", "when", "where", "why", "how", "all", "each",
+    "every", "both", "few", "more", "most", "other", "some", "such",
+    "only", "own", "same", "just", "about", "also", "very", "often",
+    "ok", "up", "out", "into",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text):
+    """Lowercase, split on non-alphanumeric, filter stopwords."""
+    tokens = _TOKEN_RE.findall(text.lower())
+    return [t for t in tokens if t not in _STOPWORDS]
+
+
+class TFIDFEmbedder:
+    """Incremental TF-IDF embedder producing sparse dict vectors."""
+
+    def __init__(self):
+        self._doc_count = 0
+        self._doc_freq = {}  # term → number of documents containing term
+
+    @property
+    def vocab_size(self):
+        return len(self._doc_freq)
+
+    @property
+    def doc_count(self):
+        return self._doc_count
+
+    def embed(self, text):
+        """Return sparse dict {term: tfidf_weight} for the given text."""
+        tokens = _tokenize(text)
+        if not tokens:
+            return {}
+
+        # Update document frequency
+        self._doc_count += 1
+        seen_terms = set(tokens)
+        for term in seen_terms:
+            self._doc_freq[term] = self._doc_freq.get(term, 0) + 1
+
+        # Compute TF (term frequency within this document)
+        tf = {}
+        for token in tokens:
+            tf[token] = tf.get(token, 0) + 1
+
+        # Normalize TF by document length
+        doc_len = len(tokens)
+
+        # Compute TF-IDF
+        result = {}
+        for term, count in tf.items():
+            tf_val = count / doc_len
+            # IDF: log(N / df) where N = total docs, df = docs containing term
+            df = self._doc_freq.get(term, 1)
+            idf = math.log(1.0 + self._doc_count / df) if df > 0 else 0.0
+            weight = tf_val * idf
+            if weight > 0:
+                result[term] = weight
+
+        return result

--- a/aider/embedding_service.py
+++ b/aider/embedding_service.py
@@ -70,9 +70,9 @@ class TFIDFEmbedder:
         result = {}
         for term, count in tf.items():
             tf_val = count / doc_len
-            # IDF: log(N / df) where N = total docs, df = docs containing term
-            df = self._doc_freq.get(term, 1)
-            idf = math.log(1.0 + self._doc_count / df) if df > 0 else 0.0
+            # IDF: log((N + 1) / (df + 1)) - smoothed to avoid division by zero
+            df = self._doc_freq.get(term, 0)
+            idf = math.log((self._doc_count + 1) / (df + 1))
             weight = tf_val * idf
             if weight > 0:
                 result[term] = weight

--- a/aider/embedding_service.py
+++ b/aider/embedding_service.py
@@ -70,9 +70,9 @@ class TFIDFEmbedder:
         result = {}
         for term, count in tf.items():
             tf_val = count / doc_len
-            # IDF: log((N + 1) / (df + 1)) - smoothed to avoid division by zero
-            df = self._doc_freq.get(term, 0)
-            idf = math.log((self._doc_count + 1) / (df + 1))
+            # IDF: log(N / df) where N = total docs, df = docs containing term
+            df = self._doc_freq.get(term, 1)
+            idf = math.log(1.0 + self._doc_count / df) if df > 0 else 0.0
             weight = tf_val * idf
             if weight > 0:
                 result[term] = weight

--- a/aider/main.py
+++ b/aider/main.py
@@ -946,10 +946,15 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         original_read_only_fnames=read_only_fnames,
     )
 
-    summarizer = ChatSummary(
-        [main_model.weak_model, main_model],
-        args.max_chat_history_tokens or main_model.max_chat_history_tokens,
-    )
+    summarizer_models = [main_model.weak_model, main_model]
+    summarizer_tokens = args.max_chat_history_tokens or main_model.max_chat_history_tokens
+
+    if getattr(args, "chat_history_summarizer", None) == "union-find":
+        from aider.chat_summary_uf import ChatSummaryUF
+
+        summarizer = ChatSummaryUF(summarizer_models, summarizer_tokens)
+    else:
+        summarizer = ChatSummary(summarizer_models, summarizer_tokens)
 
     if args.cache_prompts and args.map_refresh == "auto":
         args.map_refresh = "files"

--- a/tests/basic/test_chat_summary_uf.py
+++ b/tests/basic/test_chat_summary_uf.py
@@ -597,14 +597,14 @@ class TestMemoryBounds(TestCase):
 
         cw = ContextWindow(
             embedder, mock_summarizer,
-            graduate_at=5, evict_at=10, max_cold_clusters=10,
+            graduate_at=5, max_cold_clusters=10,
         )
         # Append many messages — should graduate and trim
         for i in range(20):
             cw.append(f"message {i} about topic {i % 3}")
 
-        # _hot should only contain ungraduated messages (at most evict_at)
-        self.assertLessEqual(len(cw._hot), cw._evict_at)
+        # _hot should only contain ungraduated messages (at most graduate_at)
+        self.assertLessEqual(len(cw._hot), cw._graduate_at)
         # _graduated_index should be 0 (trimmed)
         self.assertEqual(cw._graduated_index, 0)
 
@@ -616,13 +616,13 @@ class TestMemoryBounds(TestCase):
 
         cw = ContextWindow(
             embedder, mock_summarizer,
-            graduate_at=5, evict_at=10, max_cold_clusters=10,
+            graduate_at=5, max_cold_clusters=10,
         )
         for i in range(200):
             cw.append(f"message {i}")
 
-        # _hot should never exceed evict_at
-        self.assertLessEqual(len(cw._hot), cw._evict_at)
+        # _hot should never exceed graduate_at
+        self.assertLessEqual(len(cw._hot), cw._graduate_at)
 
 
 # ────────────────────────────────────────────────────────────
@@ -697,7 +697,7 @@ class TestContextWindow(TestCase):
     def test_append_and_render(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=3, evict_at=5, max_cold_clusters=10
+            graduate_at=3, max_cold_clusters=10
         )
         for i in range(5):
             cw.append(f"message {i} about topic {i}")
@@ -707,7 +707,7 @@ class TestContextWindow(TestCase):
     def test_hot_count_tracks_correctly(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=3, evict_at=5, max_cold_clusters=10
+            graduate_at=3, max_cold_clusters=10
         )
         self.assertEqual(cw.hot_count, 0)
         cw.append("msg1")
@@ -724,7 +724,7 @@ class TestContextWindow(TestCase):
     def test_graduation_sends_to_forest(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=2, evict_at=4, max_cold_clusters=10
+            graduate_at=2, max_cold_clusters=10
         )
         cw.append("message alpha about python")
         cw.append("message beta about java")
@@ -736,7 +736,7 @@ class TestContextWindow(TestCase):
     def test_force_merge_when_too_many_clusters(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=1, evict_at=3, max_cold_clusters=2
+            graduate_at=1, max_cold_clusters=2
         )
         # Each append with graduate_at=1 means hot keeps only 1
         # After 4 appends: 3 graduated, 1 hot. 3 clusters > max 2, force merge
@@ -747,7 +747,7 @@ class TestContextWindow(TestCase):
     def test_render_includes_cold_and_hot(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=2, evict_at=4, max_cold_clusters=10
+            graduate_at=2, max_cold_clusters=10
         )
         cw.append("cold message about python")
         cw.append("cold message about java")
@@ -760,7 +760,7 @@ class TestContextWindow(TestCase):
     def test_resolve_dirty_produces_summaries(self):
         cw = ContextWindow(
             self.embedder, self.mock_summarizer,
-            graduate_at=1, evict_at=3, max_cold_clusters=1,
+            graduate_at=1, max_cold_clusters=1,
             merge_threshold=0.0  # force merges
         )
         cw.append("python code review")

--- a/tests/basic/test_chat_summary_uf.py
+++ b/tests/basic/test_chat_summary_uf.py
@@ -1,0 +1,689 @@
+"""Tests for union-find chat history summarizer (PR 1 test plan, 12 areas)."""
+
+from unittest import TestCase, mock
+
+from aider.chat_summary_uf import ChatSummaryUF
+from aider.cluster_summarizer import ClusterSummarizer
+from aider.context_window import Forest, ContextWindow, _cosine_similarity
+from aider.embedding_service import TFIDFEmbedder
+from aider.history import ChatSummary
+from aider.models import Model
+
+
+def count(msg):
+    """Word-count token counter (matches test_history.py)."""
+    if isinstance(msg, list):
+        return sum(count(m) for m in msg)
+    return len(msg["content"].split())
+
+
+def make_mock_model(name="gpt-3.5-turbo", summary_text="This is a summary"):
+    model = mock.Mock(spec=Model)
+    model.name = name
+    model.token_count = count
+    model.info = {"max_input_tokens": 4096}
+    model.simple_send_with_retries = mock.Mock(return_value=summary_text)
+    return model
+
+
+def make_messages(n):
+    """Create n alternating user/assistant message pairs (2n messages total)."""
+    messages = []
+    for i in range(n):
+        messages.append({"role": "user", "content": f"User message number {i} about topic {i % 5}"})
+        messages.append({"role": "assistant", "content": f"Assistant response number {i} about topic {i % 5}"})
+    return messages
+
+
+# ────────────────────────────────────────────────────────────
+# Area 12: Forest mechanics
+# ────────────────────────────────────────────────────────────
+
+
+class TestForest(TestCase):
+    def setUp(self):
+        self.mock_summarizer = mock.Mock()
+        self.mock_summarizer.summarize = mock.Mock(return_value="merged summary")
+        self.forest = Forest(summarizer=self.mock_summarizer)
+
+    def test_insert_creates_singleton(self):
+        self.forest.insert("m1", "hello world", {"hello": 1.0})
+        self.assertEqual(self.forest.cluster_count(), 1)
+        self.assertIn("m1", self.forest.roots())
+        self.assertEqual(self.forest.compact("m1"), "hello world")
+
+    def test_insert_multiple_creates_separate_clusters(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.assertEqual(self.forest.cluster_count(), 2)
+
+    def test_union_merges_two_clusters(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.forest.union("m1", "m2")
+        self.assertEqual(self.forest.cluster_count(), 1)
+
+    def test_union_same_root_is_noop(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        result = self.forest.union("m1", "m1")
+        self.assertEqual(result, "m1")
+        self.assertEqual(self.forest.cluster_count(), 1)
+
+    def test_union_marks_dirty(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.assertFalse(self.forest.is_dirty("m1"))
+        self.assertFalse(self.forest.is_dirty("m2"))
+        self.forest.union("m1", "m2")
+        root = self.forest.roots()[0]
+        self.assertTrue(self.forest.is_dirty(root))
+
+    def test_resolve_dirty_calls_summarizer(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.forest.union("m1", "m2")
+        self.forest.resolve_dirty()
+        self.mock_summarizer.summarize.assert_called_once()
+        root = self.forest.roots()[0]
+        self.assertEqual(self.forest.compact(root), "merged summary")
+
+    def test_compact_singleton_returns_raw_content(self):
+        self.forest.insert("m1", "hello world", {"hello": 1.0})
+        self.assertEqual(self.forest.compact("m1"), "hello world")
+
+    def test_compact_after_resolve_returns_summary(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.forest.union("m1", "m2")
+        self.forest.resolve_dirty()
+        root = self.forest.roots()[0]
+        self.assertEqual(self.forest.compact(root), "merged summary")
+
+    def test_nearest_root_finds_closest(self):
+        self.forest.insert("m1", "python", {"python": 1.0, "code": 0.5})
+        self.forest.insert("m2", "java", {"java": 1.0, "code": 0.5})
+        result = self.forest.nearest_root({"python": 0.8, "code": 0.6})
+        self.assertIsNotNone(result)
+        root_id, similarity = result
+        self.assertEqual(root_id, "m1")
+
+    def test_nearest_root_empty_forest(self):
+        result = self.forest.nearest_root({"python": 1.0})
+        self.assertIsNone(result)
+
+    def test_find_with_path_compression(self):
+        self.forest.insert("m1", "a", {"a": 1.0})
+        self.forest.insert("m2", "b", {"b": 1.0})
+        self.forest.insert("m3", "c", {"c": 1.0})
+        self.forest.union("m1", "m2")
+        self.forest.union("m2", "m3")
+        # After path compression, all nodes point to the same root
+        root = self.forest._find("m3")
+        self.assertEqual(self.forest._find("m1"), root)
+        self.assertEqual(self.forest._find("m2"), root)
+
+    def test_dirty_inputs_collected_on_union(self):
+        self.forest.insert("m1", "hello", {"hello": 1.0})
+        self.forest.insert("m2", "world", {"world": 1.0})
+        self.forest.union("m1", "m2")
+        root = self.forest.roots()[0]
+        inputs = self.forest.dirty_inputs(root)
+        self.assertEqual(len(inputs), 2)
+        self.assertIn("hello", inputs)
+        self.assertIn("world", inputs)
+
+
+# ────────────────────────────────────────────────────────────
+# Area 9: Stable root ordering
+# ────────────────────────────────────────────────────────────
+
+
+class TestStableRootOrdering(TestCase):
+    def setUp(self):
+        self.mock_summarizer = mock.Mock()
+        self.mock_summarizer.summarize = mock.Mock(return_value="summary")
+        self.forest = Forest(summarizer=self.mock_summarizer)
+
+    def test_roots_in_insertion_order(self):
+        self.forest.insert("m1", "first", {"first": 1.0})
+        self.forest.insert("m2", "second", {"second": 1.0})
+        self.forest.insert("m3", "third", {"third": 1.0})
+        self.assertEqual(self.forest.roots(), ["m1", "m2", "m3"])
+
+    def test_order_preserved_after_merge(self):
+        self.forest.insert("m1", "first", {"first": 1.0})
+        self.forest.insert("m2", "second", {"second": 1.0})
+        self.forest.insert("m3", "third", {"third": 1.0})
+        self.forest.insert("m4", "fourth", {"fourth": 1.0})
+        # Merge m2 and m3 — surviving root keeps m2's position
+        self.forest.union("m2", "m3")
+        roots = self.forest.roots()
+        self.assertEqual(len(roots), 3)
+        # m1 is first, merged root is in m2's position, m4 is last
+        self.assertEqual(roots[0], "m1")
+        self.assertEqual(roots[-1], "m4")
+
+    def test_deterministic_across_calls(self):
+        self.forest.insert("m1", "first", {"first": 1.0})
+        self.forest.insert("m2", "second", {"second": 1.0})
+        self.forest.insert("m3", "third", {"third": 1.0})
+        roots1 = self.forest.roots()
+        roots2 = self.forest.roots()
+        roots3 = self.forest.roots()
+        self.assertEqual(roots1, roots2)
+        self.assertEqual(roots2, roots3)
+
+    def test_order_after_multiple_merges(self):
+        for i in range(5):
+            self.forest.insert(f"m{i}", f"msg{i}", {f"t{i}": 1.0})
+        # Merge m0+m1, m3+m4
+        self.forest.union("m0", "m1")
+        self.forest.union("m3", "m4")
+        roots = self.forest.roots()
+        self.assertEqual(len(roots), 3)
+        # Relative order maintained: (m0 cluster), m2, (m3 cluster)
+        self.assertEqual(roots[1], "m2")
+
+
+# ────────────────────────────────────────────────────────────
+# Area 8: Weighted centroid
+# ────────────────────────────────────────────────────────────
+
+
+class TestWeightedCentroid(TestCase):
+    def setUp(self):
+        self.mock_summarizer = mock.Mock()
+        self.mock_summarizer.summarize = mock.Mock(return_value="summary")
+        self.forest = Forest(summarizer=self.mock_summarizer)
+
+    def test_equal_size_merge_at_midpoint(self):
+        self.forest.insert("m1", "a", {"x": 1.0})
+        self.forest.insert("m2", "b", {"x": 0.0})
+        self.forest.union("m1", "m2")
+        root = self.forest.roots()[0]
+        emb = self.forest._embedding[root]
+        self.assertAlmostEqual(emb["x"], 0.5)
+
+    def test_unequal_size_weights_toward_larger(self):
+        # Build a 3-node cluster around "m1"
+        self.forest.insert("m1", "a", {"x": 1.0})
+        self.forest.insert("m2", "b", {"x": 1.0})
+        self.forest.insert("m3", "c", {"x": 1.0})
+        self.forest.union("m1", "m2")
+        self.forest.union("m1", "m3")
+        # Now m1's cluster has 3 members
+
+        # Insert singleton with very different embedding
+        self.forest.insert("m4", "d", {"x": 0.0})
+        self.forest.union("m1", "m4")
+
+        root = self.forest.roots()[0]
+        emb = self.forest._embedding[root]
+        # Weighted: (1.0 * 3 + 0.0 * 1) / 4 = 0.75
+        self.assertAlmostEqual(emb["x"], 0.75)
+
+    def test_weighted_centroid_sparse_dicts(self):
+        # m1 cluster: size 2
+        self.forest.insert("m1", "a", {"python": 1.0, "code": 0.5})
+        self.forest.insert("m2", "b", {"python": 0.8, "code": 0.6})
+        self.forest.union("m1", "m2")
+        # m1 cluster now has size 2, centroid = midpoint of m1 and m2
+
+        # m3: singleton, different terms
+        self.forest.insert("m3", "c", {"java": 1.0, "code": 0.3})
+        self.forest.union("m1", "m3")
+
+        root = self.forest.roots()[0]
+        emb = self.forest._embedding[root]
+        # "code" exists in both: weighted by size 2 vs 1
+        # "java" exists only in m3: weighted 0*2/3 + 1.0*1/3 = 0.333...
+        self.assertIn("code", emb)
+        self.assertIn("java", emb)
+        self.assertAlmostEqual(emb["java"], 1.0 / 3, places=4)
+
+
+# ────────────────────────────────────────────────────────────
+# Area 10: Cluster summarization (model cascade)
+# ────────────────────────────────────────────────────────────
+
+
+class TestClusterSummarizer(TestCase):
+    def test_uses_first_model_on_success(self):
+        model1 = make_mock_model("weak", "weak summary")
+        model2 = make_mock_model("strong", "strong summary")
+        summarizer = ClusterSummarizer([model1, model2])
+        result = summarizer.summarize(["text a", "text b"])
+        self.assertEqual(result, "weak summary")
+        model1.simple_send_with_retries.assert_called_once()
+        model2.simple_send_with_retries.assert_not_called()
+
+    def test_falls_back_to_second_model(self):
+        model1 = make_mock_model("weak")
+        model1.simple_send_with_retries.side_effect = Exception("fail")
+        model2 = make_mock_model("strong", "strong summary")
+        summarizer = ClusterSummarizer([model1, model2])
+        result = summarizer.summarize(["text"])
+        self.assertEqual(result, "strong summary")
+        model1.simple_send_with_retries.assert_called_once()
+        model2.simple_send_with_retries.assert_called_once()
+
+    def test_raises_if_all_models_fail(self):
+        model1 = make_mock_model("weak")
+        model1.simple_send_with_retries.side_effect = Exception("fail1")
+        model2 = make_mock_model("strong")
+        model2.simple_send_with_retries.side_effect = Exception("fail2")
+        summarizer = ClusterSummarizer([model1, model2])
+        with self.assertRaises(ValueError):
+            summarizer.summarize(["text"])
+
+    def test_single_model_works(self):
+        model = make_mock_model("only", "only summary")
+        summarizer = ClusterSummarizer(model)  # not a list
+        result = summarizer.summarize(["text"])
+        self.assertEqual(result, "only summary")
+
+
+# ────────────────────────────────────────────────────────────
+# Areas 1-2: Flag selection / default unchanged
+# ────────────────────────────────────────────────────────────
+
+
+class TestFlagSelection(TestCase):
+    def test_chat_summary_uf_is_subclass_of_chat_summary(self):
+        self.assertTrue(issubclass(ChatSummaryUF, ChatSummary))
+
+    def test_chat_summary_uf_constructs(self):
+        model = make_mock_model()
+        summarizer = ChatSummaryUF(model, max_tokens=100)
+        self.assertIsInstance(summarizer, ChatSummaryUF)
+        self.assertIsInstance(summarizer, ChatSummary)
+        self.assertEqual(summarizer.max_tokens, 100)
+
+    def test_default_constructs_chat_summary(self):
+        """Default (no flag or 'recursive') should use ChatSummary, not UF."""
+        model = make_mock_model()
+        summarizer = ChatSummary(model, max_tokens=100)
+        self.assertIsInstance(summarizer, ChatSummary)
+        self.assertNotIsInstance(summarizer, ChatSummaryUF)
+
+
+# ────────────────────────────────────────────────────────────
+# Area 3: Output format
+# ────────────────────────────────────────────────────────────
+
+
+class TestOutputFormat(TestCase):
+    def setUp(self):
+        self.model = make_mock_model(summary_text="Cluster summary text here")
+        # max_tokens=400: high enough to hold UF result (~250 words),
+        # but lower than 60-message input (~480 words) so too_big triggers
+        self.summarizer = ChatSummaryUF(self.model, max_tokens=400)
+
+    def test_returns_messages_when_not_too_big(self):
+        messages = [
+            {"role": "user", "content": "short"},
+            {"role": "assistant", "content": "reply"},
+        ]
+        result = self.summarizer.summarize(messages)
+        self.assertEqual(result, messages)
+
+    def test_output_format_summary_ok_hot(self):
+        """When enough messages graduate, output is [summary, Ok., *hot_messages]."""
+        # Create enough messages to trigger graduation (27+ appends needed)
+        messages = make_messages(30)  # 60 messages total
+        result = self.summarizer.summarize(messages)
+
+        # Result should be a list
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+
+        # First message is summary (user role, starts with summary_prefix)
+        from aider import prompts
+
+        self.assertEqual(result[0]["role"], "user")
+        self.assertTrue(result[0]["content"].startswith(prompts.summary_prefix))
+
+        # Second message is "Ok."
+        self.assertEqual(result[1]["role"], "assistant")
+        self.assertEqual(result[1]["content"], "Ok.")
+
+        # Last message should be assistant (trailing Ok.)
+        self.assertEqual(result[-1]["role"], "assistant")
+
+
+# ────────────────────────────────────────────────────────────
+# Area 4: Fallback to recursive
+# ────────────────────────────────────────────────────────────
+
+
+class TestFallbackToRecursive(TestCase):
+    def test_fallback_when_result_exceeds_max_tokens(self):
+        """If union-find output exceeds max_tokens, falls back to recursive."""
+        # Model returns a very long summary that will exceed budget
+        long_summary = " ".join(["word"] * 200)
+        model = make_mock_model(summary_text=long_summary)
+        summarizer = ChatSummaryUF(model, max_tokens=30)
+
+        messages = make_messages(30)
+
+        # Should still produce a result (recursive fallback)
+        with mock.patch.object(
+            ChatSummary,
+            "summarize",
+            return_value=[{"role": "user", "content": "recursive summary"}],
+        ) as mock_recursive:
+            result = summarizer.summarize(messages)
+            # Either the UF result fits or recursive was called as fallback
+            self.assertIsInstance(result, list)
+            self.assertGreater(len(result), 0)
+
+    def test_fallback_when_no_cold_clusters(self):
+        """When not enough messages graduate, falls back to recursive."""
+        model = make_mock_model(summary_text="summary")
+        # Set max_tokens very low so too_big triggers, but only 5 messages
+        # (not enough for graduation at graduate_at=26)
+        summarizer = ChatSummaryUF(model, max_tokens=5)
+        messages = make_messages(3)  # 6 messages, not enough for graduation
+
+        with mock.patch.object(
+            ChatSummary,
+            "summarize",
+            return_value=[
+                {"role": "user", "content": "recursive fallback"},
+                {"role": "assistant", "content": "Ok."},
+            ],
+        ) as mock_recursive:
+            result = summarizer.summarize(messages)
+            mock_recursive.assert_called_once()
+
+
+# ────────────────────────────────────────────────────────────
+# Area 5: summarize_all() parity
+# ────────────────────────────────────────────────────────────
+
+
+class TestSummarizeAllParity(TestCase):
+    def test_delegates_to_parent(self):
+        model = make_mock_model(summary_text="all summary")
+        summarizer = ChatSummaryUF(model, max_tokens=100)
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        result = summarizer.summarize_all(messages)
+        # Should produce same format as ChatSummary.summarize_all
+        from aider import prompts
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["role"], "user")
+        self.assertTrue(result[0]["content"].startswith(prompts.summary_prefix))
+
+
+# ────────────────────────────────────────────────────────────
+# Area 6: Stale discard + rebuild
+# ────────────────────────────────────────────────────────────
+
+
+class TestStaleDiscardAndRebuild(TestCase):
+    def test_fed_count_shrink_triggers_rebuild(self):
+        """When messages shrink (previous result applied), forest rebuilds."""
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=30)
+
+        # First call with many messages
+        messages_large = make_messages(30)
+        summarizer.summarize(messages_large)
+        old_fed_count = summarizer._fed_count
+        self.assertEqual(old_fed_count, 60)
+
+        # Simulate summarize_end applying the result: done_messages shrinks
+        messages_small = make_messages(5)
+
+        # _init_context_window should be called since _fed_count (60) > len(messages_small) (10)
+        with mock.patch.object(summarizer, "_init_context_window", wraps=summarizer._init_context_window) as mock_init:
+            summarizer.summarize(messages_small)
+            mock_init.assert_called_once()
+
+    def test_fed_count_tracks_incremental_feeding(self):
+        """_fed_count increases with each call, feeding only new messages."""
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=30)
+
+        messages = make_messages(15)  # 30 messages
+        summarizer.summarize(messages)
+        self.assertEqual(summarizer._fed_count, 30)
+
+        # Add more messages
+        messages_more = messages + make_messages(5)  # 40 messages
+        # Context window should only receive the 10 new messages
+        with mock.patch.object(summarizer.context_window, "append", wraps=summarizer.context_window.append) as mock_append:
+            summarizer.summarize(messages_more)
+            # Only the new user/assistant messages should be appended
+            # 10 new messages, all have content, so 10 appends
+            self.assertEqual(mock_append.call_count, 10)
+
+
+# ────────────────────────────────────────────────────────────
+# Area 11: Incremental feeding
+# ────────────────────────────────────────────────────────────
+
+
+class TestIncrementalFeeding(TestCase):
+    def test_skips_non_user_assistant_roles(self):
+        """System messages and other roles are not fed to context window."""
+        model = make_mock_model(summary_text="summary")
+        summarizer = ChatSummaryUF(model, max_tokens=5)
+
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "function", "content": "result"},
+        ]
+
+        with mock.patch.object(
+            summarizer.context_window, "append", wraps=summarizer.context_window.append
+        ) as mock_append, mock.patch.object(
+            ChatSummary, "summarize", return_value=messages
+        ):
+            summarizer.summarize(messages)
+            # Only user and assistant messages should be appended
+            self.assertEqual(mock_append.call_count, 2)
+
+    def test_empty_content_not_fed(self):
+        """Messages with empty content are not fed."""
+        model = make_mock_model(summary_text="summary")
+        # max_tokens=1 so too_big triggers even with small messages
+        summarizer = ChatSummaryUF(model, max_tokens=1)
+
+        messages = [
+            {"role": "user", "content": "hello there friend"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "world again now"},
+        ]
+
+        with mock.patch.object(
+            summarizer.context_window, "append", wraps=summarizer.context_window.append
+        ) as mock_append, mock.patch.object(
+            ChatSummary, "summarize", return_value=messages
+        ):
+            summarizer.summarize(messages)
+            # Only non-empty user/assistant messages
+            self.assertEqual(mock_append.call_count, 2)
+
+
+# ────────────────────────────────────────────────────────────
+# Area 7: Low token budget
+# ────────────────────────────────────────────────────────────
+
+
+class TestLowTokenBudget(TestCase):
+    def test_low_budget_falls_back_gracefully(self):
+        """With a very low token budget, falls back to recursive without crashing."""
+        model = make_mock_model(summary_text="short summary")
+        summarizer = ChatSummaryUF(model, max_tokens=10)
+
+        messages = make_messages(30)
+
+        # Should not raise, should produce a result
+        with mock.patch.object(
+            ChatSummary,
+            "summarize",
+            return_value=[
+                {"role": "user", "content": "fallback"},
+                {"role": "assistant", "content": "Ok."},
+            ],
+        ):
+            result = summarizer.summarize(messages)
+            self.assertIsInstance(result, list)
+            self.assertGreater(len(result), 0)
+
+
+# ────────────────────────────────────────────────────────────
+# Embedding service
+# ────────────────────────────────────────────────────────────
+
+
+class TestTFIDFEmbedder(TestCase):
+    def test_embed_returns_sparse_dict(self):
+        embedder = TFIDFEmbedder()
+        result = embedder.embed("python code review")
+        self.assertIsInstance(result, dict)
+        self.assertIn("python", result)
+        self.assertIn("code", result)
+        self.assertIn("review", result)
+
+    def test_embed_empty_string(self):
+        embedder = TFIDFEmbedder()
+        result = embedder.embed("")
+        self.assertEqual(result, {})
+
+    def test_embed_stopwords_filtered(self):
+        embedder = TFIDFEmbedder()
+        result = embedder.embed("the quick brown fox")
+        self.assertNotIn("the", result)
+        self.assertIn("quick", result)
+        self.assertIn("brown", result)
+        self.assertIn("fox", result)
+
+    def test_vocabulary_grows(self):
+        embedder = TFIDFEmbedder()
+        embedder.embed("python code")
+        size1 = embedder.vocab_size
+        embedder.embed("java programming")
+        size2 = embedder.vocab_size
+        self.assertGreater(size2, size1)
+
+    def test_doc_count_increments(self):
+        embedder = TFIDFEmbedder()
+        self.assertEqual(embedder.doc_count, 0)
+        embedder.embed("hello")
+        self.assertEqual(embedder.doc_count, 1)
+        embedder.embed("world")
+        self.assertEqual(embedder.doc_count, 2)
+
+    def test_similar_texts_have_high_cosine(self):
+        embedder = TFIDFEmbedder()
+        emb1 = embedder.embed("python debugging error traceback")
+        emb2 = embedder.embed("python error debugging stack trace")
+        sim = _cosine_similarity(emb1, emb2)
+        self.assertGreater(sim, 0.3)
+
+    def test_different_texts_have_low_cosine(self):
+        embedder = TFIDFEmbedder()
+        emb1 = embedder.embed("python debugging error traceback")
+        emb2 = embedder.embed("cooking recipe pasta tomato sauce")
+        sim = _cosine_similarity(emb1, emb2)
+        self.assertLess(sim, 0.1)
+
+
+# ────────────────────────────────────────────────────────────
+# ContextWindow integration
+# ────────────────────────────────────────────────────────────
+
+
+class TestContextWindow(TestCase):
+    def setUp(self):
+        self.embedder = TFIDFEmbedder()
+        self.mock_summarizer = mock.Mock()
+        self.mock_summarizer.summarize = mock.Mock(return_value="cluster summary")
+
+    def test_append_and_render(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=3, evict_at=5, max_cold_clusters=10
+        )
+        for i in range(5):
+            cw.append(f"message {i} about topic {i}")
+        rendered = cw.render()
+        self.assertGreater(len(rendered), 0)
+
+    def test_hot_count_tracks_correctly(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=3, evict_at=5, max_cold_clusters=10
+        )
+        self.assertEqual(cw.hot_count, 0)
+        cw.append("msg1")
+        self.assertEqual(cw.hot_count, 1)
+        cw.append("msg2")
+        self.assertEqual(cw.hot_count, 2)
+        cw.append("msg3")
+        self.assertEqual(cw.hot_count, 3)
+        # 4th append: hot = 4, 4 > graduate_at=3, so one graduates
+        cw.append("msg4")
+        self.assertEqual(cw.hot_count, 3)
+        self.assertEqual(cw.cold_count, 1)
+
+    def test_graduation_sends_to_forest(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=2, evict_at=4, max_cold_clusters=10
+        )
+        cw.append("message alpha about python")
+        cw.append("message beta about java")
+        self.assertEqual(cw.cold_count, 0)
+        # Third message triggers graduation of first
+        cw.append("message gamma about rust")
+        self.assertGreater(cw.cold_count, 0)
+
+    def test_force_merge_when_too_many_clusters(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=1, evict_at=3, max_cold_clusters=2
+        )
+        # Each append with graduate_at=1 means hot keeps only 1
+        # After 4 appends: 3 graduated, 1 hot. 3 clusters > max 2, force merge
+        for i in range(4):
+            cw.append(f"unique topic number {i} with keyword{i}")
+        self.assertLessEqual(cw.cold_count, 2)
+
+    def test_render_includes_cold_and_hot(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=2, evict_at=4, max_cold_clusters=10
+        )
+        cw.append("cold message about python")
+        cw.append("cold message about java")
+        cw.append("hot message about rust")  # triggers graduation of first
+        cw.resolve_dirty()
+        rendered = cw.render()
+        # Should include both cold summaries/content and hot content
+        self.assertGreater(len(rendered), 0)
+
+    def test_resolve_dirty_produces_summaries(self):
+        cw = ContextWindow(
+            self.embedder, self.mock_summarizer,
+            graduate_at=1, evict_at=3, max_cold_clusters=1,
+            merge_threshold=0.0  # force merges
+        )
+        cw.append("python code review")
+        cw.append("python debugging errors")
+        cw.append("python testing framework")
+        # With graduate_at=1, max_cold=1: all get merged into one cluster
+        cw.resolve_dirty()
+        # The summarizer should have been called for the dirty merged cluster
+        if self.mock_summarizer.summarize.called:
+            rendered = cw.render()
+            # Cold part should contain the summary
+            self.assertGreater(len(rendered), 0)

--- a/tests/basic/test_chat_summary_uf.py
+++ b/tests/basic/test_chat_summary_uf.py
@@ -425,41 +425,53 @@ class TestSummarizeAllParity(TestCase):
 
 
 class TestStaleDiscardAndRebuild(TestCase):
-    def test_fed_count_shrink_triggers_rebuild(self):
+    def test_shrink_triggers_rebuild(self):
         """When messages shrink (previous result applied), forest rebuilds."""
         model = make_mock_model(summary_text="cluster summary")
         summarizer = ChatSummaryUF(model, max_tokens=30)
 
-        # First call with many messages
         messages_large = make_messages(30)
         summarizer.summarize(messages_large)
-        old_fed_count = summarizer._fed_count
-        self.assertEqual(old_fed_count, 60)
+        self.assertGreater(len(summarizer._fed_messages), 0)
 
         # Simulate summarize_end applying the result: done_messages shrinks
         messages_small = make_messages(5)
 
-        # _init_context_window should be called since _fed_count (60) > len(messages_small) (10)
-        with mock.patch.object(summarizer, "_init_context_window", wraps=summarizer._init_context_window) as mock_init:
+        with mock.patch.object(summarizer, "_rebuild", wraps=summarizer._rebuild) as mock_rebuild:
             summarizer.summarize(messages_small)
-            mock_init.assert_called_once()
+            mock_rebuild.assert_called_once()
 
-    def test_fed_count_tracks_incremental_feeding(self):
-        """_fed_count increases with each call, feeding only new messages."""
+    def test_same_length_replacement_triggers_rebuild(self):
+        """When messages are replaced (same length, different content), rebuild."""
         model = make_mock_model(summary_text="cluster summary")
         summarizer = ChatSummaryUF(model, max_tokens=30)
 
-        messages = make_messages(15)  # 30 messages
+        messages_a = make_messages(15)
+        summarizer.summarize(messages_a)
+
+        # Same length but different content
+        messages_b = [
+            {"role": r, "content": f"REPLACED msg {i}"}
+            for i, r in enumerate(["user", "assistant"] * 15)
+        ]
+        with mock.patch.object(summarizer, "_rebuild", wraps=summarizer._rebuild) as mock_rebuild:
+            summarizer.summarize(messages_b)
+            mock_rebuild.assert_called_once()
+
+    def test_incremental_feeding(self):
+        """Appending new messages feeds only the new ones, not all."""
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=30)
+
+        messages = make_messages(15)
         summarizer.summarize(messages)
-        self.assertEqual(summarizer._fed_count, 30)
+        self.assertEqual(len(summarizer._fed_messages), 30)
 
         # Add more messages
-        messages_more = messages + make_messages(5)  # 40 messages
-        # Context window should only receive the 10 new messages
+        messages_more = messages + make_messages(5)
         with mock.patch.object(summarizer.context_window, "append", wraps=summarizer.context_window.append) as mock_append:
             summarizer.summarize(messages_more)
             # Only the new user/assistant messages should be appended
-            # 10 new messages, all have content, so 10 appends
             self.assertEqual(mock_append.call_count, 10)
 
 

--- a/tests/basic/test_chat_summary_uf.py
+++ b/tests/basic/test_chat_summary_uf.py
@@ -350,6 +350,52 @@ class TestOutputFormat(TestCase):
         # Last message should be assistant (trailing Ok.)
         self.assertEqual(result[-1]["role"], "assistant")
 
+    def test_hot_tail_starts_with_user_message(self):
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=20)
+        summarizer._fed_messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+        summarizer.token_count = lambda _msg: 1
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+
+        with mock.patch.object(
+            summarizer, "too_big", return_value=True
+        ), mock.patch.object(
+            type(summarizer.context_window), "hot_count", new_callable=mock.PropertyMock
+        ) as mock_hot_count, mock.patch.object(
+            summarizer.context_window, "render", return_value=["cold summary", "new answer"]
+        ), mock.patch.object(
+            summarizer.context_window, "resolve_dirty"
+        ):
+            mock_hot_count.return_value = 1
+            result = summarizer.summarize(messages)
+
+        self.assertEqual(result[2]["role"], "user")
+        self.assertEqual(result[2]["content"], "new question")
+        self.assertEqual(result[3]["role"], "assistant")
+        self.assertEqual(result[3]["content"], "new answer")
+
+    def test_under_budget_appends_trailing_ok_when_needed(self):
+        messages = [{"role": "user", "content": "short request"}]
+        result = self.summarizer.summarize(messages)
+        self.assertEqual(
+            result,
+            [
+                {"role": "user", "content": "short request"},
+                {"role": "assistant", "content": "Ok."},
+            ],
+        )
+
 
 # ────────────────────────────────────────────────────────────
 # Area 4: Fallback to recursive
@@ -557,6 +603,42 @@ class TestLowTokenBudget(TestCase):
 
 
 class TestMixedRoleHandling(TestCase):
+    def test_system_messages_at_boundary_preserved(self):
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=20)
+        summarizer._fed_messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+        summarizer.token_count = lambda _msg: 1
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "system", "content": "boundary system"},
+            {"role": "tool", "content": "boundary tool"},
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+
+        with mock.patch.object(
+            summarizer, "too_big", return_value=True
+        ), mock.patch.object(
+            type(summarizer.context_window), "hot_count", new_callable=mock.PropertyMock
+        ) as mock_hot_count, mock.patch.object(
+            summarizer.context_window, "render", return_value=["cold summary", "new question", "new answer"]
+        ), mock.patch.object(
+            summarizer.context_window, "resolve_dirty"
+        ):
+            mock_hot_count.return_value = 2
+            result = summarizer.summarize(messages)
+
+        result_contents = [msg["content"] for msg in result]
+        self.assertIn("boundary system", result_contents)
+        self.assertIn("boundary tool", result_contents)
+
     def test_system_messages_in_tail_preserved(self):
         """System messages interspersed with user/assistant are preserved in hot tail."""
         model = make_mock_model(summary_text="cluster summary")

--- a/tests/basic/test_chat_summary_uf.py
+++ b/tests/basic/test_chat_summary_uf.py
@@ -72,11 +72,11 @@ class TestForest(TestCase):
     def test_union_marks_dirty(self):
         self.forest.insert("m1", "hello", {"hello": 1.0})
         self.forest.insert("m2", "world", {"world": 1.0})
-        self.assertFalse(self.forest.is_dirty("m1"))
-        self.assertFalse(self.forest.is_dirty("m2"))
+        self.assertNotIn("m1", self.forest._dirty)
+        self.assertNotIn("m2", self.forest._dirty)
         self.forest.union("m1", "m2")
         root = self.forest.roots()[0]
-        self.assertTrue(self.forest.is_dirty(root))
+        self.assertIn(root, self.forest._dirty)
 
     def test_resolve_dirty_calls_summarizer(self):
         self.forest.insert("m1", "hello", {"hello": 1.0})
@@ -127,7 +127,7 @@ class TestForest(TestCase):
         self.forest.insert("m2", "world", {"world": 1.0})
         self.forest.union("m1", "m2")
         root = self.forest.roots()[0]
-        inputs = self.forest.dirty_inputs(root)
+        inputs = list(self.forest._dirty_inputs.get(root, []))
         self.assertEqual(len(inputs), 2)
         self.assertIn("hello", inputs)
         self.assertIn("world", inputs)
@@ -537,6 +537,92 @@ class TestLowTokenBudget(TestCase):
             result = summarizer.summarize(messages)
             self.assertIsInstance(result, list)
             self.assertGreater(len(result), 0)
+
+
+# ────────────────────────────────────────────────────────────
+# Mixed-role message handling
+# ────────────────────────────────────────────────────────────
+
+
+class TestMixedRoleHandling(TestCase):
+    def test_system_messages_in_tail_preserved(self):
+        """System messages interspersed with user/assistant are preserved in hot tail."""
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=400)
+
+        messages = []
+        for i in range(30):
+            messages.append({"role": "user", "content": f"User message {i} about topic {i % 3}"})
+            messages.append({"role": "assistant", "content": f"Assistant response {i} about topic {i % 3}"})
+        # Insert system messages near the end
+        messages.insert(-2, {"role": "system", "content": "System reminder"})
+        messages.insert(-1, {"role": "tool", "content": "Tool output"})
+
+        result = summarizer.summarize(messages)
+        if result != messages:  # Only check if summarization happened
+            result_contents = [m.get("content", "") for m in result]
+            # System and tool messages from the tail should be preserved
+            self.assertIn("System reminder", result_contents)
+            self.assertIn("Tool output", result_contents)
+
+    def test_hot_tail_maps_to_correct_original_messages(self):
+        """hot_count user/assistant messages map back to correct original indices."""
+        model = make_mock_model(summary_text="cluster summary")
+        summarizer = ChatSummaryUF(model, max_tokens=400)
+
+        messages = make_messages(30)  # 60 messages
+        # Insert 3 system messages in the last 10 messages
+        messages.insert(55, {"role": "system", "content": "reminder 1"})
+        messages.insert(58, {"role": "system", "content": "reminder 2"})
+        messages.insert(61, {"role": "system", "content": "reminder 3"})
+
+        result = summarizer.summarize(messages)
+        if result != messages:
+            # All 3 system messages should appear in the result
+            system_msgs = [m for m in result if m.get("role") == "system"]
+            self.assertEqual(len(system_msgs), 3)
+
+
+# ────────────────────────────────────────────────────────────
+# Memory bounds
+# ────────────────────────────────────────────────────────────
+
+
+class TestMemoryBounds(TestCase):
+    def test_hot_list_trimmed_after_graduation(self):
+        """_hot list is trimmed after messages graduate, bounding memory."""
+        embedder = TFIDFEmbedder()
+        mock_summarizer = mock.Mock()
+        mock_summarizer.summarize = mock.Mock(return_value="summary")
+
+        cw = ContextWindow(
+            embedder, mock_summarizer,
+            graduate_at=5, evict_at=10, max_cold_clusters=10,
+        )
+        # Append many messages — should graduate and trim
+        for i in range(20):
+            cw.append(f"message {i} about topic {i % 3}")
+
+        # _hot should only contain ungraduated messages (at most evict_at)
+        self.assertLessEqual(len(cw._hot), cw._evict_at)
+        # _graduated_index should be 0 (trimmed)
+        self.assertEqual(cw._graduated_index, 0)
+
+    def test_hot_stays_bounded_over_long_session(self):
+        """Memory stays bounded even after many appends."""
+        embedder = TFIDFEmbedder()
+        mock_summarizer = mock.Mock()
+        mock_summarizer.summarize = mock.Mock(return_value="summary")
+
+        cw = ContextWindow(
+            embedder, mock_summarizer,
+            graduate_at=5, evict_at=10, max_cold_clusters=10,
+        )
+        for i in range(200):
+            cw.append(f"message {i}")
+
+        # _hot should never exceed evict_at
+        self.assertLessEqual(len(cw._hot), cw._evict_at)
 
 
 # ────────────────────────────────────────────────────────────

--- a/tests/basic/test_integration_uf.py
+++ b/tests/basic/test_integration_uf.py
@@ -1,0 +1,243 @@
+"""Integration test: union-find summarizer with real tokenizer, mock LLM.
+
+Tests the full control loop that was broken in practice:
+- too_big() fires on real token counts
+- force_graduate creates cold clusters within the budget
+- resolve_dirty summarizes clusters (mock LLM, no API calls)
+- render() produces structured output
+- /topics shows clusters, /drop-topic removes them
+
+Uses the real model tokenizer (litellm) but mocks all LLM calls.
+This catches control-loop bugs that unit tests with word-count mocks miss.
+"""
+
+from unittest import TestCase, mock
+
+from aider.chat_summary_uf import ChatSummaryUF
+from aider.commands import Commands
+from aider.models import Model
+from aider import prompts
+
+
+def _make_real_tokenizer_summarizer(model_name="claude-sonnet-4-5", max_tokens=1024):
+    """Build ChatSummaryUF with real tokenizer but mock LLM calls."""
+    model = Model(model_name)
+
+    counter = {"n": 0}
+
+    def mock_send(messages):
+        counter["n"] += 1
+        return f"Cluster {counter['n']} summary: topic discussion"
+
+    # Mock LLM calls on both weak and main model
+    model.weak_model.simple_send_with_retries = mock_send
+    model.simple_send_with_retries = mock_send
+
+    summarizer = ChatSummaryUF([model.weak_model, model], max_tokens=max_tokens)
+    return summarizer, model, counter
+
+
+def _build_conversation(n_exchanges=15):
+    """Build a realistic multi-topic conversation with enough tokens to trigger summarization."""
+    topics = [
+        ("database migration", "Adding a new column called verified to the users table for email verification status. The migration needs both up and down methods, plus an index on the verified column for faster queries. We should use ALTER TABLE ADD COLUMN with a DEFAULT false."),
+        ("JWT authentication", "Implementing Bearer token validation middleware with pyjwt. The token should include user_id, role, and exp claims. We need a refresh token endpoint that issues new access tokens. Token expiry is 24 hours, refresh expiry is 30 days."),
+        ("React components", "Building a dashboard with react-loading-skeleton for loading states. The sidebar navigation should highlight the active route using useLocation from react-router-dom. We also need a ThemeProvider using React context for dark mode support with tailwind dark: classes."),
+        ("CI pipeline", "GitHub Actions workflow that runs pytest with coverage before deploying. Using actions/cache with pip cache directory keyed on requirements.txt hash. The deploy job uses needs: [test] to depend on the test job passing first."),
+        ("payment processing", "Race condition in the payment webhook handler where two webhook events process the same payment simultaneously. Fix with SELECT FOR UPDATE database lock. The lock timeout is configurable via PAYMENT_LOCK_TIMEOUT_MS with a default of 5000ms."),
+    ]
+    messages = []
+    for i in range(n_exchanges):
+        topic_name, topic_detail = topics[i % len(topics)]
+        messages.append({
+            "role": "user",
+            "content": (
+                f"I need help with {topic_name}. {topic_detail} "
+                f"Can you review the current implementation in the codebase and suggest specific improvements? "
+                f"I want to make sure we handle all edge cases properly. This is exchange {i}."
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": (
+                f"I've reviewed the {topic_name} implementation. {topic_detail} "
+                f"Here are my specific suggestions: "
+                f"First, the current implementation doesn't handle the error case where the connection drops mid-operation. "
+                f"Second, we should add input validation to prevent injection attacks. "
+                f"Third, the test coverage is missing edge cases around concurrent access patterns. "
+                f"Fourth, consider adding structured logging so we can debug production issues more easily. "
+                f"I can help implement any of these changes right now."
+            ),
+        })
+    return messages
+
+
+class TestIntegrationControlLoop(TestCase):
+    """Verify the control loop works with real tokenizers."""
+
+    def test_too_big_fires_with_real_tokenizer(self):
+        """Sanity check: too_big returns True for a realistic conversation."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+        total = sum(summarizer.token_count(m) for m in messages)
+        self.assertGreater(total, 1024, f"Expected >1024 tokens, got {total}")
+        self.assertTrue(summarizer.too_big(messages))
+
+    def test_cold_clusters_form(self):
+        """The critical test: summarize() produces cold clusters, not a recursive blob."""
+        summarizer, model, counter = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+
+        result = summarizer.summarize(messages)
+
+        # Must not return original (that means too_big was False)
+        self.assertNotEqual(result, messages, "summarize() returned original messages unchanged")
+
+        # Must have cold clusters
+        self.assertGreater(
+            summarizer.context_window.cold_count, 0,
+            "No cold clusters formed — force_graduate didn't work"
+        )
+
+        # Result must start with summary prefix (UF path, not recursive)
+        self.assertEqual(result[0]["role"], "user")
+        self.assertTrue(
+            result[0]["content"].startswith(prompts.summary_prefix),
+            "Result doesn't start with summary prefix"
+        )
+
+        # LLM was called for cluster summarization
+        self.assertGreater(counter["n"], 0, "No LLM calls made for cluster summarization")
+
+        # Result fits within budget
+        result_tokens = sum(summarizer.token_count(m) for m in result)
+        self.assertLessEqual(result_tokens, 1024, f"Result {result_tokens} exceeds budget 1024")
+
+    def test_result_smaller_than_input(self):
+        """UF result must be strictly smaller than input."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+
+        result = summarizer.summarize(messages)
+
+        result_tokens = sum(summarizer.token_count(m) for m in result)
+        input_tokens = sum(summarizer.token_count(m) for m in messages)
+        self.assertLess(result_tokens, input_tokens)
+
+    def test_hot_zone_within_budget(self):
+        """Hot messages should fit in ~25% of max_tokens after graduation."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+
+        summarizer.summarize(messages)
+
+        hot_budget = 1024 // 4  # 256
+        hot_messages = summarizer.context_window.hot_messages()
+        hot_tokens = sum(
+            summarizer.token_count({"role": "user", "content": c})
+            for c in hot_messages
+        )
+        # Allow some slack — the 25% is a target, not a hard cap
+        self.assertLess(
+            hot_tokens, 1024 // 2,
+            f"Hot zone {hot_tokens} tokens exceeds half the budget"
+        )
+
+    def test_topics_shows_clusters_after_summarization(self):
+        """End-to-end: summarize → /topics shows numbered clusters."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+
+        result = summarizer.summarize(messages)
+
+        # Build mock coder
+        coder = mock.Mock()
+        coder.summarizer = summarizer
+        coder.summarizer_thread = None
+        coder.main_model = model
+        coder.done_messages = list(result)
+
+        outputs = []
+        io = mock.Mock()
+        io.tool_output = lambda *a, **kw: outputs.append(a[0] if a else "")
+
+        commands = Commands(io, coder)
+        commands.cmd_topics("")
+
+        # Should have numbered topic lines
+        topic_lines = [o for o in outputs if o.strip() and o.strip()[0].isdigit() and ". " in o]
+        self.assertGreater(
+            len(topic_lines), 0,
+            f"No topic lines in output: {outputs}"
+        )
+
+    def test_drop_topic_removes_cluster(self):
+        """End-to-end: summarize → /drop-topic removes a cluster."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+        messages = _build_conversation(8)
+
+        result = summarizer.summarize(messages)
+        clusters_before = summarizer.context_window.cold_count
+
+        coder = mock.Mock()
+        coder.summarizer = summarizer
+        coder.summarizer_thread = None
+        coder.main_model = model
+        coder.done_messages = list(result)
+
+        outputs = []
+        io = mock.Mock()
+        io.tool_output = lambda *a, **kw: outputs.append(a[0] if a else "")
+        io.tool_error = lambda *a, **kw: outputs.append(a[0] if a else "")
+
+        commands = Commands(io, coder)
+        commands.cmd_drop_topic("1")
+
+        self.assertEqual(
+            summarizer.context_window.cold_count, clusters_before - 1,
+            "Cluster count didn't decrease after /drop-topic"
+        )
+        drop_output = [o for o in outputs if "Dropped topic" in o]
+        self.assertEqual(len(drop_output), 1)
+
+    def test_repeated_summarize_cycles(self):
+        """Simulate multiple summarize cycles like a real session."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
+
+        # First batch
+        messages = _build_conversation(6)
+        result1 = summarizer.summarize(messages)
+        self.assertNotEqual(result1, messages)
+
+        # Simulate summarize_end applying the result
+        # Then more messages arrive
+        messages2 = list(result1)
+        for i in range(4):
+            messages2.append({
+                "role": "user",
+                "content": f"Follow-up question {i} about deployment configuration",
+            })
+            messages2.append({
+                "role": "assistant",
+                "content": f"Here is my response {i} about the deployment setup and configuration.",
+            })
+
+        # Second summarization cycle
+        if summarizer.too_big(messages2):
+            result2 = summarizer.summarize(messages2)
+            self.assertNotEqual(result2, messages2)
+            # Should still have clusters
+            self.assertGreaterEqual(summarizer.context_window.cold_count, 0)
+
+    def test_low_budget_still_works(self):
+        """Even at a very low budget, UF path should succeed or fall back gracefully."""
+        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=256)
+        messages = _build_conversation(6)
+
+        result = summarizer.summarize(messages)
+
+        # Should produce a result (either UF or recursive fallback)
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+        result_tokens = sum(summarizer.token_count(m) for m in result)
+        self.assertLessEqual(result_tokens, 256)

--- a/tests/basic/test_integration_uf.py
+++ b/tests/basic/test_integration_uf.py
@@ -14,7 +14,7 @@ This catches control-loop bugs that unit tests with word-count mocks miss.
 from unittest import TestCase, mock
 
 from aider.chat_summary_uf import ChatSummaryUF
-from aider.commands import Commands
+
 from aider.models import Model
 from aider import prompts
 
@@ -142,63 +142,6 @@ class TestIntegrationControlLoop(TestCase):
             hot_tokens, 1024 // 2,
             f"Hot zone {hot_tokens} tokens exceeds half the budget"
         )
-
-    def test_topics_shows_clusters_after_summarization(self):
-        """End-to-end: summarize → /topics shows numbered clusters."""
-        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
-        messages = _build_conversation(8)
-
-        result = summarizer.summarize(messages)
-
-        # Build mock coder
-        coder = mock.Mock()
-        coder.summarizer = summarizer
-        coder.summarizer_thread = None
-        coder.main_model = model
-        coder.done_messages = list(result)
-
-        outputs = []
-        io = mock.Mock()
-        io.tool_output = lambda *a, **kw: outputs.append(a[0] if a else "")
-
-        commands = Commands(io, coder)
-        commands.cmd_topics("")
-
-        # Should have numbered topic lines
-        topic_lines = [o for o in outputs if o.strip() and o.strip()[0].isdigit() and ". " in o]
-        self.assertGreater(
-            len(topic_lines), 0,
-            f"No topic lines in output: {outputs}"
-        )
-
-    def test_drop_topic_removes_cluster(self):
-        """End-to-end: summarize → /drop-topic removes a cluster."""
-        summarizer, model, _ = _make_real_tokenizer_summarizer(max_tokens=1024)
-        messages = _build_conversation(8)
-
-        result = summarizer.summarize(messages)
-        clusters_before = summarizer.context_window.cold_count
-
-        coder = mock.Mock()
-        coder.summarizer = summarizer
-        coder.summarizer_thread = None
-        coder.main_model = model
-        coder.done_messages = list(result)
-
-        outputs = []
-        io = mock.Mock()
-        io.tool_output = lambda *a, **kw: outputs.append(a[0] if a else "")
-        io.tool_error = lambda *a, **kw: outputs.append(a[0] if a else "")
-
-        commands = Commands(io, coder)
-        commands.cmd_drop_topic("1")
-
-        self.assertEqual(
-            summarizer.context_window.cold_count, clusters_before - 1,
-            "Cluster count didn't decrease after /drop-topic"
-        )
-        drop_output = [o for o in outputs if "Dropped topic" in o]
-        self.assertEqual(len(drop_output), 1)
 
     def test_repeated_summarize_cycles(self):
         """Simulate multiple summarize cycles like a real session."""

--- a/tests/basic/test_smoke_uf.py
+++ b/tests/basic/test_smoke_uf.py
@@ -247,40 +247,21 @@ class TestSmokeUFFoundation(TestCase):
         self.assertGreater(len(result), 0)
 
     def test_stale_rebuild_after_done_messages_shrink(self):
-        """When done_messages shrinks and then grows past budget, forest rebuilds."""
+        """When done_messages shrinks, prefix mismatch triggers rebuild."""
         summarizer, model = _make_summarizer()
         padded = _padded_conversation()
 
         # First summarization
         result = summarizer.summarize(padded)
-        fed_after_first = summarizer._fed_count
-        self.assertEqual(fed_after_first, len(padded))
+        self.assertGreater(len(summarizer._fed_messages), 0)
 
         # Simulate summarize_end applying the result (done_messages = result, shorter).
-        # Then more messages arrive, growing past too_big again.
-        grown = list(result)
-        for i in range(30):
-            grown.append({"role": "user", "content": f"New message {i} about a completely different topic"})
-            grown.append({"role": "assistant", "content": f"New response {i} about the different topic"})
-
-        # _fed_count (62) > len(result) was (28), but now grown is 88.
-        # The key: _fed_count (62) < len(grown) (88), BUT the forest has stale data.
-        # Actually: _fed_count (62) < len(grown) (88), so it tries incremental feed.
-        # The correct trigger is when result was applied: _fed_count stays at 62,
-        # then next call with the short result + growth detects stale via content mismatch.
-        # The real stale detection: _fed_count > len(messages) only fires if messages shrunk.
-        # Let's test the actual shrink case:
-        result2 = summarizer.summarize(result)
-        # result is 28 messages, _fed_count was 62 > 28 → too_big check first.
-        # But result (28 msgs) may not be too_big at max_tokens=400.
-        # If not too_big, summarize returns early — _fed_count unchanged.
-        # This is correct behavior: no need to rebuild if history fits in budget.
-        if not summarizer.too_big(result):
-            # Short enough to fit — no summarization needed, no rebuild
-            self.assertEqual(summarizer._fed_count, fed_after_first)
-        else:
-            # Would rebuild: _fed_count resets
-            self.assertLessEqual(summarizer._fed_count, len(result))
+        # The result has different content (summaries), so prefix check fails → rebuild.
+        with mock.patch.object(summarizer, "_rebuild", wraps=summarizer._rebuild) as mock_rebuild:
+            result2 = summarizer.summarize(result)
+            if summarizer.too_big(result):
+                mock_rebuild.assert_called_once()
+            # If result fits budget, summarize returns early — no rebuild needed
 
     def test_incremental_feeding_skips_system_messages(self):
         """System messages are not fed into the forest."""

--- a/tests/basic/test_smoke_uf.py
+++ b/tests/basic/test_smoke_uf.py
@@ -1,0 +1,314 @@
+"""Smoke test: union-find summarizer with realistic conversation data.
+
+Uses a distilled Flask #1169 debugging conversation (from the experiment corpus)
+to verify the foundation: feed messages → clusters form by topic similarity →
+render() produces structured output → fallback to recursive works → stale rebuild works.
+
+Runs with a mock model (no API calls) but real TF-IDF clustering.
+"""
+
+from unittest import TestCase, mock
+
+from aider.chat_summary_uf import ChatSummaryUF
+from aider import prompts
+
+
+# -- Realistic conversation: 3 distinct topics from Flask #1169 --
+# Topic A: path traversal security in send_from_directory
+# Topic B: Windows drive letter handling
+# Topic C: file descriptor leak under concurrency
+
+CONVERSATION = [
+    # Topic A: path traversal
+    {"role": "user", "content": (
+        "I'm looking into issue #1169 in Flask's helpers.py. "
+        "send_from_directory fails when using absolute paths. "
+        "It triggers a SecurityError because safe_join rejects the path."
+    )},
+    {"role": "assistant", "content": (
+        "Let's look at the implementation of send_from_directory. "
+        "It calls safe_join(directory, filename). If the filename is absolute, "
+        "safe_join treats it as a traversal attempt. We need to resolve the realpath first."
+    )},
+    {"role": "user", "content": (
+        "I've updated helpers.py to use os.path.realpath and os.path.commonpath "
+        "to validate the path. The test_send_file_security test passes now. "
+        "No directory traversal is possible."
+    )},
+    {"role": "assistant", "content": (
+        "Good progress. Make sure to add a test case for symlink traversal. "
+        "os.path.realpath resolves symlinks, which could expose paths outside "
+        "the intended directory."
+    )},
+    {"role": "user", "content": (
+        "Added test_symlink_traversal to test_helpers.py. It confirms that "
+        "symlinks pointing outside the base directory are correctly rejected. "
+        "The SecurityError message is now more descriptive."
+    )},
+    {"role": "assistant", "content": (
+        "Excellent. The path validation logic in helpers.py looks solid. "
+        "Update the docstrings to reflect that absolute paths are now supported "
+        "provided they resolve within the base directory."
+    )},
+
+    # Topic B: Windows drive letters
+    {"role": "user", "content": (
+        "I noticed that on Windows, drive letters complicate the path validation. "
+        "os.path.commonpath fails when comparing paths on different drives. "
+        "We need ntpath.normcase to handle drive letter capitalization."
+    )},
+    {"role": "assistant", "content": (
+        "Be careful with importing ntpath directly. Stick to os.path.normpath "
+        "and os.path.abspath for cross-platform compatibility. "
+        "Add a mock in test_helpers.py to simulate Windows drive boundary issues."
+    )},
+    {"role": "user", "content": (
+        "I've added Windows path test cases using monkeypatch to simulate drive letters. "
+        "The normcase fix handles C: vs c: correctly. "
+        "All 42 tests in test_helpers.py pass including the new Windows cases."
+    )},
+    {"role": "assistant", "content": (
+        "Does the CI runner confirm the Windows tests pass? We want to ensure "
+        "the normalization in helpers.py doesn't accidentally strip UNC path prefixes "
+        "on network shares."
+    )},
+    {"role": "user", "content": (
+        "CI runner confirmed green on Windows. The explicit call to os.path.abspath "
+        "before os.path.realpath correctly handles UNC paths and drive letter variations. "
+        "No regressions in flask.tests.test_send_file."
+    )},
+    {"role": "assistant", "content": (
+        "Perfect. The Windows path handling is now robust. "
+        "Should we use posixpath.normpath internally to stop the Windows runner "
+        "from converting forward slashes to backslashes?"
+    )},
+
+    # Topic C: file descriptor leak
+    {"role": "user", "content": (
+        "I just got a ping from a Discord user. After updating to 1.0.2, "
+        "their static file serving crashes under load. "
+        "The os.stat calls are leaking file descriptors."
+    )},
+    {"role": "assistant", "content": (
+        "That is concerning. The file object is probably not being explicitly closed "
+        "after the stat check in helpers.py. A context manager should fix the leak."
+    )},
+    {"role": "user", "content": (
+        "I've written a stress test using threading to spawn 100 concurrent requests "
+        "to send_from_directory. It consistently crashes at 1024 open file descriptors. "
+        "Adding the context manager fixes it — stable at 12."
+    )},
+    {"role": "assistant", "content": (
+        "Excellent reproduction strategy. The benchmarks show negligible latency impact "
+        "from the context manager. Let's add the stress test to TestFileHandling "
+        "as a regression test."
+    )},
+    {"role": "user", "content": (
+        "Added the stress test to test_helpers.py. It completes in under two seconds. "
+        "The file descriptor count stays bounded even with 100 concurrent requests. "
+        "CI is green across all platforms."
+    )},
+    {"role": "assistant", "content": (
+        "Great work. The resource leak fix and the stress test cover the concurrency "
+        "edge case. This should prevent the issue from recurring."
+    )},
+
+    # More Topic A (interleaved — tests that clustering groups by topic, not by time)
+    {"role": "user", "content": (
+        "Wait, I found another edge case in the path traversal check. "
+        "If the user passes a relative path that resolves outside the base directory "
+        "via enough ../ components, our check misses it."
+    )},
+    {"role": "assistant", "content": (
+        "Good catch. We should use werkzeug.utils.safe_join to combine directory "
+        "and filename. It's specifically designed to prevent directory traversal. "
+        "Create a reproduction test case first."
+    )},
+    {"role": "user", "content": (
+        "The traversal test confirmed the vulnerability. I've refactored helpers.py "
+        "to use safe_join. If safe_join returns None, we now raise werkzeug.exceptions.NotFound. "
+        "All tests pass including the new traversal case."
+    )},
+    {"role": "assistant", "content": (
+        "This adds a critical layer of protection. The path validation in helpers.py "
+        "is now much more robust. Prepare a follow-up PR for this security hardening."
+    )},
+]
+
+
+def _word_count(msg):
+    if isinstance(msg, list):
+        return sum(_word_count(m) for m in msg)
+    if isinstance(msg, str):
+        return len(msg.split())
+    return len(msg.get("content", "").split())
+
+
+def _make_summarizer(max_tokens=400):
+    """Build a ChatSummaryUF with a mock model that returns unique cluster summaries."""
+    counter = {"n": 0}
+
+    def _unique_summary(msgs):
+        counter["n"] += 1
+        return f"Cluster {counter['n']} summary: discussed Flask helpers.py topic {counter['n']}"
+
+    model = mock.Mock()
+    model.name = "gemini/gemini-3.1-flash-lite-preview"
+    model.token_count = _word_count
+    model.info = {"max_input_tokens": 4096}
+    model.simple_send_with_retries = mock.Mock(side_effect=_unique_summary)
+    return ChatSummaryUF(models=[model], max_tokens=max_tokens), model
+
+
+def _padded_conversation():
+    """Conversation + padding to exceed graduate_at (26 user/assistant messages)."""
+    padded = list(CONVERSATION)
+    for i in range(20):
+        padded.append({"role": "user", "content": f"Follow-up question {i} about helpers.py path validation"})
+        padded.append({"role": "assistant", "content": f"Response {i} about the security fix in send_from_directory"})
+    return padded
+
+
+class TestSmokeUFFoundation(TestCase):
+    """End-to-end foundation tests: clustering, rendering, fallback, rebuild."""
+
+    def test_clusters_form_from_realistic_data(self):
+        """TF-IDF clustering produces cold clusters from a multi-topic conversation."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+
+        result = summarizer.summarize(padded)
+        cw = summarizer.context_window
+        forest = cw._forest
+
+        self.assertGreater(forest.cluster_count(), 0, "Expected cold clusters")
+        self.assertGreater(cw.hot_count, 0, "Expected hot messages")
+        self.assertNotEqual(result, padded, "Expected summarized output, not original")
+
+    def test_output_format_matches_recursive(self):
+        """Output is [summary_msg, 'Ok.', *hot_messages] — same as recursive."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+
+        result = summarizer.summarize(padded)
+
+        # First message is summary with prefix
+        self.assertEqual(result[0]["role"], "user")
+        self.assertTrue(result[0]["content"].startswith(prompts.summary_prefix))
+
+        # Second message is "Ok."
+        self.assertEqual(result[1]["role"], "assistant")
+        self.assertEqual(result[1]["content"], "Ok.")
+
+        # Remaining are hot messages from the original
+        for msg in result[2:]:
+            self.assertIn(msg["role"], ("user", "assistant"))
+
+    def test_render_produces_cold_and_hot(self):
+        """render() returns cold summaries followed by hot contents."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+        summarizer.summarize(padded)
+
+        cw = summarizer.context_window
+        rendered = cw.render()
+
+        # Cold part: cluster summaries
+        cold_count = cw.cold_count
+        hot_count = cw.hot_count
+        self.assertEqual(len(rendered), cold_count + hot_count)
+
+        # Cold parts are either cluster summaries (contain "Cluster" from mock)
+        # or raw singleton content (never merged, so not summarized)
+        cold_parts = rendered[:cold_count]
+        summarized = [p for p in cold_parts if "Cluster" in p]
+        self.assertGreater(len(summarized), 0, "Expected at least one merged cluster summary")
+
+    def test_distinct_topics_form_separate_clusters(self):
+        """Messages about different topics cluster separately, not by timestamp."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+        summarizer.summarize(padded)
+
+        forest = summarizer.context_window._forest
+        # With 3 distinct topics + padding, should get multiple clusters
+        self.assertGreater(forest.cluster_count(), 1,
+                           "Expected multiple clusters from distinct topics")
+
+    def test_fallback_to_recursive_when_inflated(self):
+        """If union-find result exceeds budget, falls back to recursive."""
+        # Very low budget forces fallback
+        summarizer, model = _make_summarizer(max_tokens=5)
+        padded = _padded_conversation()
+
+        # Should not crash — falls back to recursive
+        result = summarizer.summarize(padded)
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+
+    def test_stale_rebuild_after_done_messages_shrink(self):
+        """When done_messages shrinks and then grows past budget, forest rebuilds."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+
+        # First summarization
+        result = summarizer.summarize(padded)
+        fed_after_first = summarizer._fed_count
+        self.assertEqual(fed_after_first, len(padded))
+
+        # Simulate summarize_end applying the result (done_messages = result, shorter).
+        # Then more messages arrive, growing past too_big again.
+        grown = list(result)
+        for i in range(30):
+            grown.append({"role": "user", "content": f"New message {i} about a completely different topic"})
+            grown.append({"role": "assistant", "content": f"New response {i} about the different topic"})
+
+        # _fed_count (62) > len(result) was (28), but now grown is 88.
+        # The key: _fed_count (62) < len(grown) (88), BUT the forest has stale data.
+        # Actually: _fed_count (62) < len(grown) (88), so it tries incremental feed.
+        # The correct trigger is when result was applied: _fed_count stays at 62,
+        # then next call with the short result + growth detects stale via content mismatch.
+        # The real stale detection: _fed_count > len(messages) only fires if messages shrunk.
+        # Let's test the actual shrink case:
+        result2 = summarizer.summarize(result)
+        # result is 28 messages, _fed_count was 62 > 28 → too_big check first.
+        # But result (28 msgs) may not be too_big at max_tokens=400.
+        # If not too_big, summarize returns early — _fed_count unchanged.
+        # This is correct behavior: no need to rebuild if history fits in budget.
+        if not summarizer.too_big(result):
+            # Short enough to fit — no summarization needed, no rebuild
+            self.assertEqual(summarizer._fed_count, fed_after_first)
+        else:
+            # Would rebuild: _fed_count resets
+            self.assertLessEqual(summarizer._fed_count, len(result))
+
+    def test_incremental_feeding_skips_system_messages(self):
+        """System messages are not fed into the forest."""
+        summarizer, model = _make_summarizer()
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello from user"},
+            {"role": "assistant", "content": "Hello from assistant"},
+        ] * 20  # 60 messages, 40 user/assistant
+        summarizer.summarize(msgs)
+
+        cw = summarizer.context_window
+        # System messages should not have been appended to hot zone
+        # Only user/assistant messages are fed
+        total_fed = cw.hot_count + sum(
+            len(cw._forest._children.get(r, set()))
+            for r in cw._forest.roots()
+        )
+        # Should be 40 (20 user + 20 assistant), not 60
+        self.assertLessEqual(total_fed, 40)
+
+    def test_deterministic_render_across_calls(self):
+        """render() produces identical output on repeated calls (stable ordering)."""
+        summarizer, model = _make_summarizer()
+        padded = _padded_conversation()
+        summarizer.summarize(padded)
+
+        cw = summarizer.context_window
+        render1 = cw.render()
+        render2 = cw.render()
+        self.assertEqual(render1, render2)


### PR DESCRIPTION
**Part 1 of 2.** This PR adds the backend. [Part 2](#4941) adds `/topics` and `/drop-topic` commands on top of it. Split for reviewability — together they give users selective control over chat history.

## Summary

- Adds `--chat-history-summarizer union-find` flag, opt-in alternative to the default recursive summarizer
- Groups messages into topic clusters by TF-IDF similarity, summarizes each cluster independently
- Produces the same output format, uses the same model cascade, falls back to recursive if output exceeds budget
- Without the flag, this PR is a no-op. Default behavior completely unchanged
- Benchmarked as quality-equivalent (136 paired observations, McNemar p=0.248, 1.14× cost)
- No new dependencies (pure Python TF-IDF embedder)

## Test plan

- [x] 57 new tests passing (`tests/basic/test_chat_summary_uf.py` + `tests/basic/test_smoke_uf.py`)
- [x] 523 existing tests passing, zero regressions

## Why

The current recursive summarizer compresses chat history into a single opaque text blob. Original messages are discarded. There's no provenance, and no way to selectively remove one stale topic without re-summarizing everything.

- #3607 — selective history control ("I want to drop the debugging context but keep the refactor decisions")
- #2219 — see/edit context ("I want to see what the model's context actually contains")
- #948 — token breakdown with actions ("show me what's consuming tokens and let me act on it")

Union-find compaction groups messages into topic-coherent clusters and summarizes each one independently. Every summary traces back to its source messages through `find()`. Topics become addressable units you can inspect and drop.

This is the backend. User-facing commands (`/topics`, `/drop-topic`) come in a follow-up PR once the foundation is reviewed.

## Background

The algorithm was [prototyped against gemini-cli](https://june.kim/union-find-compaction), where it showed a +8–18pp recall advantage over flat summarization across 7 trials (1 significant at p=0.039, rest directional). It was then ported to aider for validation against aider's stronger recursive baseline. Full experiment methodology, preregistration, and data are in the [research repo](https://github.com/kimjune01/union-find-compaction-for-aider).

## What changes

**New files** (549 lines of production code, 689 lines of tests):

| File | Lines | What it does |
|------|------:|--------------|
| `aider/context_window.py` | 328 | `Forest` (union-find cluster store with stable ordering and weighted centroids) + `ContextWindow` (hot/cold zones with graduation and eviction) |
| `aider/embedding_service.py` | 80 | `TFIDFEmbedder` — pure Python, incremental vocabulary, no external dependencies |
| `aider/cluster_summarizer.py` | 56 | Per-cluster summarization via existing model cascade (`simple_send_with_retries`) |
| `aider/chat_summary_uf.py` | 85 | `ChatSummaryUF(ChatSummary)` — drop-in subclass with incremental feeding and mandatory fallback |
| `tests/basic/test_chat_summary_uf.py` | 689 | 49 tests covering 12 areas (see table below) |
| `tests/basic/test_smoke_uf.py` | 314 | 8 smoke tests with realistic Flask #1169 conversation data |

**Modified files** (15 lines changed):

| File | Change |
|------|--------|
| `aider/args.py` | `--chat-history-summarizer` argument (default `recursive`, choices `[recursive, union-find]`) |
| `aider/main.py` | Conditional at summarizer construction — `ChatSummaryUF` when `union-find`, `ChatSummary` otherwise |

## What doesn't change

- Default summarization (recursive, unchanged)
- Threading model (`summarize_start`/`summarize_worker`/`summarize_end`)
- Output format (`[summary_msg, "Ok.", *hot_messages]`)
- `summarize_all()` behavior (delegates to parent)
- Existing commands (`/clear`, `/drop`, `/tokens`, `/reset`)
- Existing tests (no modifications, all 523 still passing)

## How it works

Messages flow through a hot zone and a cold forest:

1. Each user/assistant message is TF-IDF-embedded and pushed to the hot zone
2. When the hot zone exceeds `graduate_at` (26 messages), the oldest graduates to the forest
3. Graduated messages merge with the nearest existing cluster if cosine similarity ≥ 0.15, or form a new singleton
4. If cluster count exceeds `max_cold_clusters` (10), the closest pair is force-merged
5. Dirty clusters (merged but not yet summarized) are summarized via the model cascade
6. `render()` returns cold summaries + hot contents, formatted as `[summary_msg, "Ok.", *hot_messages]`

The overlap window (graduate_at=26, evict_at=30) gives `resolve_dirty()` time to summarize before eviction.

## Safety

1. **Mandatory fallback.** If the union-find result exceeds `max_tokens` or is ≥ input tokens, falls back to `super().summarize()` (recursive). Worst case, you get the current system.
2. **Stale-safety preserved.** `summarize_end()` stale check works identically. The `_fed_count` mechanism triggers a full forest rebuild when `done_messages` changes (shrinks, is cleared, or is replaced by a previous summarization result).
3. **Same tokenizer.** Inherits `self.token_count = self.models[0].token_count` from `ChatSummary.__init__()`.
4. **Stable root ordering.** `roots()` returns clusters in insertion order via a tracked `_root_order` list, ensuring deterministic `render()` output across calls.
5. **Weighted centroid averaging.** `union()` weights centroids by cluster size (`emb * size / total`), preventing small clusters from distorting large ones over repeated merges.
6. **No new dependencies.** TF-IDF embedder is pure Python. No numpy, no scipy, no API calls.

## Test coverage

49 unit tests in `tests/basic/test_chat_summary_uf.py`, organized by area:

| Area | Tests | What's verified |
|------|------:|-----------------|
| Forest mechanics | 12 | Insert, union, roots, compact, nearest_root, dirty tracking, path compression, dirty input collection |
| Stable root ordering | 4 | Insertion order preserved, order after merge, deterministic across calls, multiple merges |
| Weighted centroid | 3 | Equal-size midpoint, unequal-size weights toward larger, sparse dict weighting |
| Cluster summarization | 4 | First model success, fallback to second model, all fail raises ValueError, single model (not list) |
| Flag selection | 3 | Subclass relationship, ChatSummaryUF constructs correctly, default is ChatSummary (not UF) |
| Output format | 2 | Not-too-big returns unchanged, summary + "Ok." + hot_messages format |
| Fallback to recursive | 2 | Result exceeds max_tokens, not enough messages for graduation |
| `summarize_all()` parity | 1 | Delegates to parent, same output format |
| Stale discard + rebuild | 2 | `_fed_count` shrink triggers `_init_context_window()`, incremental feeding tracks correctly |
| Incremental feeding | 2 | Skips non-user/assistant roles, empty content not fed |
| Low token budget | 1 | Graceful fallback without crash |
| TF-IDF embedder | 7 | Sparse dict output, empty string, stopwords filtered, vocabulary growth, doc count, cosine similarity (high for similar, low for different) |
| ContextWindow integration | 6 | Append/render, hot count tracking, graduation to forest, force merge, cold+hot render, dirty resolution |

8 smoke tests in `tests/basic/test_smoke_uf.py` with a distilled Flask #1169 conversation (3 topics: path traversal, Windows drive letters, file descriptor leak):

| Test | What's verified |
|------|-----------------|
| Clusters form from realistic data | Cold clusters and hot messages created from multi-topic conversation |
| Output format matches recursive | `[summary_msg, "Ok.", *hot_messages]` structure preserved |
| Render produces cold and hot | `render()` returns cluster summaries followed by hot contents |
| Distinct topics form separate clusters | Messages about different topics cluster separately, not by timestamp |
| Fallback to recursive when inflated | Low budget triggers graceful fallback |
| Stale rebuild after shrink | Correct behavior when done_messages shrinks (summary applied) |
| System messages filtered | System role messages not fed into forest |
| Deterministic render | `render()` produces identical output on repeated calls |

## Benchmark

Tested on 17 real aider conversations (136 paired observation points where both backends triggered summarization):

| Metric | Value |
|--------|-------|
| McNemar's test | p = 0.248 (no significant difference in recall) |
| Cost ratio | 1.14× (union-find uses slightly more tokens due to per-cluster prompts) |
| Latency overhead | Sub-millisecond (TF-IDF embedding + union-find operations; LLM calls dominate) |

The union-find backend produces quality-equivalent summaries. The value is structured context: visibility into what the model remembers, and selective control over what it forgets.

## Follow-up (not in this PR)

- `/topics` — read-only command showing topic clusters with token counts and previews
- `/drop-topic N` — selective topic removal with `done_messages` sync and threading guard
- Cross-session topic persistence (#4079)

## Future paths

The new code is fully contained — 4 new files, no modifications to base_coder.py, no changes to the threading model, no new state that other systems depend on. The opt-in flag keeps all three options cheap:

- **Make it the default:** Change `default="recursive"` to `default="union-find"` in `args.py`. One line.
- **Rip it out:** Delete 4 files, remove 15 lines from `args.py` + `main.py`. Five minutes.
- **Keep as-is:** Zero maintenance. The recursive path doesn't know the union-find path exists.