### PR TITLE
fix: handle corrupt git index errors in sanity check

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -435,6 +435,8 @@ def sanity_check_repo(repo, io):
     except AssertionError as exc:
         error_msg = str(exc)
         bad_ver = True
+    except Exception as exc:
+        error_msg = str(exc)
 
     if bad_ver:
         io.tool_error("Aider only works with git repos with version number 1 or 2.")

--- a/tests/basic/test_sanity_check_repo.py
+++ b/tests/basic/test_sanity_check_repo.py
@@ -172,6 +172,18 @@ def test_sanity_check_repo_with_corrupt_repo(create_repo, mock_io):
     mock_io.tool_output.assert_called_with(str(git_error))
 
 
+def test_sanity_check_repo_with_corrupt_git_index(create_repo, mock_io):
+    _, repo = create_repo
+    git_error = struct.error("unpack requires a buffer of 8 bytes")
+    mock_repo_obj = mock_repo_wrapper(repo, git_repo_error=git_error)
+
+    result = sanity_check_repo(mock_repo_obj, mock_io)
+
+    assert result is False
+    mock_io.tool_error.assert_called_with("Unable to read git repository, it may be corrupt?")
+    mock_io.tool_output.assert_called_with(str(git_error))
+
+
 def test_sanity_check_repo_with_no_repo(mock_io):
     # Call the function with repo=None
     result = sanity_check_repo(None, mock_io)


### PR DESCRIPTION
## Summary
- catch non-GitPython exceptions raised while probing tracked files in `sanity_check_repo()`
- surface corrupt git index errors as the existing repository corruption message instead of crashing
- add a regression test for the `struct.error` path seen with damaged indexes

## Testing
- `python3 -m pytest tests/basic/test_sanity_check_repo.py -k "corrupt_git_index or corrupt_repo or git_index_version_greater_than_2"`
- `python3 -m ruff check aider/main.py tests/basic/test_sanity_check_repo.py`

Fixes #5061