### PR TITLE
fix: set SSL_VERIFY=False for --no-verify-ssl

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -519,7 +519,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if not args.verify_ssl:
         import httpx
 
-        os.environ["SSL_VERIFY"] = ""
+        os.environ["SSL_VERIFY"] = "False"
         litellm._load_litellm()
         litellm._lazy_module.client_session = httpx.Client(verify=False)
         litellm._lazy_module.aclient_session = httpx.AsyncClient(verify=False)

--- a/tests/basic/test_ssl_verification.py
+++ b/tests/basic/test_ssl_verification.py
@@ -64,8 +64,8 @@ class TestSSLVerification(TestCase):
                 mock_client.assert_called_once_with(verify=False)
                 mock_async_client.assert_called_once_with(verify=False)
 
-                # Verify SSL_VERIFY environment variable was set to empty string
-                self.assertEqual(os.environ.get("SSL_VERIFY"), "")
+                # Verify SSL_VERIFY environment variable was set to "False"
+                self.assertEqual(os.environ.get("SSL_VERIFY"), "False")
 
     @patch("aider.io.InputOutput.offer_url")
     @patch("aider.models.model_info_manager.set_verify_ssl")


### PR DESCRIPTION
Fixes #3702. `--no-verify-ssl` did not disable SSL verification for LiteLLM-backed providers such as Gemini, OpenRouter, and Anthropic, leading to `CERTIFICATE_VERIFY_FAILED` errors.

## Root cause

Aider set `SSL_VERIFY` to an empty string when `--no-verify-ssl` was used. LiteLLM's `get_ssl_verify()` does not treat an empty string as boolean false, so SSL verification was not disabled as intended. Setting `SSL_VERIFY=False` uses the value LiteLLM expects and allows it to pass `verify=False` through to its HTTP client.

## Changes

- Set `os.environ["SSL_VERIFY"] = "False"` in `aider/main.py` when `--no-verify-ssl` is enabled
- Update `tests/basic/test_ssl_verification.py` to assert the new env var value

## Test plan

- [x] Updated `test_no_verify_ssl_flag_sets_model_info_manager`
- [x] Manually verified the failing LiteLLM provider path with `--no-verify-ssl`