### PR TITLE
fix: catch RuntimeError in command execution (#4988)

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -914,7 +914,11 @@ class Coder:
             return
 
         if self.commands.is_command(inp):
-            return self.commands.run(inp)
+            try:
+                return self.commands.run(inp)
+            except RuntimeError as err:
+                self.io.tool_error(f"Error running command: {err}")
+                return
 
         self.check_for_file_mentions(inp)
         inp = self.check_for_urls(inp)


### PR DESCRIPTION
## Summary

Fixes #4988

A `RuntimeError` from HuggingFace embedding model download (e.g., `RuntimeError: Cannot send a request, as the client has been closed`) was not being caught in `preproc_user_input`, causing aider to crash.

## Changes
- Wrapped `self.commands.run(inp)` in try-except to catch `RuntimeError`
- Shows user-friendly error message instead of crashing

## Test plan
- Run aider with network issues when HuggingFace model download fails
- Run a command that triggers embedding download when HTTP client is closed
- Should show error message and continue running instead of crashing with traceback