### PR TITLE
fix: add debug logging for programming exceptions caught by ANY_GIT_ERROR

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import json
 import locale
+import logging
 import math
 import mimetypes
 import os
@@ -51,6 +52,8 @@ from aider.waiting import WaitingSpinner
 
 from ..dump import dump  # noqa: F401
 from .chat_chunks import ChatChunks
+
+logger = logging.getLogger(__name__)
 
 
 class UnknownEditFormat(ValueError):
@@ -2316,6 +2319,7 @@ class Coder:
             return edited
 
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in apply_updates: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(str(err))
             return edited
         except Exception as err:
@@ -2391,6 +2395,7 @@ class Coder:
 
             return self.gpt_prompts.files_content_gpt_no_edits
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in auto_commit: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to commit: {str(err)}")
             return
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import re
 import subprocess
@@ -25,6 +26,8 @@ from aider.scrape import Scraper, install_playwright
 from aider.utils import is_image_file
 
 from .dump import dump  # noqa: F401
+
+logger = logging.getLogger(__name__)
 
 
 class SwitchCoder(Exception):
@@ -295,6 +298,7 @@ class Commands:
         try:
             return cmd_method(args)
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in do_run: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to complete {cmd_name}: {err}")
 
     def matching_commands(self, inp):
@@ -339,6 +343,7 @@ class Commands:
         try:
             self.raw_cmd_commit(args)
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in cmd_commit: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to complete commit: {err}")
 
     def raw_cmd_commit(self, args=None):
@@ -555,6 +560,7 @@ class Commands:
         try:
             self.raw_cmd_undo(args)
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in cmd_undo: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to complete undo: {err}")
 
     def raw_cmd_undo(self, args):
@@ -609,7 +615,8 @@ class Commands:
         try:
             remote_head = self.coder.repo.repo.git.rev_parse(f"origin/{current_branch}")
             has_origin = True
-        except ANY_GIT_ERROR:
+        except ANY_GIT_ERROR as e:
+            logger.debug("Caught %s in raw_cmd_undo: %s", type(e).__name__, e, exc_info=True)
             has_origin = False
 
         if has_origin:
@@ -627,7 +634,8 @@ class Commands:
             try:
                 self.coder.repo.repo.git.checkout("HEAD~1", file_path)
                 restored.add(file_path)
-            except ANY_GIT_ERROR:
+            except ANY_GIT_ERROR as e:
+                logger.debug("Caught %s in raw_cmd_undo: %s", type(e).__name__, e, exc_info=True)
                 unrestored.add(file_path)
 
         if unrestored:
@@ -659,6 +667,7 @@ class Commands:
         try:
             self.raw_cmd_diff(args)
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in cmd_diff: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to complete diff: {err}")
 
     def raw_cmd_diff(self, args=""):

--- a/aider/main.py
+++ b/aider/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import sys
@@ -39,6 +40,8 @@ from aider.watch import FileWatcher
 
 from .dump import dump  # noqa: F401
 
+logger = logging.getLogger(__name__)
+
 
 def check_config_files_for_yes(config_files):
     found = False
@@ -71,7 +74,8 @@ def guessed_wrong_repo(io, git_root, fnames, git_dname):
 
     try:
         check_repo = Path(GitRepo(io, fnames, git_dname).root).resolve()
-    except (OSError,) + ANY_GIT_ERROR:
+    except ANY_GIT_ERROR as e:
+        logger.debug("Caught %s in guessed_wrong_repo: %s", type(e).__name__, e, exc_info=True)
         return
 
     # we had no guess, rely on the "true" repo result
@@ -90,6 +94,7 @@ def make_new_repo(git_root, io):
         repo = git.Repo.init(git_root)
         check_gitignore(git_root, io, False)
     except ANY_GIT_ERROR as err:  # issue #1233
+        logger.debug("Caught %s in make_new_repo: %s", type(err).__name__, err, exc_info=True)
         io.tool_error(f"Unable to create git repo in {git_root}")
         io.tool_output(str(err))
         return
@@ -112,8 +117,8 @@ def setup_git(git_root, io):
     if git_root:
         try:
             repo = git.Repo(git_root)
-        except ANY_GIT_ERROR:
-            pass
+        except ANY_GIT_ERROR as e:
+            logger.debug("Caught %s in setup_git: %s", type(e).__name__, e, exc_info=True)
     elif cwd == Path.home():
         io.tool_warning(
             "You should probably run aider in your project's directory, not your home dir."
@@ -183,7 +188,8 @@ def check_gitignore(git_root, io, ask=True):
                 return
         else:
             content = ""
-    except ANY_GIT_ERROR:
+    except ANY_GIT_ERROR as e:
+        logger.debug("Caught %s in check_gitignore: %s", type(e).__name__, e, exc_info=True)
         return
 
     if ask:
@@ -430,6 +436,7 @@ def sanity_check_repo(repo, io):
             f"Internal error: {str(exc)}"
         )
     except ANY_GIT_ERROR as exc:
+        logger.debug("Caught %s in main: %s", type(exc).__name__, exc, exc_info=True)
         error_msg = str(exc)
         bad_ver = "version in (1, 2)" in error_msg
     except AssertionError as exc:

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import os
 import time
 from pathlib import Path, PurePosixPath
@@ -34,6 +35,8 @@ ANY_GIT_ERROR += [
     TimeoutError,
 ]
 ANY_GIT_ERROR = tuple(ANY_GIT_ERROR)
+
+logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -110,8 +113,8 @@ class GitRepo:
                 repo_path = git.Repo(fname, search_parent_directories=True).working_dir
                 repo_path = utils.safe_abs_path(repo_path)
                 repo_paths.append(repo_path)
-            except ANY_GIT_ERROR:
-                pass
+            except ANY_GIT_ERROR as e:
+                logger.debug("Caught %s in __init__: %s", type(e).__name__, e, exc_info=True)
 
         num_repos = len(set(repo_paths))
 
@@ -283,6 +286,7 @@ class GitRepo:
                 try:
                     self.repo.git.add(fname)
                 except ANY_GIT_ERROR as err:
+                    logger.debug("Caught %s in commit: %s", type(err).__name__, err, exc_info=True)
                     self.io.tool_error(f"Unable to add {fname}: {err}")
             cmd += ["--"] + fnames
         else:
@@ -314,6 +318,7 @@ class GitRepo:
                 return commit_hash, commit_message
 
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in commit: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to commit: {err}")
             # No return here, implicitly returns None
 
@@ -381,10 +386,10 @@ class GitRepo:
             try:
                 commits = self.repo.iter_commits(active_branch)
                 current_branch_has_commits = any(commits)
-            except ANY_GIT_ERROR:
-                pass
-        except (TypeError,) + ANY_GIT_ERROR:
-            pass
+            except ANY_GIT_ERROR as e:
+                logger.debug("Caught %s in get_diffs: %s", type(e).__name__, e, exc_info=True)
+        except ANY_GIT_ERROR as e:
+            logger.debug("Caught %s in get_diffs: %s", type(e).__name__, e, exc_info=True)
 
         if not fnames:
             fnames = []
@@ -414,6 +419,7 @@ class GitRepo:
 
             return diffs
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in get_diffs: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to diff: {err}")
 
     def diff_commits(self, pretty, from_commit, to_commit):
@@ -439,6 +445,7 @@ class GitRepo:
         except ValueError:
             commit = None
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in get_tracked_files: %s", type(err).__name__, err, exc_info=True)
             self.git_repo_error = err
             self.io.tool_error(f"Unable to list files in git repo: {err}")
             self.io.tool_output("Is your git repo corrupted?")
@@ -468,6 +475,7 @@ class GitRepo:
                         except StopIteration:
                             break
                 except ANY_GIT_ERROR as err:
+                    logger.debug("Caught %s in get_tracked_files: %s", type(err).__name__, err, exc_info=True)
                     self.git_repo_error = err
                     self.io.tool_error(f"Unable to list files in git repo: {err}")
                     self.io.tool_output("Is your git repo corrupted?")
@@ -481,6 +489,7 @@ class GitRepo:
             staged_files = [path for path, _ in index.entries.keys()]
             files.update(self.normalize_path(path) for path in staged_files)
         except ANY_GIT_ERROR as err:
+            logger.debug("Caught %s in get_tracked_files: %s", type(err).__name__, err, exc_info=True)
             self.io.tool_error(f"Unable to read staged files: {err}")
 
         res = [fname for fname in files if not self.ignored_file(fname)]
@@ -526,7 +535,8 @@ class GitRepo:
         try:
             if self.repo.ignored(path):
                 return True
-        except ANY_GIT_ERROR:
+        except ANY_GIT_ERROR as e:
+            logger.debug("Caught %s in git_ignored_file: %s", type(e).__name__, e, exc_info=True)
             return False
 
     def ignored_file(self, fname):
@@ -604,7 +614,8 @@ class GitRepo:
     def get_head_commit(self):
         try:
             return self.repo.head.commit
-        except (ValueError,) + ANY_GIT_ERROR:
+        except ANY_GIT_ERROR as e:
+            logger.debug("Caught %s in get_head_commit: %s", type(e).__name__, e, exc_info=True)
             return None
 
     def get_head_commit_sha(self, short=False):

--- a/tests/basic/test_any_git_error_logging.py
+++ b/tests/basic/test_any_git_error_logging.py
@@ -1,0 +1,26 @@
+import logging
+from unittest import mock
+
+from aider.repo import ANY_GIT_ERROR, GitRepo
+
+
+def test_git_ignored_file_logs_debug_on_any_git_error():
+    """Verify that debug logging fires when a programming exception
+    is caught by except ANY_GIT_ERROR."""
+    # Set up a minimal GitRepo-like object with a mock repo
+    repo = mock.MagicMock()
+    repo.ignored.side_effect = TypeError("simulated programming bug")
+
+    git_repo = mock.MagicMock(spec=GitRepo)
+    git_repo.repo = repo
+
+    # Call the real method with our mocked object
+    with mock.patch("aider.repo.logger") as mock_logger:
+        result = GitRepo.git_ignored_file(git_repo, "somefile.py")
+
+    assert result is False
+    mock_logger.debug.assert_called_once()
+    call_args = mock_logger.debug.call_args
+    assert "TypeError" in str(call_args)
+    assert "git_ignored_file" in str(call_args)
+    assert call_args.kwargs.get("exc_info") is True


### PR DESCRIPTION
## Summary

Addresses #4932.

`ANY_GIT_ERROR` includes `TypeError`, `ValueError`, `AttributeError`, and `AssertionError` — exception types that signal programming bugs, not git errors. When silently caught at 22+ call sites, real bugs become invisible: users see a vague message instead of a traceback, and bug reports are much harder to diagnose.

## Changes

### Phase 1 — Observability (this PR)

Added `logger.debug()` before every silent `except ANY_GIT_ERROR` block across four files:

- `aider/repo.py` — 8 call sites
- `aider/coders/base_coder.py` — 2 call sites (`apply_updates`, `auto_commit`)
- `aider/commands.py` — 5 call sites (`do_run`, `cmd_commit`, `cmd_undo`, `cmd_diff`)
- `aider/main.py` — 5 call sites (`guessed_wrong_repo`, `make_new_repo`, `setup_git`, `check_gitignore`, `sanity_check_repo`)

Format is consistent across all sites:
```python
logger.debug("Caught %s in <function>: %s", type(e).__name__, e, exc_info=True)
```

`exc_info=True` ensures the full traceback appears in debug logs, making hidden bugs fully visible.

### Redundancy fix

`repo.py:384` wrote `(TypeError,) + ANY_GIT_ERROR` — manually prepending `TypeError` when it is already a member of the tuple. Same issue in `get_head_commit` with `(ValueError,)`. Both simplified to plain `ANY_GIT_ERROR`, removing the evidence of confusion noted in the issue.

## What this does NOT change

- No user-visible behavior changes
- No exceptions removed from `ANY_GIT_ERROR` (that is Phase 2 work)
- No new dependencies

## Testing

Added `tests/basic/test_any_git_error_logging.py` with a test that:
1. Mocks `repo.ignored()` to raise `TypeError` (a programming bug)
2. Calls `git_ignored_file()` through the real code path
3. Asserts `logger.debug` was called with the correct function name, exception type, and `exc_info=True`

## Next steps (Phase 2)

Once Phase 1 is in and debug logs are available in the wild, the remaining work is to audit which call sites legitimately need `TypeError`/`AttributeError` (where gitpython itself raises them) vs. which are cargo-cult catches that can be narrowed. Happy to continue that work in a follow-up PR.
