### PR TITLE
Handle /models import errors gracefully

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -212,7 +212,13 @@ class Commands:
         args = args.strip()
 
         if args:
-            models.print_matching_models(self.io, args)
+            try:
+                models.print_matching_models(self.io, args)
+            except (ImportError, ModuleNotFoundError) as err:
+                self.io.tool_error(
+                    f"Unable to load model metadata for /models: {err}. "
+                    "Please upgrade or reinstall your LLM dependencies."
+                )
         else:
             self.io.tool_output("Please provide a partial model name to search for.")
 

--- a/tests/basic/test_commands_models.py
+++ b/tests/basic/test_commands_models.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from aider.commands import Commands
+from aider.io import InputOutput
+
+
+class TestCommandsModels(TestCase):
+    def test_cmd_models_handles_import_error(self):
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        commands = Commands(io, SimpleNamespace())
+
+        with (
+            mock.patch(
+                "aider.commands.models.print_matching_models",
+                side_effect=ImportError("cannot import name '_parsing' from 'openai.lib'"),
+            ),
+            mock.patch.object(io, "tool_error") as mock_tool_error,
+        ):
+            commands.cmd_models("gpt")
+
+        mock_tool_error.assert_called_once()
+        message = mock_tool_error.call_args.args[0]
+        self.assertIn("Unable to load model metadata for /models", message)
+        self.assertIn("cannot import name '_parsing' from 'openai.lib'", message)


### PR DESCRIPTION
## Summary
- catch `ImportError` and `ModuleNotFoundError` in `/models` so dependency breakage no longer crashes the command
- show a user-facing error message that preserves the original import failure details
- add a focused regression test for the `/models` command path without depending on the full coder stack

## Verification
- `python -m pytest tests/basic/test_commands_models.py`
- `python -m compileall aider/commands.py tests/basic/test_commands_models.py`

Closes #4904.