### PR TITLE
fix: check len(errors) before string conversion in udiff_coder.py

### DIFF
--- a/aider/coders/udiff_coder.py
+++ b/aider/coders/udiff_coder.py
@@ -112,8 +112,9 @@ class UnifiedDiffCoder(Coder):
             self.io.write_text(full_path, content)
 
         if errors:
+            some_hunks_applied = len(errors) < len(uniq)
             errors = "\n\n".join(errors)
-            if len(errors) < len(uniq):
+            if some_hunks_applied:
                 errors += other_hunks_applied
             raise ValueError(errors)
 


### PR DESCRIPTION
## Summary

https://github.com/Aider-AI/aider/blob/f09d70659ae90a0d068c80c288cbb55f2d3c3755/aider/coders/udiff_coder.py#L114-L118
The `errors` list is converted to string before its length is compared to `uniq` list.

## Verification
- `python -m pytest tests/basic/test_coder.py`