### PR TITLE
fix: handle git config lock errors gracefully

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -141,13 +141,20 @@ def setup_git(git_root, io):
     if user_name and user_email:
         return repo.working_tree_dir
 
-    with repo.config_writer() as git_config:
+    try:
+        with repo.config_writer() as git_config:
+            if not user_name:
+                git_config.set_value("user", "name", "Your Name")
+                io.tool_warning('Update git name with: git config user.name "Your Name"')
+            if not user_email:
+                git_config.set_value("user", "email", "you@example.com")
+                io.tool_warning('Update git email with: git config user.email "you@example.com"')
+    except OSError as err:
+        io.tool_warning(f"Unable to update git config automatically: {err}")
         if not user_name:
-            git_config.set_value("user", "name", "Your Name")
-            io.tool_warning('Update git name with: git config user.name "Your Name"')
+            io.tool_warning('Set git name with: git config user.name "Your Name"')
         if not user_email:
-            git_config.set_value("user", "email", "you@example.com")
-            io.tool_warning('Update git email with: git config user.email "you@example.com"')
+            io.tool_warning('Set git email with: git config user.email "you@example.com"')
 
     return repo.working_tree_dir
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -126,6 +126,22 @@ class TestMain(TestCase):
         self.assertTrue(gitignore.exists())
         self.assertEqual(".aider*", gitignore.read_text().splitlines()[0])
 
+    def test_setup_git_handles_config_writer_lock(self):
+        with IgnorantTemporaryDirectory() as git_dir:
+            git.Repo.init(git_dir)
+            io = MagicMock()
+            with patch.object(git.Repo, "config_writer", side_effect=OSError("config.lock exists")):
+                git_root = setup_git(str(git_dir), io)
+
+            self.assertEqual(Path(git_root).resolve(), Path(git_dir).resolve())
+            io.tool_warning.assert_any_call(
+                "Unable to update git config automatically: config.lock exists"
+            )
+            io.tool_warning.assert_any_call('Set git name with: git config user.name "Your Name"')
+            io.tool_warning.assert_any_call(
+                'Set git email with: git config user.email "you@example.com"'
+            )
+
     def test_check_gitignore(self):
         with GitTemporaryDirectory():
             os.environ["GIT_CONFIG_GLOBAL"] = "globalgitconfig"


### PR DESCRIPTION
## Summary
- catch `OSError` from `repo.config_writer()` in `setup_git()`
- warn the user how to set `user.name` and `user.email` manually instead of crashing when `.git/config.lock` exists
- add a regression test for the locked config path

## Testing
- `python3 -m pytest tests/basic/test_main.py -k "setup_git or config_writer_lock"`
- `python3 -m ruff check aider/main.py tests/basic/test_main.py`

Fixes #5060