### PR TITLE
Handle unwritable version check cache

### DIFF
--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -12,6 +12,15 @@ from aider.dump import dump  # noqa: F401
 VERSION_CHECK_FNAME = Path.home() / ".aider" / "caches" / "versioncheck"
 
 
+def _touch_version_check_file(io=None, verbose=False):
+    try:
+        VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
+        VERSION_CHECK_FNAME.touch()
+    except OSError as err:
+        if verbose and io:
+            io.tool_warning(f"Unable to write version check cache: {err}")
+
+
 def install_from_main_branch(io):
     """
     Install the latest version of aider from the main branch of the GitHub repository.
@@ -84,15 +93,14 @@ def check_version(io, just_check=False, verbose=False):
             io.tool_output(f"Current version: {current_version}")
             io.tool_output(f"Latest version: {latest_version}")
 
-        is_update_available = packaging.version.parse(latest_version) > packaging.version.parse(
-            current_version
-        )
+        is_update_available = packaging.version.parse(
+            latest_version
+        ) > packaging.version.parse(current_version)
     except Exception as err:
         io.tool_error(f"Error checking pypi for new version: {err}")
         return False
     finally:
-        VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
-        VERSION_CHECK_FNAME.touch()
+        _touch_version_check_file(io, verbose)
 
     ###
     # is_update_available = True

--- a/tests/basic/test_versioncheck.py
+++ b/tests/basic/test_versioncheck.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock, patch
+
+from aider import versioncheck
+
+
+def test_check_version_ignores_unwritable_cache_path(tmp_path, monkeypatch):
+    blocked_parent = tmp_path / "blocked"
+    blocked_parent.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        versioncheck, "VERSION_CHECK_FNAME", blocked_parent / "versioncheck"
+    )
+
+    io = Mock()
+    with patch("requests.get", side_effect=RuntimeError("offline")):
+        assert versioncheck.check_version(io) is False
+
+    io.tool_error.assert_called_once_with(
+        "Error checking pypi for new version: offline"
+    )


### PR DESCRIPTION
Fixes #2865.

The version check currently writes `~/.aider/caches/versioncheck` in a `finally` block. In Docker/user setups where `HOME` resolves to an unwritable location such as `/`, that cache write can raise `PermissionError` and crash startup even though the version check itself is non-critical.

This change wraps the cache write in a small helper and ignores `OSError` by default. In verbose mode it reports the skipped cache write as a warning.

Local verification:

* `python3 -m pytest tests/basic/test_versioncheck.py`
* `ruff check aider/versioncheck.py tests/basic/test_versioncheck.py`
* `ruff format --check aider/versioncheck.py tests/basic/test_versioncheck.py`
