### PR TITLE
fix(coders): catch doubled-prefix hallucinations in edit-block headers

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -584,6 +584,16 @@ def find_filename(lines, fence, valid_fnames):
             if fname == Path(vfn).name:
                 return vfn
 
+    # Check for doubled-prefix hallucinations like ".claude/.claude/foo.json"
+    # when valid_fnames contains ".claude/foo.json". Try progressively shorter
+    # suffixes against valid_fnames.
+    for fname in filenames:
+        parts = Path(fname).parts
+        for i in range(1, len(parts)):
+            candidate = str(Path(*parts[i:]))
+            if candidate in valid_fnames:
+                return candidate
+
     # Perform fuzzy matching with valid_fnames
     for fname in filenames:
         close_matches = difflib.get_close_matches(fname, valid_fnames, n=1, cutoff=0.8)

--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -68,8 +68,20 @@ class WholeFileCoder(Coder):
                     # Did gpt prepend a bogus dir? It especially likes to
                     # include the path/to prefix from the one-shot example in
                     # the prompt.
-                    if fname and fname not in chat_files and Path(fname).name in chat_files:
-                        fname = Path(fname).name
+                    if fname and fname not in chat_files:
+                        if Path(fname).name in chat_files:
+                            fname = Path(fname).name
+                        else:
+                            # Catch doubled-prefix hallucinations like
+                            # ".claude/.claude/foo.json" when chat_files contains
+                            # ".claude/foo.json". Try progressively shorter
+                            # suffixes against chat_files.
+                            parts = Path(fname).parts
+                            for i in range(1, len(parts)):
+                                candidate = str(Path(*parts[i:]))
+                                if candidate in chat_files:
+                                    fname = candidate
+                                    break
                 if not fname:  # blank line? or ``` was on first line i==0
                     if saw_fname:
                         fname = saw_fname

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -49,6 +49,15 @@ class TestUtils(unittest.TestCase):
         lines = [r"\windows__init__.py", "```"]
         self.assertEqual(eb.find_filename(lines, fence, valid_fnames), r"\windows\__init__.py")
 
+        # Test doubled-prefix hallucination where fuzzy match falls below cutoff.
+        # LLM emits "sub/dir/sub/dir/foo.py"; valid contains "sub/dir/foo.py".
+        # SequenceMatcher ratio is 0.778 (< 0.8 cutoff) so fuzzy match misses;
+        # basename "foo.py" doesn't equal the full LLM-emitted path. Suffix-strip
+        # is the only mechanism that recovers the canonical path here.
+        valid_fnames_doubled = ["sub/dir/foo.py", "other.py"]
+        lines = ["sub/dir/sub/dir/foo.py", "```"]
+        self.assertEqual(eb.find_filename(lines, fence, valid_fnames_doubled), "sub/dir/foo.py")
+
     # fuzzy logic disabled v0.11.2-dev
     def __test_replace_most_similar_chunk(self):
         whole = "This is a sample text.\nAnother line of text.\nYet another line.\n"

--- a/tests/basic/test_wholefile.py
+++ b/tests/basic/test_wholefile.py
@@ -152,6 +152,40 @@ Quote!
             updated_content = f.read()
         self.assertEqual(updated_content, "Updated content\n")
 
+    def test_update_files_doubled_path_prefix(self):
+        # Two files in distinct subdirs so that find_common_root resolves to the
+        # tempdir, and chat_files retains the "subdir/" prefix on the target.
+        os.makedirs("subdir", exist_ok=True)
+        os.makedirs("other", exist_ok=True)
+
+        target_rel = "subdir/sample.txt"
+        with open(target_rel, "w") as f:
+            f.write("Original content\n")
+        with open("other/sibling.txt", "w") as f:
+            f.write("sibling\n")
+
+        io = InputOutput(yes=True)
+        coder = WholeFileCoder(
+            main_model=self.GPT35,
+            io=io,
+            fnames=[target_rel, "other/sibling.txt"],
+        )
+
+        # LLM hallucinates a doubled prefix: chat_files contains
+        # "subdir/sample.txt"; LLM emits "subdir/subdir/sample.txt".
+        coder.partial_response_content = (
+            f"subdir/{target_rel}\n```\nUpdated content\n```"
+        )
+
+        edited_files = coder.apply_updates()
+
+        # Canonical path should be edited; doubled path must not be created.
+        self.assertIn(target_rel, edited_files)
+        self.assertFalse(Path("subdir", "subdir", "sample.txt").exists())
+
+        with open(target_rel, "r") as f:
+            self.assertEqual(f.read(), "Updated content\n")
+
     def test_update_files_not_in_chat(self):
         # Create a sample file in the temporary directory
         sample_file = "sample.txt"


### PR DESCRIPTION
## Summary
Catch doubled-prefix hallucinations like `.claude/.claude/foo.json` (when the chat file is `.claude/foo.json`) by extending the existing prepended-bogus-dir guard with progressive suffix-stripping against `chat_files` / `valid_fnames`. Closes #5111.

## Why
Observed in production dispatch across small editor models (`groq/llama-3.3-70b-versatile`, `openrouter/openai/gpt-oss-120b`, `gemini-2.5-flash-lite`). Existing basename-only guard in `WholeFileCoder` and basename+fuzzy guards in `find_filename` miss multi-segment doubled prefixes; result is a 0-byte canonical file and content at a doubled path.

## Changes
- `aider/coders/wholefile_coder.py`: after basename guard, try progressively shorter suffixes against `chat_files`.
- `aider/coders/editblock_coder.py:find_filename`: same pattern, between basename and fuzzy match (catches cases where `SequenceMatcher` ratio falls below the 0.8 cutoff).
- 2 tests covering both code paths, including a mutation-tested case where fuzzy match would otherwise miss (ratio 0.778 < 0.8).

## Risk
Low. Strict subset of behaviour:
- Only triggers when exact match and basename match both fail.
- Only resolves when a deterministic suffix is itself in `chat_files` / `valid_fnames`.
- No behaviour change on any path that currently resolves correctly.

## Test plan
- [x] `pytest tests/basic/test_wholefile.py tests/basic/test_editblock.py` — 38 passed (was 36 before)
- [x] Mutation test: confirmed both new tests fail without the fix (return doubled path verbatim)