### PR TITLE
Fix .aiderignore decoding with configured encoding

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -514,7 +514,8 @@ class GitRepo:
         if mtime != self.aider_ignore_ts:
             self.aider_ignore_ts = mtime
             self.ignore_file_cache = {}
-            lines = self.aider_ignore_file.read_text().splitlines()
+            encoding = getattr(self.io, "encoding", None) or "utf-8"
+            lines = self.aider_ignore_file.read_text(encoding=encoding).splitlines()
             self.aider_ignore_spec = pathspec.PathSpec.from_lines(
                 pathspec.patterns.GitWildMatchPattern,
                 lines,

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -560,6 +560,35 @@ class TestRepo(unittest.TestCase):
             # self.assertIn(str(fname), fnames)
             # self.assertNotIn(str(fname2), fnames)
 
+    def test_aiderignore_uses_configured_encoding(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+
+            fname = Path("ignored.txt")
+            fname.touch()
+            raw_repo.git.add(str(fname))
+
+            aiderignore = Path(".aiderignore")
+            aiderignore.write_bytes("ignored.txt\n# \U0001f600\n".encode("utf-8"))
+            git_repo = GitRepo(InputOutput(encoding="utf-8"), None, None, str(aiderignore))
+
+            original_read_text = Path.read_text
+
+            def read_text_with_cp1251_default(path, *args, **kwargs):
+                if Path(path) != aiderignore:
+                    return original_read_text(path, *args, **kwargs)
+
+                encoding = kwargs.get("encoding")
+                if encoding is None and args:
+                    encoding = args[0]
+                if encoding is None:
+                    encoding = "cp1251"
+
+                return path.read_bytes().decode(encoding)
+
+            with patch.object(Path, "read_text", read_text_with_cp1251_default):
+                self.assertTrue(git_repo.ignored_file(str(fname)))
+
     def test_get_tracked_files_from_subdir(self):
         with GitTemporaryDirectory():
             # new repo


### PR DESCRIPTION
Fixes #5188

Summary:
- read `.aiderignore` with Aider's configured file encoding instead of the platform default
- add a regression test that simulates a non-UTF-8 default locale reading a UTF-8 `.aiderignore`

Tests:
- `uv run --no-project --with-requirements requirements.txt --with pytest python -m pytest tests/basic/test_repo.py -q`
