### PR TITLE
watch: open .gitignore files as utf-8 with permissive fallback

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -56,8 +56,17 @@ def load_gitignores(gitignore_paths: list[Path]) -> Optional[PathSpec]:
     ]  # Always ignore
     for path in gitignore_paths:
         if path.exists():
-            with open(path) as f:
-                patterns.extend(f.readlines())
+            # `.gitignore` files often contain bytes that don't round-trip
+            # through Windows' cp1252 default codec — comments in non-ASCII,
+            # files dropped in by Unix tools, etc. Read with utf-8 first and
+            # fall back to a permissive decode so an unreadable .gitignore
+            # doesn't crash aider on startup (#2888).
+            try:
+                with open(path, encoding="utf-8") as f:
+                    patterns.extend(f.readlines())
+            except UnicodeDecodeError:
+                with open(path, encoding="utf-8", errors="replace") as f:
+                    patterns.extend(f.readlines())
 
     return PathSpec.from_lines(GitWildMatchPattern, patterns) if patterns else None
 

--- a/aider/watch.py
+++ b/aider/watch.py
@@ -57,7 +57,7 @@ def load_gitignores(gitignore_paths: list[Path]) -> Optional[PathSpec]:
     for path in gitignore_paths:
         if path.exists():
             # `.gitignore` files often contain bytes that don't round-trip
-            # through Windows' cp1252 default codec — comments in non-ASCII,
+            # through Windows' cp1252 default codec, comments in non-ASCII,
             # files dropped in by Unix tools, etc. Read with utf-8 first and
             # fall back to a permissive decode so an unreadable .gitignore
             # doesn't crash aider on startup (#2888).

--- a/tests/basic/test_watch.py
+++ b/tests/basic/test_watch.py
@@ -15,6 +15,21 @@ class MinimalCoder:
         return fname
 
 
+def test_load_gitignores_utf8_fallback(tmp_path):
+    """load_gitignores does not crash on .gitignore files with non-UTF-8 bytes."""
+    from aider.watch import load_gitignores
+
+    # Write a .gitignore that contains a Latin-1 byte (0xe9 = 'e with acute')
+    # invalid in strict UTF-8 streams.
+    bad = tmp_path / ".gitignore"
+    bad.write_bytes(b"*.log\n# caf\xe9\n*.tmp\n")
+
+    spec = load_gitignores([bad])
+    assert spec is not None
+    assert spec.match_file("foo.log")
+    assert spec.match_file("bar.tmp")
+
+
 def test_gitignore_patterns():
     """Test that gitignore patterns are properly loaded and matched"""
     from pathlib import Path


### PR DESCRIPTION
Fixes #2888.

`load_gitignores` opened each `.gitignore` with the platform default codec, which on Windows is cp1252. `.gitignore` files commonly contain comments or filenames in non-ASCII (or bytes from Unix tooling), so the user's traceback hits `UnicodeDecodeError` from `cp1252.py` and crashes aider on startup before the file watcher can come up. Open with `encoding='utf-8'` and fall back to `errors='replace'` if the file is genuinely not utf-8, same shape as the existing source-file decoder in aider/io.py.