### PR TITLE
fix: handle SwitchCoder in --message-file one-shot mode

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -1146,6 +1146,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             io.tool_error(f"Error reading message file: {e}")
             analytics.event("exit", reason="Message file IO error")
             return 1
+        except SwitchCoder:
+            pass
 
         analytics.event("exit", reason="Completed --message-file")
         return

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -12,6 +12,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from aider.coders import Coder
+from aider.commands import SwitchCoder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import check_gitignore, load_dotenv_files, main, setup_git
@@ -334,6 +335,26 @@ class TestMain(TestCase):
                 input=DummyInput(),
                 output=DummyOutput(),
             )
+            MockCoder.return_value.run.assert_called_once_with(with_message=message_file_content)
+
+        os.remove(message_file_path)
+
+    def test_message_file_flag_with_chat_mode_command(self):
+        # A chat-mode command (e.g. /ask) raises SwitchCoder once it has run.
+        # The --message-file path must swallow it instead of crashing (issue #5189).
+        message_file_content = "/ask what does this code do?"
+        message_file_path = tempfile.mktemp()
+        with open(message_file_path, "w", encoding="utf-8") as message_file:
+            message_file.write(message_file_content)
+
+        with patch("aider.coders.Coder.create") as MockCoder:
+            MockCoder.return_value.run = MagicMock(side_effect=SwitchCoder())
+            result = main(
+                ["--yes", "--message-file", message_file_path],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+            self.assertIsNone(result)
             MockCoder.return_value.run.assert_called_once_with(with_message=message_file_content)
 
         os.remove(message_file_path)


### PR DESCRIPTION
## Summary

`aider --message-file <file>` crashes with an uncaught `aider.commands.SwitchCoder` when the message file uses a chat-mode command such as `/ask`, `/code`, `/architect`, or `/context`.

`_generic_chat_command` runs the prompt in a sub-coder and then raises `SwitchCoder` to flip the main loop back. In `main.py`, the `--message` path already catches `SwitchCoder`, but the `--message-file` path does not — so after the answer is produced, aider exits with a traceback.

This makes `--message-file` consistent with `--message` by catching `SwitchCoder`.

Fixes #5189.

## Changes

- `aider/main.py`: catch `SwitchCoder` in the `--message-file` branch.
- `tests/basic/test_main.py`: add `test_message_file_flag_with_chat_mode_command` (fails without the fix, passes with it).

## Testing

```bash
AIDER_ANALYTICS=false pytest tests/basic/test_main.py -k message_file
```

Both message-file tests pass, and `pre-commit` (black/isort/flake8) is clean.

Made with [Cursor](https://cursor.com)