### PR TITLE
feat: add --one-shot flag for sessionless single-prompt execution

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -654,6 +654,12 @@ def get_parser(default_config_files, git_root):
         ),
     ).complete = shtab.FILE
     group.add_argument(
+        "--one-shot",
+        action="store_true",
+        default=False,
+        help="Run a single prompt without git repo, then exit (implies --no-git)",
+    )
+    group.add_argument(
         "--gui",
         "--browser",
         action=argparse.BooleanOptionalAction,

--- a/aider/main.py
+++ b/aider/main.py
@@ -676,6 +676,17 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         for fname in loaded_dotenvs:
             io.tool_output(f"Loaded {fname}")
 
+    if args.one_shot:
+        args.git = False
+        if not args.message and not args.message_file:
+            if args.files:
+                # Use the first positional arg as the message
+                args.message = args.files.pop(0)
+            else:
+                io.tool_error("--one-shot requires a message, use --message or --message-file")
+                analytics.event("exit", reason="One-shot without message")
+                return 1
+
     all_files = args.files + (args.file or [])
     fnames = [str(Path(fn).resolve()) for fn in all_files]
     read_only_fnames = []


### PR DESCRIPTION
## Summary

Add a `--one-shot` flag that allows running a single prompt without initializing a git repository, then exits immediately after delivering the response. This is useful for quick one-off tasks like explaining code or simple refactoring where you don't need a full session.

## Usage

```bash
# Message via --message flag
aider --one-shot --message "explain this function" src/utils.js

# Message as positional argument (more concise)
aider --one-shot "explain this function" src/utils.js

# Message from file
aider --one-shot --message-file prompt.txt src/utils.js
```

## Implementation

- **`aider/args.py`**: Added `--one-shot` argument to the "Modes" group
- **`aider/main.py`**: When `--one-shot` is set:
  - Forces `--no-git` to skip all git repository initialization
  - If no `--message` or `--message-file` is provided, treats the first positional argument as the message
  - Shows an error if no message source is found
- The existing `--message` handler in `main.py` runs the coder with the message and exits, which works unchanged

## Testing

- Manually tested with both `--message` and positional-arg message syntax
- Verified git repo is skipped (`Git repo: none`)
- Verified file modifications work correctly
- All existing pytest tests pass (the one failure on Windows is pre-existing and unrelated)

Closes #5143