### PR TITLE
fix: make console output resilient to terminal encoding

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -54,6 +54,30 @@ def ensure_hash_prefix(color):
     return color
 
 
+def make_console_output_resilient(console):
+    """Replace characters the terminal can't encode instead of crashing.
+
+    On consoles whose codepage isn't UTF-8 (e.g. Windows cp1252), writing a
+    character the codec can't represent raises an uncaught UnicodeEncodeError
+    that takes down the whole session. Switching the output stream's error
+    handler to "replace" lets rich emit a placeholder for those characters and
+    keep going.
+    """
+    stream = getattr(console, "file", None)
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    # Only relax a strict handler; leave any explicit preference untouched.
+    if getattr(stream, "errors", None) not in (None, "strict"):
+        return
+    try:
+        reconfigure(errors="replace")
+    except (ValueError, OSError):
+        # Some streams (already-detached, non-reconfigurable) refuse this; the
+        # existing per-message fallbacks still guard those cases.
+        pass
+
+
 def restore_multiline(func):
     """Decorator to restore multiline mode after function execution"""
 
@@ -364,6 +388,10 @@ class InputOutput:
             self.console = Console(force_terminal=False, no_color=True)  # non-pretty
             if self.is_dumb_terminal:
                 self.tool_output("Detected dumb terminal, disabling fancy input and pretty output.")
+
+        # Keep output from crashing on terminals that can't encode every
+        # character (e.g. Windows cp1252); unencodable chars are replaced.
+        make_console_output_resilient(self.console)
 
         self.file_watcher = file_watcher
         self.root = root

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -1,3 +1,4 @@
+import io as pyio
 import os
 import unittest
 from pathlib import Path
@@ -5,10 +6,16 @@ from unittest.mock import MagicMock, patch
 
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
+from rich.console import Console
 from rich.text import Text
 
 from aider.dump import dump  # noqa: F401
-from aider.io import AutoCompleter, ConfirmGroup, InputOutput
+from aider.io import (
+    AutoCompleter,
+    ConfirmGroup,
+    InputOutput,
+    make_console_output_resilient,
+)
 from aider.utils import ChdirTemporaryDirectory
 
 
@@ -382,6 +389,59 @@ class TestInputOutputMultilineMode(unittest.TestCase):
 
             # The invalid Unicode should be replaced with '?'
             self.assertEqual(converted_message, "Hello ?World")
+
+    def test_console_output_resilient_to_terminal_encoding(self):
+        """Output must not crash when the terminal can't encode a character.
+
+        Regression for issue #5128: on a non-UTF-8 console (e.g. Windows
+        cp1252) printing a character the codepage can't encode raised an
+        uncaught UnicodeEncodeError that killed the session. The console's
+        output stream should replace such characters instead of crashing.
+        """
+        # A strict cp1252 stream mirrors a legacy Windows console: it cannot
+        # encode characters like the right arrow (U+2192) and raises by default.
+        raw = pyio.BytesIO()
+        strict_stream = pyio.TextIOWrapper(raw, encoding="cp1252", errors="strict", newline="")
+
+        io = InputOutput(pretty=False, fancy_input=False)
+        io.console = Console(file=strict_stream, force_terminal=False)
+
+        # Sanity: without the fix the strict stream really does crash.
+        with self.assertRaises(UnicodeEncodeError):
+            Console(
+                file=pyio.TextIOWrapper(
+                    pyio.BytesIO(), encoding="cp1252", errors="strict", newline=""
+                ),
+                force_terminal=False,
+            ).print("arrow →")
+
+        make_console_output_resilient(io.console)
+
+        # All console-backed output paths must now survive unencodable chars.
+        io.tool_error("Build failed → retry")
+        io.tool_warning("Heads up ✓")
+        io.tool_output("Repo map:", "node ⋮ child")
+        strict_stream.flush()
+
+        written = raw.getvalue().decode("cp1252")
+        # Nothing crashed, the unencodable characters were replaced, and the
+        # surrounding text still made it through.
+        self.assertNotIn("→", written)
+        self.assertNotIn("✓", written)
+        self.assertNotIn("⋮", written)
+        self.assertIn("Build failed", written)
+        self.assertIn("retry", written)
+
+    def test_make_console_output_resilient_preserves_explicit_errors(self):
+        """An explicit non-strict error handler should be left untouched."""
+        stream = pyio.TextIOWrapper(
+            pyio.BytesIO(), encoding="cp1252", errors="backslashreplace", newline=""
+        )
+        console = Console(file=stream, force_terminal=False)
+
+        make_console_output_resilient(console)
+
+        self.assertEqual(stream.errors, "backslashreplace")
 
     def test_multiline_mode_restored_after_interrupt(self):
         """Test that multiline mode is restored after KeyboardInterrupt"""


### PR DESCRIPTION
## Why

Fixes #5128.

On consoles whose codepage isn't UTF-8 (for example Windows cp1252), aider crashes with an uncaught UnicodeEncodeError as soon as any output contains a character the codepage can't encode — checkmarks, arrows, box-drawing characters, emoji, or non-Latin text. The traceback bottoms out in `aider/io.py` `_tool_message` -> `console.print` -> rich's `_write_buffer`.

`_tool_message` already tries an ASCII fallback, but it can't recover: when rich's `file.write` raises, the unencodable text stays in rich's internal buffer (the `del self._buffer[:]` after the write never runs), so the retry re-flushes the same bad buffer and raises again. `tool_output` had no guard at all. The result is that essentially any decorated output takes down the whole session.

## What

Relax the console output stream's error handler from `strict` to `replace` when the console is constructed. Unencodable characters are then emitted as a placeholder instead of raising, which fixes every console-backed output path at once rather than guarding individual call sites.

- An explicit, non-strict error handler is left untouched.
- Streams that can't be reconfigured are handled gracefully.
- No new dependencies, no behavior change on UTF-8 terminals.

## Test

Added regression tests that drive the real output paths against a strict cp1252 stream (a stand-in for a legacy Windows console) and assert no crash with unencodable characters replaced, plus a test that an explicit error handler is preserved.