### PR TITLE
Fix TypeError when working_tree_dir is None

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -123,6 +123,12 @@ class GitRepo:
 
         # https://github.com/gitpython-developers/GitPython/issues/427
         self.repo = git.Repo(repo_paths.pop(), odbt=git.GitDB)
+
+        if not self.repo.working_tree_dir:
+            raise FileNotFoundError(
+                "The git repo does not seem to have a working tree?"
+            )
+
         self.root = utils.safe_abs_path(self.repo.working_tree_dir)
 
         if aider_ignore_file:

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -714,3 +714,10 @@ class TestRepo(unittest.TestCase):
                 system_msg_content.startswith(prefix),
                 "system_prompt_prefix should be prepended to the system prompt",
             )
+
+    def test_bare_repo_raises_file_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bare_path = Path(tmpdir) / "bare.git"
+            git.Repo.init(str(bare_path), bare=True)
+            with self.assertRaises(FileNotFoundError):
+                GitRepo(InputOutput(), None, str(bare_path))


### PR DESCRIPTION
## Summary
- Guard against `None` value from `repo.working_tree_dir` in `GitRepo.__init__` to prevent `TypeError`
- When `working_tree_dir` is `None` (e.g., bare repositories), raise `FileNotFoundError` with a descriptive message instead of crashing with an uncaught `TypeError` in `pathlib.py`
- Added test for bare repository handling

## Context
The crash occurs because `self.repo.working_tree_dir` returns `None` for bare git repositories, and this `None` gets passed to `safe_abs_path()` -> `Path(res).resolve()`, which raises `TypeError`.

The fix raises `FileNotFoundError` early in `GitRepo.__init__`, which is already the expected exception type (caught in `main.py` line 921). The error message matches the existing `sanity_check_repo()` message for consistency.

## Test plan
- [x] Added `test_bare_repo_raises_file_not_found` test
- [x] All 22 existing tests in `tests/basic/test_repo.py` pass

Fixes #4971

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>