### PR TITLE
fix: preserve command output on Windows

### DIFF
--- a/aider/run_cmd.py
+++ b/aider/run_cmd.py
@@ -10,7 +10,11 @@ import psutil
 
 def run_cmd(command, verbose=False, error_print=None, cwd=None):
     try:
-        if sys.stdin.isatty() and hasattr(pexpect, "spawn") and platform.system() != "Windows":
+        if (
+            sys.stdin.isatty()
+            and hasattr(pexpect, "spawn")
+            and platform.system() != "Windows"
+        ):
             return run_cmd_pexpect(command, verbose, cwd)
 
         return run_cmd_subprocess(command, verbose, cwd)
@@ -47,11 +51,8 @@ def run_cmd_subprocess(command, verbose=False, cwd=None, encoding=sys.stdout.enc
         shell = os.environ.get("SHELL", "/bin/sh")
         parent_process = None
 
-        # Determine the appropriate shell
         if platform.system() == "Windows":
             parent_process = get_windows_parent_process_name()
-            if parent_process == "powershell.exe":
-                command = f"powershell -Command {command}"
 
         if verbose:
             print("Running command:", command)
@@ -73,6 +74,7 @@ def run_cmd_subprocess(command, verbose=False, cwd=None, encoding=sys.stdout.enc
         )
 
         output = []
+        assert process.stdout is not None
         while True:
             chunk = process.stdout.read(1)
             if not chunk:
@@ -113,7 +115,9 @@ def run_cmd_pexpect(command, verbose=False, cwd=None):
             # Use the shell from SHELL environment variable
             if verbose:
                 print("Running pexpect.spawn with shell:", shell)
-            child = pexpect.spawn(shell, args=["-i", "-c", command], encoding="utf-8", cwd=cwd)
+            child = pexpect.spawn(
+                shell, args=["-i", "-c", command], encoding="utf-8", cwd=cwd
+            )
         else:
             # Fall back to spawning the command directly
             if verbose:

--- a/tests/basic/test_run_cmd.py
+++ b/tests/basic/test_run_cmd.py
@@ -1,11 +1,23 @@
 import pytest  # noqa: F401
 
-from aider.run_cmd import run_cmd
+from aider.run_cmd import run_cmd, run_cmd_subprocess
 
 
 def test_run_cmd_echo():
     command = "echo Hello, World!"
     exit_code, output = run_cmd(command)
+
+    assert exit_code == 0
+    assert output.strip() == "Hello, World!"
+
+
+def test_run_cmd_subprocess_preserves_commas_in_powershell(monkeypatch):
+    monkeypatch.setattr("aider.run_cmd.platform.system", lambda: "Windows")
+    monkeypatch.setattr(
+        "aider.run_cmd.get_windows_parent_process_name", lambda: "powershell.exe"
+    )
+
+    exit_code, output = run_cmd_subprocess("echo Hello, World!")
 
     assert exit_code == 0
     assert output.strip() == "Hello, World!"


### PR DESCRIPTION
## Summary
- remove the Windows PowerShell wrapper in `run_cmd_subprocess` so shell commands keep the default Windows `shell=True` behavior
- add a regression test covering the PowerShell-parent path for commands containing commas
- keep the fix scoped to the Windows `run_cmd` output regression without changing the pagerank PR

## Verification
- `python -m pytest -q tests/basic/test_run_cmd.py`
- `python -c "from aider.run_cmd import run_cmd; code, out = run_cmd('echo Hello, World!'); print('EXIT=', code); print('OUT=', repr(out))"`
- `python -c "from aider.run_cmd import run_cmd_subprocess; import aider.run_cmd as rc; rc.platform.system=lambda:'Windows'; rc.get_windows_parent_process_name=lambda:'powershell.exe'; code, out = run_cmd_subprocess('echo Hello, World!'); print('EXIT=', code); print('OUT=', repr(out))"`