### PR TITLE
main: handle NoSuchPathError from git.Repo when path resolution fails

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -62,7 +62,12 @@ def get_git_root():
     try:
         repo = git.Repo(search_parent_directories=True)
         return repo.working_tree_dir
-    except (git.InvalidGitRepositoryError, FileNotFoundError):
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError):
+        # Windows paths containing `$` (e.g. `F:\$data\...` from
+        # `mklink /D`-style mounts) reach here as `NoSuchPathError`
+        # because git-python resolves them through the parent search and
+        # fails the existence check (#2957). Treat the same as no repo —
+        # aider operates without one — instead of crashing on startup.
         return None
 
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -66,8 +66,8 @@ def get_git_root():
         # Windows paths containing `$` (e.g. `F:\$data\...` from
         # `mklink /D`-style mounts) reach here as `NoSuchPathError`
         # because git-python resolves them through the parent search and
-        # fails the existence check (#2957). Treat the same as no repo —
-        # aider operates without one — instead of crashing on startup.
+        # fails the existence check (#2957). Treat the same as no repo,
+        # aider operates without one, instead of crashing on startup.
         return None
 
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -14,7 +14,7 @@ from prompt_toolkit.output import DummyOutput
 from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
-from aider.main import check_gitignore, load_dotenv_files, main, setup_git
+from aider.main import check_gitignore, get_git_root, load_dotenv_files, main, setup_git
 from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory, make_repo
 
 
@@ -1481,3 +1481,10 @@ class TestMain(TestCase):
             )
         for call in mock_io_instance.tool_warning.call_args_list:
             self.assertNotIn("Cost estimates may be inaccurate", call[0][0])
+
+    @patch("aider.main.git.Repo")
+    def test_get_git_root_no_such_path(self, mock_repo):
+        """get_git_root returns None instead of raising when git raises NoSuchPathError."""
+        mock_repo.side_effect = git.NoSuchPathError("F:\\$data\\python")
+        result = get_git_root()
+        self.assertIsNone(result)


### PR DESCRIPTION
Fixes #2957.

`get_git_root` only catches `InvalidGitRepositoryError` and `FileNotFoundError`. Windows paths containing `$` (e.g. `F:\\$data\\python\\...` from `mklink /D` directory junctions) reach `git.Repo(search_parent_directories=True)` and fall through with `NoSuchPathError` instead, which escapes the handler and crashes aider on startup. Add `git.NoSuchPathError` to the except tuple so aider just falls through to the no-repo path the same way it already does for invalid-repo / missing-file cases.