### PR TITLE
fix: read .aiderignore with the configured encoding

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -514,7 +514,9 @@ class GitRepo:
         if mtime != self.aider_ignore_ts:
             self.aider_ignore_ts = mtime
             self.ignore_file_cache = {}
-            lines = self.aider_ignore_file.read_text().splitlines()
+            lines = self.aider_ignore_file.read_text(
+                encoding=self.io.encoding, errors="replace"
+            ).splitlines()
             self.aider_ignore_spec = pathspec.PathSpec.from_lines(
                 pathspec.patterns.GitWildMatchPattern,
                 lines,

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -81,6 +81,26 @@ class TestRepo(unittest.TestCase):
             self.assertIn("index", diffs)
             self.assertIn("АБВ", diffs)
 
+    def test_aiderignore_respects_configured_encoding(self):
+        # Regression: refresh_aider_ignore() read .aiderignore with the platform
+        # default encoding instead of the configured io.encoding, so an ignore
+        # file saved in a non-UTF8 encoding raised UnicodeDecodeError and aborted
+        # the session. It must honor io.encoding like the rest of GitRepo.
+        with GitTemporaryDirectory():
+            encoding = "cp1251"
+
+            # ASCII pattern plus a Cyrillic comment; the cp1251 bytes (0xc0 0xc1
+            # 0xc2) are invalid UTF-8, so a default-encoding read would raise.
+            aignore = Path(".aiderignore")
+            aignore.write_text("secret.txt\n# АБВ\n", encoding=encoding)
+
+            io = InputOutput(encoding=encoding)
+            git_repo = GitRepo(io, None, ".", aider_ignore_file=".aiderignore")
+
+            # Must not raise on the non-UTF8 file, and the pattern still applies.
+            self.assertTrue(git_repo.ignored_file("secret.txt"))
+            self.assertFalse(git_repo.ignored_file("keep.txt"))
+
     def test_diffs_detached_head(self):
         with GitTemporaryDirectory():
             repo = git.Repo()


### PR DESCRIPTION
## Problem

`GitRepo.refresh_aider_ignore()` reads `.aiderignore` with `Path.read_text()` and no `encoding=` argument, so it uses the platform default encoding (`locale.getpreferredencoding()`). On any system whose default is not UTF-8 (Windows cp1252/cp932, or a `C`/ascii locale), a `.aiderignore` containing non-ASCII bytes raises `UnicodeDecodeError`. Because the ignore file is refreshed on the file-mention path, this aborts the session rather than failing in a narrow command.

This is the only `read_text()` in `repo.py` that does not pass an encoding; every other read/decode in this module already uses `self.io.encoding`.

## Fix

Read `.aiderignore` with the configured `io.encoding` and `errors="replace"`, matching how `GitRepo` decodes git output elsewhere (e.g. `get_diffs()` uses `.decode(self.io.encoding, "replace")`). This respects a user's `--encoding` setting and never crashes on undecodable bytes.

## Test

Adds `test_aiderignore_respects_configured_encoding`, mirroring `test_diffs_with_single_byte_encoding`: writes a `.aiderignore` in cp1251 (bytes invalid as UTF-8) and asserts `ignored_file()` works without raising. It fails on `main` (`UnicodeDecodeError: ... byte 0xc0`) and passes with the fix. Full `tests/basic/test_repo.py` (22 tests) passes; pre-commit (isort/black/flake8/codespell) clean.
