### PR TITLE
fix: read gitignore files as utf-8

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -56,7 +56,7 @@ def load_gitignores(gitignore_paths: list[Path]) -> Optional[PathSpec]:
     ]  # Always ignore
     for path in gitignore_paths:
         if path.exists():
-            with open(path) as f:
+            with open(path, encoding="utf-8", errors="replace") as f:
                 patterns.extend(f.readlines())
 
     return PathSpec.from_lines(GitWildMatchPattern, patterns) if patterns else None

--- a/tests/basic/test_watch.py
+++ b/tests/basic/test_watch.py
@@ -72,6 +72,28 @@ def test_gitignore_patterns():
     tmp_gitignore.unlink()
 
 
+def test_gitignore_patterns_read_utf8(tmp_path, monkeypatch):
+    from aider.watch import load_gitignores
+
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        "ignored.txt\n# Не включать временные файлы MS\n",
+        encoding="utf-8",
+    )
+    original_open = open
+
+    def cp1252_default_open(file, mode="r", *args, **kwargs):
+        if Path(file) == gitignore and "b" not in mode and kwargs.get("encoding") is None:
+            kwargs["encoding"] = "cp1252"
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", cp1252_default_open)
+
+    spec = load_gitignores([gitignore])
+
+    assert spec.match_file("ignored.txt")
+
+
 def test_get_roots_to_watch(tmp_path):
     # Create a test directory structure
     (tmp_path / "included").mkdir()


### PR DESCRIPTION
## Summary
- Read watcher gitignore files with explicit UTF-8 decoding instead of the platform default encoding
- Use replacement for malformed bytes so file watching does not crash on decode errors
- Add a regression test that simulates a Windows cp1252 default while reading a UTF-8 gitignore

## Testing
- `python3 -m pytest tests/basic/test_watch.py`
- `python3 -m ruff check aider/watch.py tests/basic/test_watch.py`

Fixes #2888