### PR TITLE
Surface agent skills published via llms.txt on /web

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -247,10 +247,54 @@ class Commands:
 
         self.io.tool_output("... added to chat.")
 
+        self.announce_llms_txt_skills(url)
+
         self.coder.cur_messages += [
             dict(role="user", content=content),
             dict(role="assistant", content="Ok."),
         ]
+
+    def announce_llms_txt_skills(self, url):
+        """
+        After scraping a URL, check the domain's `/llms.txt` for a `## Skills`
+        section and tell the user about any agent skills it publishes.
+
+        This only surfaces what is available; it never loads a skill
+        automatically. The user can pull one in with `/web <skill-url>`.
+        Fails silently (and caches the result per origin) so it never blocks.
+        """
+        from urllib.parse import urljoin, urlparse
+
+        from aider.scrape import fetch_llms_txt, parse_llms_txt_skills
+
+        try:
+            parts = urlparse(url)
+        except ValueError:
+            return
+        if not parts.scheme or not parts.netloc:
+            return
+        origin = f"{parts.scheme}://{parts.netloc}"
+
+        checked = getattr(self, "checked_llms_txt_origins", None)
+        if checked is None:
+            checked = self.checked_llms_txt_origins = set()
+        if origin in checked:
+            return
+        checked.add(origin)
+
+        text = fetch_llms_txt(origin, verify_ssl=self.verify_ssl)
+        if not text:
+            return
+        skills = parse_llms_txt_skills(text)
+        if not skills:
+            return
+
+        self.io.tool_output(
+            f"{origin} publishes {len(skills)} agent skill(s) via llms.txt:"
+        )
+        for title, skill_url, description in skills:
+            self.io.tool_output(f"  - {title}: {description}")
+            self.io.tool_output(f"    load with: /web {urljoin(origin + '/', skill_url)}")
 
     def is_command(self, inp):
         return inp[0] in "/!"

--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -250,6 +250,66 @@ class Scraper:
         return md
 
 
+def parse_llms_txt_skills(text):
+    """
+    Extract the `## Skills` section from an llms.txt document.
+
+    Returns a list of (title, url, description) tuples, one per skill entry.
+    Each entry follows the llms.txt link convention:
+        - [title](url): description  <!-- optional metadata -->
+
+    See https://github.com/MauricioPerera/llms-txt-skills for the proposed format.
+    """
+    skills = []
+    item_re = re.compile(
+        r"^-\s*\[([^\]]+)\]\(([^)]+)\)\s*:\s*(.+?)(?:\s*<!--.*?-->)?\s*$"
+    )
+    in_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if re.match(r"^##\s+skills\s*$", stripped, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section and stripped.startswith("## "):
+            break
+        if in_section:
+            m = item_re.match(stripped)
+            if m:
+                skills.append((m.group(1).strip(), m.group(2).strip(), m.group(3).strip()))
+    return skills
+
+
+def fetch_llms_txt(origin, verify_ssl=True, timeout=5):
+    """
+    Fetch `{origin}/llms.txt` and return its text, or None if it does not exist.
+
+    Returns None on any non-200 response, timeout, or when the body looks like
+    HTML (single-page apps often serve their index for unknown paths with a 200).
+    """
+    import httpx
+
+    url = origin.rstrip("/") + "/llms.txt"
+    headers = {"User-Agent": f"Mozilla./5.0 ({aider_user_agent})"}
+    try:
+        with httpx.Client(
+            headers=headers, verify=verify_ssl, follow_redirects=True, timeout=timeout
+        ) as client:
+            response = client.get(url)
+    except Exception:
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    content_type = response.headers.get("content-type", "").lower()
+    text = response.text
+    head = text.lstrip().lower()
+    if "html" in content_type or head.startswith("<!doctype html") or head.startswith("<html"):
+        return None
+
+    return text
+
+
 def slimdown_html(soup):
     for svg in soup.find_all("svg"):
         svg.decompose()

--- a/tests/scrape/test_scrape.py
+++ b/tests/scrape/test_scrape.py
@@ -171,5 +171,79 @@ class TestScrape(unittest.TestCase):
         scraper.html_to_markdown.assert_called_once_with(html_content)
 
 
+class TestParseLlmsTxtSkills(unittest.TestCase):
+    def test_parses_skills_section(self):
+        from aider.scrape import parse_llms_txt_skills
+
+        text = (
+            "# Some API\n\n"
+            "> tagline\n\n"
+            "## Endpoint\n\n"
+            "`GET /thing`\n\n"
+            "## Skills\n\n"
+            "Intro prose that should be ignored.\n\n"
+            "- [placeholder](/skills/placeholder/SKILL.md): make placeholder images."
+            ' <!-- skill: {"version":"1.0.0"} -->\n'
+            "- [api-client](/skills/api-client/SKILL.md): call the API over HTTP.\n\n"
+            "## After\n\n"
+            "- [not-a-skill](/x): should be ignored, wrong section.\n"
+        )
+        skills = parse_llms_txt_skills(text)
+        self.assertEqual(
+            skills,
+            [
+                (
+                    "placeholder",
+                    "/skills/placeholder/SKILL.md",
+                    "make placeholder images.",
+                ),
+                ("api-client", "/skills/api-client/SKILL.md", "call the API over HTTP."),
+            ],
+        )
+
+    def test_no_skills_section(self):
+        from aider.scrape import parse_llms_txt_skills
+
+        self.assertEqual(parse_llms_txt_skills("# Title\n\n> tag\n\n## Endpoint\n"), [])
+
+    def test_fetch_llms_txt_rejects_html(self):
+        from unittest.mock import patch
+
+        from aider.scrape import fetch_llms_txt
+
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"content-type": "text/html; charset=utf-8"}
+        response.text = "<!doctype html><html><body>SPA</body></html>"
+
+        client = MagicMock()
+        client.get.return_value = response
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with patch("httpx.Client", return_value=client):
+            self.assertIsNone(fetch_llms_txt("https://example.com"))
+
+    def test_fetch_llms_txt_returns_markdown(self):
+        from unittest.mock import patch
+
+        from aider.scrape import fetch_llms_txt
+
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"content-type": "text/plain; charset=utf-8"}
+        response.text = "# Site\n\n## Skills\n\n- [s](/s/SKILL.md): a skill.\n"
+
+        client = MagicMock()
+        client.get.return_value = response
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with patch("httpx.Client", return_value=client):
+            text = fetch_llms_txt("https://example.com")
+        self.assertIsNotNone(text)
+        self.assertIn("## Skills", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

When `/web` scrapes a URL, aider now also checks the domain's `/llms.txt` for a `## Skills` section and tells the user which agent skills the site publishes, with a ready-to-run `/web` command to load each one:

```
... added to chat.
https://img.automators.work publishes 2 agent skill(s) via llms.txt:
  - placeholder: generate SVG placeholder image URLs for UI mockups via this API.
    load with: /web https://img.automators.work/skills/placeholder/SKILL.md
  - api-client: patterns for consuming the placeholder image API via HTTP.
    load with: /web https://img.automators.work/skills/api-client/SKILL.md
```

## Why

`llms.txt` is increasingly used by sites to describe themselves to LLMs. A proposed convention adds a `## Skills` section so a site can publish reusable agent instructions (`SKILL.md`) alongside its docs — see https://github.com/MauricioPerera/llms-txt-skills. aider already scrapes URLs to pull in docs; this lets it also tell the user when a site ships purpose-built skills, without making them hunt for the URL.

## Design

- **Never auto-loads.** It only surfaces what's available; the user explicitly pulls a skill in with `/web <skill-url>`. No new trust surface.
- **Fail-open and silent.** 404 / timeout / HTML response (SPA serving its index) → nothing is printed, nothing blocks. Results are cached per origin so each domain is probed at most once per session.
- **Minimal footprint.** A one-line hook in `cmd_web` plus two small pure helpers in `scrape.py`. Reuses `httpx` (already a dependency); no new deps.

## Changes

- `aider/scrape.py`: `parse_llms_txt_skills()` and `fetch_llms_txt()` helpers.
- `aider/commands.py`: `announce_llms_txt_skills()`, called from `cmd_web`.
- `tests/scrape/test_scrape.py`: unit tests for the parser and for HTML rejection in the fetch (no network).

Happy to adjust scope or wording — e.g. also trigger on auto-detected pasted URLs, or gate it behind a flag.