### PR TITLE
refactor : remove unused class-level tree_cache variable

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -705,8 +705,6 @@ class RepoMap:
         spin.end()
         return best_tree
 
-    tree_cache = dict()
-
     def render_tree(self, abs_fname, rel_fname, lois):
         mtime = self.get_mtime(abs_fname)
         key = (rel_fname, tuple(sorted(lois)), mtime)


### PR DESCRIPTION
`tree_cache = dict()` is initialized at the class level (line 708) and never used.
Methods in RepoMap use `self.tree_cache`.