### PR TITLE
fix: fall back to ASCII in tool_output

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -1009,7 +1009,15 @@ class InputOutput:
             style["reverse"] = bold
 
         style = RichStyle(**style)
-        self.console.print(*messages, style=style)
+        try:
+            self.console.print(*messages, style=style)
+        except UnicodeEncodeError:
+            safe_messages = []
+            for message in messages:
+                if isinstance(message, Text):
+                    message = message.plain
+                safe_messages.append(str(message).encode("ascii", errors="replace").decode("ascii"))
+            self.console.print(*safe_messages, style=style)
 
     def get_assistant_mdstream(self):
         mdargs = dict(

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -383,6 +383,23 @@ class TestInputOutputMultilineMode(unittest.TestCase):
             # The invalid Unicode should be replaced with '?'
             self.assertEqual(converted_message, "Hello ?World")
 
+    def test_tool_output_unicode_fallback(self):
+        """Test that tool_output falls back to ASCII-safe output on encoding errors"""
+        io = InputOutput(pretty=False, fancy_input=False)
+
+        with patch.object(io.console, "print") as mock_print:
+            mock_print.side_effect = [
+                UnicodeEncodeError("cp1251", "⋮ repo map line", 0, 1, "invalid"),
+                None,
+            ]
+
+            io.tool_output("⋮ repo map line")
+
+            self.assertEqual(mock_print.call_count, 2)
+            args, kwargs = mock_print.call_args
+            converted_message = args[0]
+            self.assertEqual(converted_message, "? repo map line")
+
     def test_multiline_mode_restored_after_interrupt(self):
         """Test that multiline mode is restored after KeyboardInterrupt"""
         io = InputOutput(fancy_input=True)


### PR DESCRIPTION
Fixes #5029.

`/map` prints the repository map through `InputOutput.tool_output()`. When Rich raises a `UnicodeEncodeError` on non-UTF-8 consoles, that path currently lets the exception escape even though `_tool_message()` already retries with ASCII-safe output.

This patch applies the same fallback in `tool_output()`, so repo map output degrades to ASCII instead of crashing.

Validation:
- `pytest -q tests/basic/test_io.py -k 'tool_output_unicode_fallback or tool_message_unicode_fallback'`
- mocked repro for `tool_output("⋮ repo map line")` now retries and prints `? repo map line`

Note: `tests/basic/test_io.py::TestInputOutput::test_color_initialization` still fails on clean `main` in this environment and is unrelated to this change.
