### PR TITLE
security: bump GitPython, Pillow, urllib3 to CVE-clean versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/common-constraints.txt
     #   gitpython
-gitpython==3.1.46
+gitpython==3.1.49
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -249,7 +249,7 @@ pexpect==4.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -451,7 +451,7 @@ typing-inspection==0.4.2
     #   -c requirements/common-constraints.txt
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -132,7 +132,7 @@ fsspec==2026.2.0
     #   torch
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.46
+gitpython==3.1.49
     # via
     #   -r requirements/requirements.in
     #   streamlit
@@ -331,7 +331,7 @@ pathspec==1.0.4
     #   grep-ast
 pexpect==4.9.0
     # via -r requirements/requirements.in
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -r requirements/requirements.in
     #   llama-index-core
@@ -607,7 +607,7 @@ typing-inspection==0.4.2
     #   pydantic
 tzdata==2025.3
     # via pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 uv==0.10.11
     # via -r requirements/requirements-dev.in

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -33,7 +33,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/common-constraints.txt
     #   gitpython
-gitpython==3.1.46
+gitpython==3.1.49
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -77,7 +77,7 @@ pandas==2.3.3
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -149,7 +149,7 @@ tzdata==2025.3
     # via
     #   -c requirements/common-constraints.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -166,7 +166,7 @@ pandas==2.3.3
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c requirements/common-constraints.txt
     #   matplotlib
@@ -302,7 +302,7 @@ tzdata==2025.3
     # via
     #   -c requirements/common-constraints.txt
     #   pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -221,7 +221,7 @@ packaging==26.0
     #   huggingface-hub
     #   marshmallow
     #   transformers
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
@@ -372,7 +372,7 @@ typing-inspection==0.4.2
     # via
     #   -c requirements/common-constraints.txt
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests


### PR DESCRIPTION
## Summary

Bumps three transitively-pinned libraries to their lowest CVE-clean versions. Trivy scans of images built with `aider-chat==0.86.2` reported 7 HIGH-severity CVEs across these three libraries.

- `gitpython` 3.1.46 → 3.1.49 (CVE-2026-42215, -42284, -44243, -44244)
- `pillow` 12.1.1 → 12.2.0 (CVE-2026-42311)
- `urllib3` 2.6.3 → 2.7.0 (CVE-2026-44431)

Closes #5139
Closes #5140
Closes #5141

## Files touched

The pins live in pip-tools / `uv pip compile`-generated lockfiles, not in `pyproject.toml`. Edited in place:

- `requirements.txt`
- `requirements/common-constraints.txt`
- `requirements/requirements-browser.txt`
- `requirements/requirements-dev.txt`
- `requirements/requirements-help.txt`

## Quirks / things for the maintainer to double-check

- `uv` was not available in our environment, so the lockfiles were updated **by hand** rather than regenerated. The 3 changed pins are simple version-string swaps — no hashes are present in the existing lockfiles, so no hash regeneration was needed. Still, please run `uv pip compile --no-strip-extras --constraint=requirements/common-constraints.txt --output-file=tmp.requirements.txt requirements/requirements.in` (and the equivalent for the other `.in` files) locally to confirm no transitive resolution drift before merging.
- All bumps within same major release line; expected drop-in.

## Verification

- `aider --version` smoke-tested in downstream consumer.

## Downstream context

Reported by the HomericIntelligence/AchaeanFleet team. We've worked around it locally by force-overriding the pins post-install, but a native upstream fix removes the need for that workaround everywhere.
