### PR TITLE
fix: gracefully skip missing litellm exception classes in _load

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -76,7 +76,10 @@ class LiteLLMExceptions:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            try:
+                ex = getattr(litellm, var)
+            except AttributeError:
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):


### PR DESCRIPTION
When iterating the hardcoded list of litellm exception class names in _load(), getattr(litellm, var) can raise AttributeError if the installed version of litellm doesn't have that exception class (e.g., PermissionDeniedError).

This wraps the getattr in a try/except AttributeError and continues, gracefully
skipping exception classes that don't exist in the current litellm version.

Closes #5202