### PR TITLE
fix: fall back to httpx when playwright is missing

### DIFF
--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -104,7 +104,12 @@ class Scraper:
         """
 
         if self.playwright_available:
-            content, mime_type = self.scrape_with_playwright(url)
+            try:
+                content, mime_type = self.scrape_with_playwright(url)
+            except ModuleNotFoundError as err:
+                self.playwright_available = False
+                self.print_error(f"Playwright unavailable, falling back to httpx: {err}")
+                content, mime_type = self.scrape_with_httpx(url)
         else:
             content, mime_type = self.scrape_with_httpx(url)
 

--- a/tests/scrape/test_scrape.py
+++ b/tests/scrape/test_scrape.py
@@ -170,6 +170,22 @@ class TestScrape(unittest.TestCase):
         # Assert that html_to_markdown was called with the HTML content
         scraper.html_to_markdown.assert_called_once_with(html_content)
 
+    def test_scrape_falls_back_when_playwright_missing(self):
+        mock_print_error = MagicMock()
+        scraper = Scraper(print_error=mock_print_error, playwright_available=True)
+        scraper.scrape_with_playwright = MagicMock(
+            side_effect=ModuleNotFoundError("No module named 'playwright'")
+        )
+        scraper.scrape_with_httpx = MagicMock(return_value=("fallback content", "text/plain"))
+
+        result = scraper.scrape("https://example.com")
+
+        self.assertEqual(result, "fallback content")
+        self.assertFalse(scraper.playwright_available)
+        scraper.scrape_with_httpx.assert_called_once_with("https://example.com")
+        mock_print_error.assert_called_once()
+        self.assertIn("Playwright unavailable, falling back to httpx", mock_print_error.call_args.args[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- catch `ModuleNotFoundError` when the `/web` scrape path tries to use Playwright without the optional dependency installed
- mark Playwright unavailable for the current scraper instance and fall back to the existing `httpx` scraping path
- add a regression test covering the fallback behavior without requiring Playwright to be installed locally

## Verification
- `python -m pytest tests/scrape/test_scrape.py -k playwright_missing`
- `python -m pytest tests/scrape/test_scrape.py -k "playwright_missing or scrape_text_plain or scrape_text_html"`
- `python -m compileall aider/scrape.py tests/scrape/test_scrape.py`

Closes #4911.