### PR TITLE
[BUG] Aider ignores model setting when generating commit message

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -109,6 +109,8 @@ class Commands:
             # If the user was using the old model's default, switch to the new model's default
             new_edit_format = model.edit_format
 
+        if self.coder.repo:
+            self.coder.repo.models = model.commit_message_models()
         raise SwitchCoder(main_model=model, edit_format=new_edit_format)
 
     def cmd_editor_model(self, args):
@@ -133,6 +135,8 @@ class Commands:
             weak_model=model_name,
         )
         models.sanity_check_models(self.io, model)
+        if self.coder.repo:
+            self.coder.repo.models = model.commit_message_models()
         raise SwitchCoder(main_model=model)
 
     def cmd_chat_mode(self, args):

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -2224,3 +2224,21 @@ class TestCommands(TestCase):
             )
             self.assertEqual(new_coder.done_messages, [{"role": "user", "content": "d1"}])
             self.assertEqual(new_coder.cur_messages, [{"role": "user", "content": "c1"}])
+
+    def test_weak_model_change_updates_commit_message_model(self):
+        with GitTemporaryDirectory():
+            io = InputOutput(pretty=False, fancy_input=False, yes=True)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            # Confirm repo was created and has the initial weak model
+            self.assertIsNotNone(coder.repo)
+            initial_model_names = [m.name for m in coder.repo.models]
+            self.assertNotIn("gpt-4", initial_model_names)
+
+            # cmd_weak_model raises SwitchCoder; catch it and check the shared repo was updated
+            with self.assertRaises(SwitchCoder):
+                commands.cmd_weak_model("gpt-4")
+
+            updated_model_names = [m.name for m in coder.repo.models]
+            self.assertIn("gpt-4", updated_model_names)


### PR DESCRIPTION
## Problem

After running `/weak-model` or `/model` inside aider, commit message generation (via `/commit` or the automatic post-edit commit) kept using the model selected at startup instead of the newly configured one — the behavior reported in #5213.

## Root cause

`GitRepo` is created once at coder startup with a frozen `models` list (a `commit_message_models()` snapshot). When `cmd_weak_model` / `cmd_model` build a new `Model` and `raise SwitchCoder`, neither updated `self.coder.repo.models`. The coder created by `SwitchCoder` reuses the same shared `GitRepo` (carried through `original_kwargs`), so `repo.models` stayed stale and `get_commit_message` kept iterating the old models.

## Fix

In `aider/commands.py`, refresh the shared repo's commit-message models before the coder switch, in both commands:

```python
if self.coder.repo:
    self.coder.repo.models = model.commit_message_models()
```

## Tests

Added `test_weak_model_change_updates_commit_message_model` to `tests/basic/test_commands.py`: it creates a coder in a `GitTemporaryDirectory`, runs `cmd_weak_model("gpt-4")`, and asserts `"gpt-4"` is now present in `coder.repo.models`. It fails before the fix (the list stayed `['gpt-4o-mini', 'gpt-3.5-turbo']`) and passes after.

Closes #5213