### PR TITLE
fix: preserve architect context when file-add dialog triggers

### DIFF
--- a/aider/coders/architect_coder.py
+++ b/aider/coders/architect_coder.py
@@ -9,12 +9,26 @@ class ArchitectCoder(AskCoder):
     auto_accept_architect = False
 
     def reply_completed(self):
-        content = self.partial_response_content
+        # Collect all architect assistant responses from this turn.
+        # When check_for_file_mentions triggers a reflection loop, the original
+        # response with code changes is in cur_messages but only the reflection
+        # response ends up in partial_response_content.
+        content_parts = []
+        for msg in getattr(self, "cur_messages", []):
+            if msg["role"] == "assistant" and msg.get("content"):
+                content_parts.append(msg["content"])
+
+        if content_parts:
+            content = "\n\n".join(content_parts)
+        else:
+            content = self.partial_response_content
 
         if not content or not content.strip():
             return
 
-        if not self.auto_accept_architect and not self.io.confirm_ask("Edit the files?"):
+        if not self.auto_accept_architect and not self.io.confirm_ask(
+            "Edit the files?"
+        ):
             return
 
         kwargs = dict()

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,48 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_architect_coder_includes_prior_assistant_messages(self):
+        """After a reflection loop (e.g. file mention), the editor should
+        receive all architect assistant messages, not just the last one."""
+        with GitTemporaryDirectory():
+            io = InputOutput(yes=True)
+            io.confirm_ask = MagicMock(return_value=True)
+
+            with patch("aider.coders.architect_coder.AskCoder.__init__", return_value=None):
+                from aider.coders.architect_coder import ArchitectCoder
+
+                coder = ArchitectCoder()
+                coder.io = io
+                coder.main_model = self.GPT35
+                coder.auto_accept_architect = True
+                coder.verbose = False
+                coder.total_cost = 0
+                coder.done_messages = []
+                coder.summarizer = MagicMock()
+                coder.summarizer.too_big.return_value = False
+
+                # Simulate a reflection loop: the original architect response
+                # with code changes is in cur_messages, and a shorter follow-up
+                # (after file was added) is the latest response.
+                original_response = "Here are the code changes:\n```\nprint('hello')\n```"
+                reflection_response = "I see the file now. Let me know if you need more."
+                coder.cur_messages = [
+                    dict(role="user", content="make changes"),
+                    dict(role="assistant", content=original_response),
+                    dict(role="user", content="I added foo.py to the chat."),
+                    dict(role="assistant", content=reflection_response),
+                ]
+
+                mock_editor = MagicMock()
+                with patch("aider.coders.architect_coder.Coder.create", return_value=mock_editor):
+                    coder.reply_completed()
+
+                    # The editor should receive BOTH assistant messages
+                    call_args = mock_editor.run.call_args
+                    editor_content = call_args[1]["with_message"]
+                    assert original_response in editor_content
+                    assert reflection_response in editor_content
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When the architect's response mentions a file not in the chat, `check_for_file_mentions` triggers a reflection loop. It sets `reflected_message` and returns before `reply_completed` runs. The architect gets called again with the reflection message, but only that second (shorter) response reaches the editor via `partial_response_content`. The original response containing the actual code changes is in `cur_messages` but never forwarded.

This causes the editor to work with incomplete context, as shown in #3033 where token counts drop from 6.6k to 3.4k after a file-add dialog.

The fix collects all assistant messages from `cur_messages` in `reply_completed` so the editor receives the full architect output. Falls back to `partial_response_content` for the normal (no reflection) path.

Fixes #3033