### PR TITLE
Add --max-reflections CLI option (fixes #3865)

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -265,6 +265,13 @@ def get_parser(default_config_files, git_root):
         default=2,
         help="Multiplier for map tokens when no files are specified (default: 2)",
     )
+    group.add_argument(
+        "--max-reflections",
+        metavar="MAX_REFLECTIONS",
+        default=3,
+        type=int,
+        help="Maximum number of reflection iterations allowed when the LLM response needs fixing (default: 3)",
+    )
 
     ##########
     group = parser.add_argument_group("History Files")

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -98,7 +98,6 @@ class Coder:
     num_malformed_responses = 0
     last_keyboard_interrupt = None
     num_reflections = 0
-    max_reflections = 3
     edit_format = None
     yield_stream = False
     temperature = None
@@ -338,6 +337,7 @@ class Coder:
         file_watcher=None,
         auto_copy_context=False,
         auto_accept_architect=True,
+        max_reflections=3,
     ):
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
@@ -352,6 +352,7 @@ class Coder:
 
         self.auto_copy_context = auto_copy_context
         self.auto_accept_architect = auto_accept_architect
+        self.max_reflections = max_reflections
 
         self.ignore_mentions = ignore_mentions
         if not self.ignore_mentions:

--- a/aider/main.py
+++ b/aider/main.py
@@ -1004,6 +1004,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             auto_copy_context=args.copy_paste,
             auto_accept_architect=args.auto_accept_architect,
             add_gitignore_files=args.add_gitignore_files,
+            max_reflections=args.max_reflections,
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))


### PR DESCRIPTION
Fixes #3865

`max_reflections` was hardcoded to `3` in `base_coder.py` with no way 
to configure it. This adds a `--max-reflections` CLI flag so users can 
adjust it for complex tasks.

Changes:
- `args.py`: add `--max-reflections` argument (default: 3)
- `base_coder.py`: move `max_reflections` from class attribute to `__init__` parameter
- `main.py`: pass `args.max_reflections` into `Coder.create()`

Also works via:
- Config file: `max-reflections: 5` in `.aider.conf.yml`
- Env var: `AIDER_MAX_REFLECTIONS=5`

No behavior change for existing users (default remains 3).