### PR TITLE
fix(io): tool_output falls back to ASCII on UnicodeEncodeError (#5029)

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -1009,7 +1009,20 @@ class InputOutput:
             style["reverse"] = bold
 
         style = RichStyle(**style)
-        self.console.print(*messages, style=style)
+        try:
+            self.console.print(*messages, style=style)
+        except UnicodeEncodeError:
+            # Legacy Windows terminals on non-UTF-8 code pages (cp1251 etc.)
+            # can't encode characters like U+22EE that Rich uses for tree/box
+            # drawing. Fall back to ASCII-safe output to keep the tool usable.
+            # Matches the fallback already present in _tool_message below.
+            ascii_messages = [
+                str(m.plain if isinstance(m, Text) else m)
+                .encode("ascii", errors="replace")
+                .decode("ascii")
+                for m in messages
+            ]
+            self.console.print(*ascii_messages, style=style)
 
     def get_assistant_mdstream(self):
         mdargs = dict(

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -383,6 +383,32 @@ class TestInputOutputMultilineMode(unittest.TestCase):
             # The invalid Unicode should be replaced with '?'
             self.assertEqual(converted_message, "Hello ?World")
 
+    def test_tool_output_unicode_fallback(self):
+        """tool_output must not crash on Unicode that the terminal can't encode.
+
+        Regression guard for issue #5029 — /map output on Windows cp1251 raised
+        UnicodeEncodeError on the vertical-ellipsis char (U+22EE) used by Rich
+        for tree/box drawing.
+        """
+        io = InputOutput(pretty=False, fancy_input=False)
+
+        with patch.object(io.console, "print") as mock_print:
+            # First call raises (cp1251 can't encode U+22EE), second call succeeds.
+            mock_print.side_effect = [
+                UnicodeEncodeError("charmap", "", 0, 1, "undefined"),
+                None,
+            ]
+            # U+22EE is the character that crashed the legacy-Windows renderer in #5029.
+            io.tool_output("Repo map:\n\u22ee line 1\n\u22ee line 2")
+
+            # The fallback must be invoked.
+            self.assertEqual(mock_print.call_count, 2)
+            # The retry should send plain-ASCII content (U+22EE → '?').
+            args, _ = mock_print.call_args
+            joined = " ".join(str(a) for a in args)
+            self.assertNotIn("\u22ee", joined)
+            self.assertIn("?", joined)
+
     def test_multiline_mode_restored_after_interrupt(self):
         """Test that multiline mode is restored after KeyboardInterrupt"""
         io = InputOutput(fancy_input=True)


### PR DESCRIPTION
## Why

Closes #5029.

`/map` output on Windows with cp1251 (Russian) locale crashed with an uncaught `UnicodeEncodeError`. Root cause: Rich uses U+22EE (vertical ellipsis, `⋮`) for tree/box drawing, and the legacy Windows terminal's cp1251 codec can't encode it.

The crash traceback points at `aider/io.py:1012` inside `tool_output`:

```
File "io.py", line 1012, in tool_output
    self.console.print(*messages, style=style)
```

## What

`_tool_message` already handles this exact case (see current code lines 979–986): catch `UnicodeEncodeError`, re-encode with `errors='replace'`, retry the print.

`tool_output` was missing the same handler. This PR mirrors the existing fallback into `tool_output` — same pattern, same semantics. No new public API, no behavior change on UTF-8 platforms.

## Diff shape

- `aider/io.py`: +14 lines (try/except in `tool_output`)
- `tests/basic/test_io.py`: +26 lines (regression test)

## Test

New test `test_tool_output_unicode_fallback` models the exact #5029 scenario — U+22EE message, first `console.print` raises `UnicodeEncodeError`, second succeeds with the character replaced.

```
$ pytest tests/basic/test_io.py -k unicode -v
test_autocompleter_with_unicode_file PASSED
test_tool_message_unicode_fallback PASSED
test_tool_output_unicode_fallback PASSED
3 passed
```

## Scope

Deliberately narrow — just the crash in #5029. Broader robustness (forcing UTF-8 console mode on Windows, warning users, etc.) is a larger design discussion and not needed to close this issue.