### PR TITLE
ci: pin issue workflow actions

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,10 +11,10 @@ jobs:
       issues: write  # Required to modify issues
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
           


### PR DESCRIPTION
## Summary
- pin `actions/checkout@v3` to its immutable commit in the scheduled issue-processing workflow
- pin `actions/setup-python@v4` to its immutable commit in the same workflow
- leave workflow behavior, permissions, and script execution unchanged

## Why
`.github/workflows/issues.yml` runs on a schedule with `issues: write`, so pinning the marketplace actions removes tag-retarget drift on a privileged workflow without changing its behavior.

## Validation
- `git diff --check`
- `python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/issues.yml').read_text(encoding='utf-8')); print('yaml-parse-ok')"`
- bounded manual review of the two-line workflow-only diff

## Notes
- This intentionally stays scoped to one workflow file.
- I did not change permissions, schedule, Python version, or the issue-processing script itself.

