### PR TITLE
fix: skip invalid repo-map tree-sitter queries

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -16,7 +16,7 @@ from grep_ast import TreeContext, filename_to_lang
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Token
 from tqdm import tqdm
-from tree_sitter import Query
+from tree_sitter import Query, QueryError
 
 from aider.dump import dump
 from aider.special import filter_important_files
@@ -298,8 +298,13 @@ class RepoMap:
             return
         tree = parser.parse(bytes(code, "utf-8"))
 
-        # Run the tags queries
-        captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        # Run the tags queries. Some bundled queries can drift out of sync with
+        # the installed tree-sitter grammars; skip tags rather than crashing.
+        try:
+            captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        except QueryError as err:
+            print(f"Skipping file {fname}: {err}")
+            return
 
         captures_by_tag = defaultdict(list)
         matches = []

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,6 +4,7 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
 
@@ -42,6 +43,29 @@ class TestRepoMap(unittest.TestCase):
             self.assertIn("test_file2.py", result)
             self.assertIn("test_file3.md", result)
             self.assertIn("test_file4.json", result)
+
+            # close the open cache files, so Windows won't error
+            del repo_map
+
+    def test_get_repo_map_skips_invalid_tree_sitter_query(self):
+        with IgnorantTemporaryDirectory() as temp_dir:
+            test_file = os.path.join(temp_dir, "broken_query.py")
+            with open(test_file, "w", encoding="utf-8") as f:
+                f.write("def hello():\n    return 1\n")
+
+            invalid_query = Path(temp_dir) / "invalid-tags.scm"
+            invalid_query.write_text(
+                "(not_a_real_node) @name.definition.function\n", encoding="utf-8"
+            )
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
+
+            with patch("aider.repomap.get_scm_fname", return_value=invalid_query):
+                result = repo_map.get_repo_map([], [test_file])
+
+            self.assertIn("broken_query.py", result)
+            self.assertNotIn("hello", result)
 
             # close the open cache files, so Windows won't error
             del repo_map


### PR DESCRIPTION
## Summary

- catch tree-sitter `QueryError` while running repo-map tag queries
- keep affected files in the repo map as filename-only entries instead of crashing
- add a regression test that forces an invalid tags query

## Motivation

A bundled tags query can drift out of sync with the installed tree-sitter grammar. Julia files currently hit this path with `Invalid node type ... module`, which aborts repo-map generation before Aider can answer the next prompt.

Fixes #4867
Fixes #4888

## Validation

- `.venv/bin/python -m pytest tests/basic/test_repomap.py::TestRepoMap::test_get_repo_map_skips_invalid_tree_sitter_query -q`
- `.venv/bin/python -m pytest tests/basic/test_repomap.py -q`
- `.venv/bin/pre-commit run --files aider/repomap.py tests/basic/test_repomap.py`
- `git diff --check`
- manual `hello.jl` repo-map smoke test now returns `hello.jl` instead of raising `tree_sitter.QueryError`
