### PR TITLE
fix(io): reconfigure Windows stdio to UTF-8 so piped output emits Unicode (#4294)

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -40,6 +40,30 @@ from aider.watch import FileWatcher
 from .dump import dump  # noqa: F401
 
 
+def _ensure_utf8_stdio() -> None:
+    """On Windows, switch sys.stdout / sys.stderr to UTF-8.
+
+    Windows defaults the standard streams to the legacy ANSI codepage
+    (cp1252 in en-US, gbk in zh-CN, etc.) when the stream is not a
+    terminal — e.g. when the user pipes aider output to a file or pager.
+    rich's legacy Windows renderer then crashes on characters aider
+    routinely emits (``charmap codec can't encode character '\\u22ee'``
+    in ``--show-repo-map``).
+
+    Safe no-op outside Windows, or when reconfigure() is unavailable
+    (e.g. a test harness has replaced sys.stdout with a non-TextIOWrapper).
+
+    See https://github.com/Aider-AI/aider/issues/4294.
+    """
+    if sys.platform != "win32":
+        return
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+
+
 def check_config_files_for_yes(config_files):
     found = False
     for config_file in config_files:
@@ -449,6 +473,7 @@ def sanity_check_repo(repo, io):
 
 
 def main(argv=None, input=None, output=None, force_git_root=None, return_coder=False):
+    _ensure_utf8_stdio()
     report_uncaught_exceptions()
 
     if argv is None:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1481,3 +1481,50 @@ class TestMain(TestCase):
             )
         for call in mock_io_instance.tool_warning.call_args_list:
             self.assertNotIn("Cost estimates may be inaccurate", call[0][0])
+
+
+class TestEnsureUtf8Stdio(TestCase):
+    """Verify _ensure_utf8_stdio() switches Windows stdio to UTF-8 (fixes #4294)
+    without breaking non-Windows or test-harness streams."""
+
+    def test_noop_on_non_windows(self):
+        """On Linux/macOS, _ensure_utf8_stdio must not touch the streams."""
+        from aider.main import _ensure_utf8_stdio
+
+        fake_stdout = MagicMock()
+        fake_stderr = MagicMock()
+        with patch("sys.platform", "linux"), \
+                patch("sys.stdout", fake_stdout), \
+                patch("sys.stderr", fake_stderr):
+            _ensure_utf8_stdio()
+
+        fake_stdout.reconfigure.assert_not_called()
+        fake_stderr.reconfigure.assert_not_called()
+
+    def test_reconfigures_both_streams_on_windows(self):
+        """On Windows, both stdout and stderr get reconfigured to utf-8."""
+        from aider.main import _ensure_utf8_stdio
+
+        fake_stdout = MagicMock()
+        fake_stderr = MagicMock()
+        with patch("sys.platform", "win32"), \
+                patch("sys.stdout", fake_stdout), \
+                patch("sys.stderr", fake_stderr):
+            _ensure_utf8_stdio()
+
+        fake_stdout.reconfigure.assert_called_once_with(encoding="utf-8")
+        fake_stderr.reconfigure.assert_called_once_with(encoding="utf-8")
+
+    def test_safe_when_reconfigure_unavailable(self):
+        """If a test harness replaced sys.stdout with a non-TextIOWrapper
+        (e.g. StringIO) reconfigure() will raise AttributeError / ValueError;
+        _ensure_utf8_stdio must swallow it and continue."""
+        from aider.main import _ensure_utf8_stdio
+
+        broken_stream = MagicMock()
+        broken_stream.reconfigure.side_effect = AttributeError("no such method")
+        with patch("sys.platform", "win32"), \
+                patch("sys.stdout", broken_stream), \
+                patch("sys.stderr", broken_stream):
+            # Should not raise
+            _ensure_utf8_stdio()


### PR DESCRIPTION
Fixes #4294.

`aider --show-repo-map > .aider.map.md` crashes on Windows with
`charmap codec can't encode character '⋮'`. When stdout is
redirected to a file or pager, Windows defaults the stream to the
system ANSI codepage (cp1252 in en-US, gbk in zh-CN, etc.). rich's
legacy Windows renderer then tries to write `⋮` (used by repo-map)
through that codec and fails.

This patch reconfigures `sys.stdout` and `sys.stderr` to UTF-8 at the
top of `main()` on Windows. UTF-8 can encode every Unicode codepoint,
so the same flow now writes successfully to a pipe or file. Non-Windows
platforms are unaffected. Test harnesses that replaced the streams
with non-TextIOWrapper objects (e.g. `StringIO`) are tolerated via
try/except — `reconfigure()` raises `AttributeError`/`ValueError`
there and we swallow it.

The call sits at the very top of `main()` (before `InputOutput()` /
rich `Console()` are constructed at line 577) so the renderer picks
up the new encoding when it captures stdout.

## Verification (Windows 11, Python 3.12, zh-CN GBK locale)

Without the patch:

```
stdout encoding: gbk
UnicodeEncodeError: 'gbk' codec can't encode character '⋮'
```

With the patch:

```
stdout encoding: utf-8
vertical ellipsis works: ⋮
```

The original issue comment notes "setting `PYTHONUTF8=1` prevents the
crashes for me" — confirming the encoding switch is the right fix.
This PR removes the need for users to set the env var.

## Tests

Added `tests/basic/test_main.py::TestEnsureUtf8Stdio`:

- `test_noop_on_non_windows` — Linux/macOS streams untouched
- `test_reconfigures_both_streams_on_windows` — both stdout/stderr → utf-8
- `test_safe_when_reconfigure_unavailable` — `AttributeError` swallowed

All 3 new tests pass. Sanity-ran the existing
`TestMain::test_main_with_empty_dir_no_files_on_command`,
`test_main_with_emptqy_dir_new_file`, and `test_cache_without_stream_no_warning`
to confirm no regression.
