### PR TITLE
Add mistral-small-2603 model settings

### DIFF
--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -3126,3 +3126,9 @@
   use_repo_map: true
   use_temperature: false
   accepts_settings: ["reasoning_effort"]
+
+- name: mistral/mistral-small-2603
+  edit_format: diff
+  weak_model_name: mistral/mistral-small-latest
+  use_repo_map: true
+  reminder: sys


### PR DESCRIPTION
Closes #5000.

Reporter got `The LLM did not conform to the edit format` running aider against `mistral/mistral-small-2603`. The repo had no model-settings entry for that model name, so it fell through to default `edit_format: whole`, which mistral-small didn't reliably produce.

Adds one entry to `aider/resources/model-settings.yml` matching the coder-class pattern used by recent additions (#4698, #4656):

```yaml
- name: mistral/mistral-small-2603
  edit_format: diff
  weak_model_name: mistral/mistral-small-latest
  use_repo_map: true
  reminder: sys
```

litellm already routes `mistral/mistral-small-2603`, so no metadata addition is needed.