### PR TITLE
chore(requirements): bump requests to 2.33.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -335,7 +335,7 @@ regex==2026.2.28
     # via
     #   -c requirements/common-constraints.txt
     #   tiktoken
-requests==2.32.5
+requests==2.33.0
     # via
     #   -c requirements/common-constraints.txt
     #   mixpanel


### PR DESCRIPTION
A few dependencies in the requirements file have CVEs fixed in newer versions:

- `requests` 2.32.5 -> 2.33.0 (CVE-2026-25645)

Bumped each one to the minimum safe version.