### PR TITLE
versioncheck: tolerate OSError when creating version-check marker

### DIFF
--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -91,8 +91,16 @@ def check_version(io, just_check=False, verbose=False):
         io.tool_error(f"Error checking pypi for new version: {err}")
         return False
     finally:
-        VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
-        VERSION_CHECK_FNAME.touch()
+        try:
+            VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
+            VERSION_CHECK_FNAME.touch()
+        except OSError:
+            # Some sandboxes set HOME=/ (or leave it unset and the resolver
+            # falls back to /), so VERSION_CHECK_FNAME ends up rooted in /
+            # and `mkdir` fails with PermissionError (#2865). The cache
+            # marker is purely an optimisation; skip it instead of crashing
+            # aider on startup.
+            pass
 
     ###
     # is_update_available = True


### PR DESCRIPTION
Fixes #2865.

`check_version`'s `finally` block called `VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)` and `touch()` unconditionally. Sandboxes that leave `HOME` unset (or set it to `/`) end up resolving `Path.home()` to `/`, so `VERSION_CHECK_FNAME` is `/.aider/caches/versioncheck` and `mkdir` fails with `PermissionError: [Errno 13] Permission denied: '/.aider'`. The exception escapes through the finally and crashes aider on startup. The marker is purely an optimisation, wrap the two filesystem ops in a `try / except OSError` so a missing or unwritable home directory doesn't take aider down.