### PR TITLE
fix: catch ModuleNotFoundError when loading litellm with helpful diagnostic

### DIFF
--- a/aider/llm.py
+++ b/aider/llm.py
@@ -34,7 +34,27 @@ class LazyLiteLLM:
         if VERBOSE:
             print("Loading litellm...")
 
-        self._lazy_module = importlib.import_module("litellm")
+        try:
+            self._lazy_module = importlib.import_module("litellm")
+        except ModuleNotFoundError as err:
+            print(
+                "Error: Failed to import litellm - a core dependency is missing or"
+                " incompatible."
+            )
+            print(f"Missing module: {err.name}")
+            print(
+                "This is often caused by incompatible dependency versions. Try"
+                " reinstalling aider:"
+            )
+            print()
+            print("    pip install --upgrade aider-chat")
+            print()
+            print(
+                "Or, if you installed in development mode, upgrade the openai package:"
+            )
+            print()
+            print("    pip install --upgrade openai")
+            raise
 
         self._lazy_module.suppress_debug_info = True
         self._lazy_module.set_verbose = False


### PR DESCRIPTION
When litellm fails to import due to a dependency version mismatch (e.g., openai missing the translation_verbose module), the raw ModuleNotFoundError crashes aider without explanation.

This wraps the lazy litellm import in a try/except that prints a clear error message
with the specific missing module name and suggests reinstalling aider or upgrading
the openai package before re-raising.

Closes #5220