### PR TITLE
Fix uncaught FileNotFoundError in format_files_for_input

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -1159,7 +1159,10 @@ class InputOutput:
             # Use shorter of abs/rel paths for readonly files
             ro_paths = []
             for rel_path in read_only_files:
-                abs_path = os.path.abspath(os.path.join(self.root, rel_path))
+                try:
+                    abs_path = os.path.abspath(os.path.join(self.root, rel_path))
+                except (FileNotFoundError, OSError):
+                    abs_path = rel_path
                 ro_paths.append(Text(abs_path if len(abs_path) < len(rel_path) else rel_path))
 
             files_with_label = [Text("Readonly:")] + ro_paths


### PR DESCRIPTION
## Problem

`os.path.abspath` raises `FileNotFoundError` when the current working directory no longer exists (e.g., after a directory deletion). This crashes aider with an unhandled exception.

## Fix

Catch `FileNotFoundError` and `OSError` when resolving paths, falling back to the relative path.

Closes #5209