### PR TITLE
feat: add bash tree-sitter tags for repomap support

### DIFF
--- a/aider/queries/tree-sitter-language-pack/bash-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/bash-tags.scm
@@ -1,0 +1,8 @@
+(function_definition
+  name: (word) @name.definition.function) @definition.function
+
+(variable_assignment
+  name: (variable_name) @name.definition.variable) @definition.variable
+
+(command
+  name: (command_name) @name.reference.call) @reference.call

--- a/aider/queries/tree-sitter-languages/bash-tags.scm
+++ b/aider/queries/tree-sitter-languages/bash-tags.scm
@@ -1,0 +1,8 @@
+(function_definition
+  name: (word) @name.definition.function) @definition.function
+
+(variable_assignment
+  name: (variable_name) @name.definition.variable) @definition.variable
+
+(command
+  name: (command_name) @name.reference.call) @reference.call

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -400,6 +400,9 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_matlab(self):
         self._test_language_repo_map("matlab", "m", "Person")
 
+    def test_language_bash(self):
+        self._test_language_repo_map("bash", "sh", "greet")
+
     def _test_language_repo_map(self, lang, key, symbol):
         """Helper method to test repo map generation for a specific language."""
         # Get the fixture file path and name based on language

--- a/tests/fixtures/languages/bash/test.sh
+++ b/tests/fixtures/languages/bash/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+GREETING="hello"
+
+greet() {
+    local name=$1
+    echo "$GREETING, $name"
+}
+
+say_hi() {
+    greet "world"
+}
+
+main() {
+    say_hi
+    greet "$USER"
+}
+
+main "$@"


### PR DESCRIPTION
Adds tree-sitter tag queries for Bash/shell scripts so the repo map can index `.sh`, `.bash`, and `.zsh` files.

## What
- New `bash-tags.scm` under both `tree-sitter-language-pack/` and `tree-sitter-languages/` (matching the MATLAB precedent in #20429b685)
- Captures: `function_definition` → definitions, `variable_assignment` → definitions, `command` → references
- Test fixture `tests/fixtures/languages/bash/test.sh` and `test_language_bash` in `test_repomap.py`

## Why
Bash/shell scripts are present in nearly every codebase but currently have no repo map support — `grep_ast` already maps `.sh`/`.bash`/`.zsh` to the `bash` parser, so the tags file was the missing piece.

## Test
- `pytest tests/basic/test_repomap.py` — all 46 tests pass (45 prior + new `test_language_bash`)
- Pre-commit (isort, black, flake8, codespell) clean