### PR TITLE
chore(requirements): bump litellm to 1.83.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ jsonschema-specifications==2025.9.1
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
-litellm==1.82.3
+litellm==1.83.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in


### PR DESCRIPTION
Noticed some outdated dependencies with known CVEs:

- `litellm` 1.82.3 -> 1.83.0 (CVE-2026-35029)

Bumped each one to the minimum safe version.