### PR TITLE
fix: require exact SEARCH/REPLACE divider in edit blocks

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -384,7 +384,7 @@ def do_replace(fname, content, before_text, after_text, fence=None):
 
 
 HEAD = r"^<{5,9} SEARCH>?\s*$"
-DIVIDER = r"^={5,9}\s*$"
+DIVIDER = r"^={7}\s*$"
 UPDATED = r"^>{5,9} REPLACE\s*$"
 
 HEAD_ERR = "<<<<<<< SEARCH"

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -127,6 +127,25 @@ Hope you like it!
         edits = list(eb.find_original_update_blocks(edit))
         self.assertEqual(edits, [("foo.txt", "Two\n", "Tooooo\n")])
 
+    def test_find_original_update_blocks_with_rst_heading(self):
+        edit = """
+Here's the change:
+
+```text
+doc.rst
+<<<<<<< SEARCH
+Title
+=====
+Some content
+=======
+New content
+>>>>>>> REPLACE
+```
+"""
+
+        edits = list(eb.find_original_update_blocks(edit))
+        self.assertEqual(edits, [("doc.rst", "Title\n=====\nSome content\n", "New content\n")])
+
     def test_find_original_update_blocks_unclosed(self):
         edit = """
 Here's the change:


### PR DESCRIPTION
## Summary
- require the SEARCH/REPLACE divider to match the canonical seven `=` characters instead of any 5-9 `=` line
- prevent `.rst` heading underlines inside SEARCH blocks from being misparsed as edit block dividers
- add a regression test covering an `.rst` heading in the SEARCH block

## Verification
- `python -m pytest tests/basic/test_editblock.py`
- `python -m pytest tests/basic/test_editblock.py -k rst_heading`
- `python -m compileall aider/coders/editblock_coder.py tests/basic/test_editblock.py`

Closes #1803.