### PR TITLE
Add bash/shell repomap support

### DIFF
--- a/aider/queries/tree-sitter-language-pack/bash-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/bash-tags.scm
@@ -1,0 +1,6 @@
+; Bash / shell script function definitions.
+; Matches both POSIX-style `name() { ... }` and keyword-style
+; `function name() { ... }` / `function name { ... }`.
+
+(function_definition
+  name: (word) @name.definition.function) @definition.function

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -284,6 +284,9 @@ class TestRepoMapAllLanguages(unittest.TestCase):
         self.GPT35 = Model("gpt-3.5-turbo")
         self.fixtures_dir = Path(__file__).parent.parent / "fixtures" / "languages"
 
+    def test_language_bash(self):
+        self._test_language_repo_map("bash", "sh", "greet")
+
     def test_language_c(self):
         self._test_language_repo_map("c", "c", "main")
 

--- a/tests/fixtures/languages/bash/test.sh
+++ b/tests/fixtures/languages/bash/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Sample bash script used as a repomap fixture.
+
+# POSIX-style function definition
+greet() {
+    local name="${1:-World}"
+    echo "Hello, ${name}!"
+}
+
+# Keyword-style function definition
+function deploy() {
+    local env="${1:-production}"
+    echo "Deploying to ${env}..."
+}
+
+# Another helper
+function cleanup() {
+    echo "Cleaning up..."
+    rm -f /tmp/deploy_lock
+}
+
+# Main entry point
+main() {
+    greet "$@"
+    deploy
+    cleanup
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds tree-sitter query support for Bash/shell scripts so that `.sh`, `.bash`, and `.zsh` files appear in the repo map with their function definitions.

**New file:** `aider/queries/tree-sitter-language-pack/bash-tags.scm`

```scheme
; Bash / shell script function definitions.
; Matches both POSIX-style `name() { ... }` and keyword-style
; `function name() { ... }` / `function name { ... }`.

(function_definition
  name: (word) @name.definition.function) @definition.function
```

This captures both declaration styles supported by the tree-sitter-bash grammar:

```bash
# POSIX-style
greet() { echo "Hello"; }

# Keyword-style
function deploy() { echo "Deploying"; }
```

## Test plan

- Added `tests/fixtures/languages/bash/test.sh` with representative function definitions
- Added `test_language_bash` to `TestRepoMapAllLanguages` — verifies that `greet` appears in the generated repo map
- `python -m pytest tests/basic/test_repomap.py::TestRepoMapAllLanguages::test_language_bash -xvs` passes locally