### PR TITLE
fix: report import errors from coder runs

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -1130,6 +1130,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             coder.run(with_message=args.message)
         except SwitchCoder:
             pass
+        except ImportError as err:
+            io.tool_error(str(err))
+            io.tool_output("Error loading required imports. Did you install aider properly?")
+            io.offer_url(urls.install_properly, "Open documentation url for more info?")
+            analytics.event("exit", reason="Message run import error")
+            return 1
         analytics.event("exit", reason="Completed --message")
         return
 
@@ -1145,6 +1151,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         except IOError as e:
             io.tool_error(f"Error reading message file: {e}")
             analytics.event("exit", reason="Message file IO error")
+            return 1
+        except ImportError as err:
+            io.tool_error(str(err))
+            io.tool_output("Error loading required imports. Did you install aider properly?")
+            io.offer_url(urls.install_properly, "Open documentation url for more info?")
+            analytics.event("exit", reason="Message file import error")
             return 1
 
         analytics.event("exit", reason="Completed --message-file")
@@ -1178,6 +1190,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
             if switch.kwargs.get("show_announcements") is not False:
                 coder.show_announcements()
+        except ImportError as err:
+            io.tool_error(str(err))
+            io.tool_output("Error loading required imports. Did you install aider properly?")
+            io.offer_url(urls.install_properly, "Open documentation url for more info?")
+            analytics.event("exit", reason="Main coder.run import error")
+            return 1
 
 
 def is_first_run_of_new_version(io, verbose=False):

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -384,6 +384,23 @@ class TestMain(TestCase):
 
     @patch("aider.main.InputOutput")
     @patch("aider.coders.base_coder.Coder.run")
+    def test_message_import_error_is_reported(self, mock_run, MockInputOutput):
+        mock_run.side_effect = ImportError("cannot import name 'BaseTransport' from 'httpx'")
+        mock_io_instance = MockInputOutput.return_value
+
+        result = main(["--message", "test message"], input=DummyInput(), output=DummyOutput())
+
+        self.assertEqual(result, 1)
+        mock_io_instance.tool_error.assert_called_with(
+            "cannot import name 'BaseTransport' from 'httpx'"
+        )
+        mock_io_instance.tool_output.assert_any_call(
+            "Error loading required imports. Did you install aider properly?"
+        )
+        mock_io_instance.offer_url.assert_called_once()
+
+    @patch("aider.main.InputOutput")
+    @patch("aider.coders.base_coder.Coder.run")
     def test_default_yes(self, mock_run, MockInputOutput):
         test_message = "test message"
 


### PR DESCRIPTION
## Summary
- catch `ImportError` around `coder.run()` entry points in `main()`
- report dependency/import failures as user-facing errors with the existing install docs link instead of crashing with a traceback
- add a regression test for the `--message` path

## Testing
- `python3 -m pytest tests/basic/test_main.py -k "message_import_error_is_reported or main_message_adds_to_input_history"`
- `python3 -m ruff check aider/main.py tests/basic/test_main.py`

Fixes #5051