### PR TITLE
docs: add Ollama local LLM setup guide to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ See the [installation instructions](https://aider.chat/docs/install.html) and [u
 - [Discord Community](https://discord.gg/Y7X7bhMQFV)
 - [Release notes](https://aider.chat/HISTORY.html)
 - [Blog](https://aider.chat/blog/)
+- [Aider + Ollama Local LLM Setup Guide (2026)](https://aicoderscope.com/blog/aider-local-ollama-setup-2026/) — Step-by-step guide to running Aider with a local Ollama model: choosing the right model size, configuring `--model` flags, and getting reliable edits without a cloud API key
 
 ## Kind Words From Users
 


### PR DESCRIPTION
## What this adds

One link added to the existing **Community & Resources** section in `README.md`:

> [Aider + Ollama Local LLM Setup Guide (2026)](https://aicoderscope.com/blog/aider-local-ollama-setup-2026/)

## Why it's useful

Aider already documents `--model` and `--ollama-api-base` flags, but users frequently ask in Discord and GitHub issues: *"Which Ollama model actually works well? What size do I need? Why does my edit keep failing with a small model?"*

This community article covers exactly that — choosing the right model tier (7B/14B/34B), configuring Aider to talk to a local Ollama endpoint, and getting reliable whole-file edits without a cloud API key. It's the end-to-end "getting started with local" story that the official docs don't currently have.

## Change scope

- One file edited: `README.md`
- 1 line added, 0 deleted
- No code or dependency changes