### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in aider, please report
+it privately. Do not include vulnerability details in public GitHub issues,
+discussions, or pull requests.
+
+Preferred reporting path:
+
+- Use GitHub Private Vulnerability Reporting if it is enabled for this
+  repository.
+- If Private Vulnerability Reporting is not yet enabled, ask the maintainers in
+  a public issue for a private reporting channel without sharing technical
+  vulnerability details.
+
+When submitting a private report, include as much safe detail as possible:
+
+- affected versions, platforms, or configurations
+- a clear description of the issue
+- reproduction steps or proof of concept, if safe to share privately
+- expected impact
+- any suggested mitigation
+
+The maintainers will review valid reports and coordinate next steps through the
+private reporting channel.
+
+## Public Disclosure
+
+Please avoid public disclosure until the maintainers have had a chance to
+review the report and coordinate a fix or mitigation where appropriate.
+
+## Maintainer Setup Note
+
+Repository administrators can enable GitHub Private Vulnerability Reporting
+from:
+
+`Settings -> Security -> Private vulnerability reporting -> Enable`


### PR DESCRIPTION
## Summary
- add a SECURITY.md with private vulnerability reporting guidance
- ask reporters not to share vulnerability details in public issues, discussions, or PRs
- include the GitHub Private Vulnerability Reporting setup path for maintainers

## Context
This is a small docs follow-up for #5217 so security reports have a clear private disclosure path.

## Tests
- Documentation-only change
- git diff --check