### PR TITLE
docs: add QuickSilver Pro as an LLM provider option

### DIFF
--- a/aider/website/docs/llms/quicksilverpro.md
+++ b/aider/website/docs/llms/quicksilverpro.md
@@ -1,0 +1,37 @@
+---
+parent: Connecting to LLMs
+nav_order: 450
+---
+
+# QuickSilver Pro
+
+Aider can connect to open-source models (DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B)
+through [QuickSilver Pro](https://quicksilverpro.io)'s OpenAI-compatible API.
+
+First, install aider:
+
+{% include install.md %}
+
+Get a QuickSilver Pro API key at [quicksilverpro.io/dashboard](https://quicksilverpro.io/dashboard),
+then point aider at the endpoint:
+
+```
+# Mac/Linux:
+export OPENAI_API_BASE=https://api.quicksilverpro.io/v1
+export OPENAI_API_KEY=<key>
+
+# Windows:
+setx OPENAI_API_BASE https://api.quicksilverpro.io/v1
+setx OPENAI_API_KEY <key>
+```
+
+Then run aider with one of the supported models:
+
+```bash
+aider --model openai/deepseek-v3     # general coding, JSON, tool calls
+aider --model openai/deepseek-r1     # reasoning-heavy tasks
+aider --model openai/qwen3.5-35b     # 262K context, long-document RAG
+```
+
+The `openai/` prefix tells aider to use the OpenAI-compatible client; the
+segment after the slash is the QuickSilver Pro model ID.


### PR DESCRIPTION
## Summary

Adds a short documentation page for [QuickSilver Pro](https://quicksilverpro.io) under `aider/website/docs/llms/`, alongside the existing provider pages (openrouter, deepseek, groq, etc.).

QuickSilver Pro exposes an OpenAI-compatible endpoint serving DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B. Aider already works against any OpenAI-compatible endpoint; this page just saves new users from having to figure out the env-var incantation themselves.

## Scope

- Docs only. No code changes, no dependency changes, no test impact.
- 1 new file: `aider/website/docs/llms/quicksilverpro.md` (37 lines).

## Disclosure

I'm affiliated with QuickSilver Pro. Happy to adjust tone, trim, or split further if you prefer a lighter treatment (e.g., a single mention in `other.md` instead of a dedicated page) — whatever fits the repo's norm.