### PR TITLE
chore(requirements): bump aiohttp to 3.13.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
-aiohttp==3.13.3
+aiohttp==3.13.4
     # via
     #   -c requirements/common-constraints.txt
     #   litellm


### PR DESCRIPTION
A few dependencies in the requirements file have CVEs fixed in newer versions:

- `aiohttp` 3.13.3 -> 3.13.4 (CVE-2026-22815)

Bumped each one to the minimum safe version.