### PR TITLE
Expand ANTHROPIC_MODELS list with recent Claude model names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ### main branch
 
+- Expanded `ANTHROPIC_MODELS` list with Claude Opus 4.1/4.5/4.6/4.7 dated variants and Claude Sonnet 3.7 so the Anthropic API key auto-detection (`models.sanity_check_models`) recognises them.
 - Added support for Claude 4.5/4.6 models and updated model aliases (sonnet/haiku/opus).
 - Expanded Gemini model support with 2.5 Flash and Flash‑Lite, added Gemini 3 preview models, and updated the flash alias to gemini/gemini-flash-latest.
 - Added DeepSeek Reasoner model and updated DeepSeek model metadata with costs and prompt caching.

--- a/aider/models.py
+++ b/aider/models.py
@@ -75,10 +75,17 @@ claude-3-opus-20240229
 claude-3-sonnet-20240229
 claude-3-5-sonnet-20240620
 claude-3-5-sonnet-20241022
+claude-3-7-sonnet-20250219
 claude-sonnet-4-20250514
 claude-opus-4-20250514
+claude-opus-4-1
+claude-opus-4-1-20250805
+claude-opus-4-5
+claude-opus-4-5-20251101
 claude-opus-4-6
+claude-opus-4-6-20260205
 claude-opus-4-7
+claude-opus-4-7-20260416
 claude-sonnet-4-5
 claude-sonnet-4-5-20250929
 claude-sonnet-4-6


### PR DESCRIPTION
## Summary

\`ANTHROPIC_MODELS\` in \`aider/models.py\` is used by \`sanity_check_models\` to map a bare Claude model name (no provider prefix) to the \`ANTHROPIC_API_KEY\` environment variable. Models not in this list fall through to the keymap provider lookup, which fails when the user passes the name without a provider prefix.

The list was stale — it had \`claude-2\`, the 3.x family, \`claude-3-5-*\`, \`claude-sonnet-4-20250514\`, \`claude-opus-4-20250514\`, plus the 4.5/4.6/4.7 unrounded names — but was missing several recent Anthropic models:

- \`claude-3-7-sonnet-20250219\`
- \`claude-opus-4-1\` / \`claude-opus-4-1-20250805\`
- \`claude-opus-4-5\` / \`claude-opus-4-5-20251101\`
- \`claude-opus-4-6-20260205\` (dated variant for Opus 4.6)
- \`claude-opus-4-7-20260416\` (dated variant for Opus 4.7)

All added names have corresponding entries in \`aider/resources/model-settings.yml\`, so the list now matches the rest of the project. Companion to the OPENAI_MODELS list expansion PR.

## Effect

Before this change, \`aider --model claude-opus-4-5\` with \`ANTHROPIC_API_KEY\` set in the environment would show \"ANTHROPIC_API_KEY: Not set\" because the bare name didn't match the list. After this change, the API key is correctly detected.

## Test plan

- Diff is purely additive: 9 lines added to the ANTHROPIC_MODELS string + 1 line in HISTORY.md.