### PR TITLE
chore(requirements): bump pygments to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -301,7 +301,7 @@ pyflakes==3.4.0
     # via
     #   -c requirements/common-constraints.txt
     #   flake8
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -c requirements/common-constraints.txt
     #   rich


### PR DESCRIPTION
Noticed some outdated dependencies with known CVEs:

- `pygments` 2.19.2 -> 2.20.0 (CVE-2026-4539)

Bumped each one to the minimum safe version.