### PR TITLE
platform_info: also catch OSError from Windows WMI calls in platform.platform()

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1128,8 +1128,11 @@ class Coder:
         platform_text = ""
         try:
             platform_text = f"- Platform: {platform.platform()}\n"
-        except KeyError:
-            # Skip platform info if it can't be retrieved
+        except (KeyError, OSError):
+            # Windows 11 WMI calls inside platform.platform() can fail with
+            # `OSError: [WinError 258] The wait operation timed out` (#3464),
+            # in addition to the previously-seen `KeyError: 'Architecture'`
+            # path. Skip platform info on either rather than crashing aider.
             platform_text = "- Platform information unavailable\n"
 
         shell_var = "COMSPEC" if os.name == "nt" else "SHELL"


### PR DESCRIPTION
Fixes #3464.

`get_platform_info` already catches `KeyError` from `platform.platform()` (introduced after #1234-style traces). The user's Windows 11 trace shows the *same* function failing with `OSError: [WinError 258] The wait operation timed out` from `_wmi.exec_query`, which escapes the current handler and crashes aider before the first message round-trip. Extend the except clause to `(KeyError, OSError)` and keep the existing `Platform information unavailable` fallback.