### PR TITLE
docs: clarify aider-install env and link local-model setup

### DIFF
--- a/aider/website/_includes/get-started.md
+++ b/aider/website/_includes/get-started.md
@@ -20,3 +20,12 @@ aider --model sonnet --api-key anthropic=<key>
 # o3-mini
 aider --model o3-mini --api-key openai=<key>
 ```
+
+Using a local model? See the per-provider setup pages for
+[Ollama](https://aider.chat/docs/llms/ollama.html),
+[LM Studio](https://aider.chat/docs/llms/lm-studio.html),
+or any
+[OpenAI-compatible endpoint](https://aider.chat/docs/llms/openai-compat.html)
+such as a llama.cpp server.
+The full list of supported providers is on the
+[Connecting to LLMs](https://aider.chat/docs/llms.html) page.

--- a/aider/website/docs/install.md
+++ b/aider/website/docs/install.md
@@ -13,9 +13,11 @@ description: How to install and get started pair programming with aider.
 
 {% include get-started.md %}
 
-This will install aider in its own separate python environment.
-If needed, 
-aider-install will also install a separate version of python 3.12 to use with aider.
+The `aider-install` command above installs aider into its own
+separate Python environment so it does not interfere with other
+packages in your current environment.
+If needed,
+`aider-install` will also install a separate copy of Python 3.12 to use with aider.
 
 Once aider is installed,
 there are also some [optional install steps](/docs/install/optional.html).


### PR DESCRIPTION
The install page's "Get started quickly" section ends with:

> This will install aider in its own separate python environment.

After the included `get-started.md` block, the sentence sits right under the `aider --model deepseek ...` example, so "This" reads as if it refers to the model command rather than `aider-install`. Issue #5115 calls this out, along with the install guide showing only cloud-provider examples.

Two small edits:

- `_includes/get-started.md`: add a short pointer below the model examples to the Ollama, LM Studio, and OpenAI-compatible setup pages so users running a local LLM can find the right page from the install guide.
- `docs/install.md`: rewrite the "This will install..." sentence to name `aider-install` explicitly, and clarify why a separate env is used.

Closes #5115