### PR TITLE
fix: abort cleanly in batch mode (--exit) when Ollama is unreachable

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -887,6 +887,13 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         analytics.event("exit", reason="Invalid lint command format")
         return 1
 
+    if main_model.ollama_error and args.exit:
+        io.tool_error(
+            f"Cannot connect to Ollama: {main_model.ollama_error}\n"
+            "Aborting because --exit (batch mode) was specified."
+        )
+        return 1
+
     if args.show_model_warnings:
         problem = models.sanity_check_models(io, main_model)
         if problem:

--- a/aider/models.py
+++ b/aider/models.py
@@ -242,6 +242,8 @@ class ModelInfoManager:
             try:
                 litellm_info = litellm.get_model_info(model)
             except Exception as ex:
+                if str(ex).startswith("OllamaError:"):
+                    raise
                 if "model_prices_and_context_window.json" not in str(ex):
                     print(str(ex))
 
@@ -327,6 +329,7 @@ class Model(ModelSettings):
         self.max_chat_history_tokens = 1024
         self.weak_model = None
         self.editor_model = None
+        self.ollama_error = None
 
         # Find the extra settings
         self.extra_model_settings = next(
@@ -357,7 +360,13 @@ class Model(ModelSettings):
             self.get_editor_model(editor_model, editor_edit_format)
 
     def get_model_info(self, model):
-        return model_info_manager.get_model_info(model)
+        try:
+            return model_info_manager.get_model_info(model)
+        except Exception as ex:
+            if str(ex).startswith("OllamaError:"):
+                self.ollama_error = ex
+                return {}
+            raise
 
     def _copy_fields(self, source):
         """Helper to copy fields from a ModelSettings instance to self"""


### PR DESCRIPTION
## Problem

When Ollama is unreachable (e.g. connection refused), aider treats the error as a non-fatal warning and continues with "sane defaults". In batch mode (`--exit --message`), this causes aider to open its interactive TUI anyway, dumping ANSI escape sequences to stdout. If stdout is redirected to a file, the file is filled with TUI garbage instead of the expected output.

## Root cause

`ModelInfoManager.get_model_info` catches all exceptions from `litellm.get_model_info` and silently swallows them (printing the message but continuing). The Ollama connection error is raised by litellm as a plain `Exception` with a message starting with `"OllamaError:"`.

## Fix

- **`models.py` `ModelInfoManager.get_model_info`**: re-raise exceptions whose message starts with `"OllamaError:"` instead of swallowing them
- **`models.py` `Model.get_model_info`**: catch the re-raised error, store it on `self.ollama_error`, and return `{}` — this preserves the existing interactive-mode behaviour (sane defaults, warning shown)
- **`main.py`**: after model setup, if `main_model.ollama_error` is set **and** `--exit` is active, emit a clear error message and return 1

## Behaviour

| Mode | Before | After |
|------|--------|-------|
| Interactive | Warning + sane defaults + TUI opens | Unchanged |
| Batch (`--exit`) | TUI garbage written to stdout | Clear error message, exit code 1 |