### PR TITLE
fix: report model import errors at startup

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -819,13 +819,20 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             )
             return 1
 
-    main_model = models.Model(
-        args.model,
-        weak_model=args.weak_model,
-        editor_model=args.editor_model,
-        editor_edit_format=args.editor_edit_format,
-        verbose=args.verbose,
-    )
+    try:
+        main_model = models.Model(
+            args.model,
+            weak_model=args.weak_model,
+            editor_model=args.editor_model,
+            editor_edit_format=args.editor_edit_format,
+            verbose=args.verbose,
+        )
+    except ImportError as err:
+        io.tool_error(str(err))
+        io.tool_output("Error loading required imports. Did you install aider properly?")
+        io.offer_url(urls.install_properly, "Open documentation url for more info?")
+        analytics.event("exit", reason="Model initialization import error")
+        return 1
 
     # Check if deprecated remove_reasoning is set
     if main_model.remove_reasoning is not None:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -391,6 +391,25 @@ class TestMain(TestCase):
         args, kwargs = MockInputOutput.call_args
         self.assertEqual(args[1], None)
 
+    @patch("aider.main.models.Model")
+    @patch("aider.main.InputOutput")
+    def test_model_import_error_is_reported(self, MockInputOutput, mock_model):
+        mock_model.side_effect = ImportError(
+            "cannot import name 'is_type_alias_type' from 'openai._utils'"
+        )
+        mock_io_instance = MockInputOutput.return_value
+
+        result = main(["--yes", "--exit"], input=DummyInput(), output=DummyOutput())
+
+        self.assertEqual(result, 1)
+        mock_io_instance.tool_error.assert_called_with(
+            "cannot import name 'is_type_alias_type' from 'openai._utils'"
+        )
+        mock_io_instance.tool_output.assert_any_call(
+            "Error loading required imports. Did you install aider properly?"
+        )
+        mock_io_instance.offer_url.assert_called_once()
+
     def test_dark_mode_sets_code_theme(self):
         # Mock InputOutput to capture the configuration
         with patch("aider.main.InputOutput") as MockInputOutput:


### PR DESCRIPTION
## Summary
- catch `ImportError` while constructing the main model in `main()`
- show the existing install guidance instead of crashing during startup when `litellm`/`openai` dependencies are incompatible
- add a regression test for the startup path

## Testing
- `python3 -m pytest tests/basic/test_main.py -k "model_import_error_is_reported or default_yes"`
- `python3 -m ruff check aider/main.py tests/basic/test_main.py`

Fixes #5055