### PR TITLE
fix(versioncheck): swallow OSError on cooldown marker write (closes #5180)

### DIFF
--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -91,8 +91,19 @@ def check_version(io, just_check=False, verbose=False):
         io.tool_error(f"Error checking pypi for new version: {err}")
         return False
     finally:
-        VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
-        VERSION_CHECK_FNAME.touch()
+        # The version-check cooldown marker is best effort. If something in
+        # the path is not a directory, the home dir is read-only, or the
+        # filesystem otherwise rejects the write, log it and move on instead
+        # of crashing aider at startup. See issue #5180 for the original
+        # NotADirectoryError repro.
+        try:
+            VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
+            VERSION_CHECK_FNAME.touch()
+        except OSError as err:
+            if verbose:
+                io.tool_warning(
+                    f"Could not update version-check marker {VERSION_CHECK_FNAME}: {err}"
+                )
 
     ###
     # is_update_available = True

--- a/tests/basic/test_versioncheck.py
+++ b/tests/basic/test_versioncheck.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+from aider import versioncheck
+
+
+def _patched_pypi(latest="999.0.0"):
+    """Return a fake pypi response so check_version's network call succeeds."""
+    response = MagicMock()
+    response.json.return_value = {"info": {"version": latest}}
+    return response
+
+
+def test_check_version_swallows_not_a_directory_error(tmp_path):
+    """Regression test for #5180: when something in the marker path is not a
+    directory (the user had a file at ~/.aider/caches), the marker write should
+    fail quietly instead of crashing aider at startup."""
+    marker = tmp_path / "not-a-dir" / "marker"
+    # Make the supposed parent dir actually be a file so `mkdir(parents=True)`
+    # raises NotADirectoryError.
+    (tmp_path / "not-a-dir").write_text("oops, I'm a file")
+
+    io = MagicMock()
+    with patch.object(versioncheck, "VERSION_CHECK_FNAME", marker), patch(
+        "requests.get", return_value=_patched_pypi()
+    ):
+        # Should not raise. Used to bubble NotADirectoryError out of the
+        # finally block.
+        versioncheck.check_version(io, just_check=True)
+
+
+def test_check_version_swallows_permission_error_on_marker_write(tmp_path):
+    """If the marker write fails for any OSError reason (read-only fs,
+    permission denied, etc.) the function should not crash."""
+    marker = tmp_path / "cache" / "marker"
+    io = MagicMock()
+
+    with patch.object(versioncheck, "VERSION_CHECK_FNAME", marker), patch(
+        "requests.get", return_value=_patched_pypi()
+    ), patch("pathlib.Path.touch", side_effect=PermissionError(13, "denied")):
+        versioncheck.check_version(io, just_check=True)
+
+
+def test_check_version_verbose_warns_on_marker_write_failure(tmp_path):
+    """In verbose mode the user should at least see a warning when the marker
+    write fails, so the silent-skip is not completely invisible."""
+    marker = tmp_path / "not-a-dir" / "marker"
+    (tmp_path / "not-a-dir").write_text("oops")
+
+    io = MagicMock()
+    with patch.object(versioncheck, "VERSION_CHECK_FNAME", marker), patch(
+        "requests.get", return_value=_patched_pypi()
+    ):
+        versioncheck.check_version(io, just_check=True, verbose=True)
+
+    warning_calls = [
+        call for call in io.tool_warning.call_args_list if "version-check marker" in str(call)
+    ]
+    assert warning_calls, "expected a verbose warning about the failed marker write"
+
+
+def test_check_version_writes_marker_in_happy_path(tmp_path):
+    """Sanity check that the normal flow still creates the marker file when
+    the filesystem cooperates."""
+    marker = tmp_path / "cache" / "marker"
+    io = MagicMock()
+
+    with patch.object(versioncheck, "VERSION_CHECK_FNAME", marker), patch(
+        "requests.get", return_value=_patched_pypi()
+    ):
+        versioncheck.check_version(io, just_check=True)
+
+    assert marker.exists(), "the marker file should be created on a clean filesystem"


### PR DESCRIPTION
## Summary

Closes #5180.

`check_version()` in `aider/versioncheck.py` runs an unconditional `finally:` block:

```python
finally:
    VERSION_CHECK_FNAME.parent.mkdir(parents=True, exist_ok=True)
    VERSION_CHECK_FNAME.touch()
```

That `mkdir` bubbles `NotADirectoryError` when something in the path chain (the reporter had a file at `~/.aider/caches`) exists as a file rather than a directory. `touch()` can similarly bubble `PermissionError` on a read-only home. Either case crashes aider at startup with a stack trace, even when the underlying version check itself succeeded.

The marker file is purely a cooldown signal so we do not hit PyPI on every invocation. Failing to record it just means we run the version check again next time, not that aider is unusable.

## What changed

- `aider/versioncheck.py`: wrap the marker-write in `try` / `except OSError` so any of the filesystem-shaped errors (`NotADirectoryError`, `PermissionError`, `FileNotFoundError`, etc.) get swallowed instead of crashing the process. In `verbose` mode the user sees a `tool_warning` so the silent skip is not completely invisible.
- `tests/basic/test_versioncheck.py` (new): four tests cover the `NotADirectoryError` repro from #5180, the `PermissionError` variant, the verbose warning, and the unchanged happy-path marker creation.

## Test plan

- [x] `pytest tests/basic/test_versioncheck.py` reports `4 passed`.
- [x] The `NotADirectoryError` repro reproduces on `main` (a file at the parent path causes `check_version` to raise) and is silent on this branch.
- [x] Happy path still creates `VERSION_CHECK_FNAME` exactly as before.
