### PR TITLE
Detect and use Python file encoding (PEP 263) on read and write

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -450,12 +450,32 @@ class InputOutput:
             self.tool_error(f"{filename}: {e}")
             return
 
+    def read_python_encoding(self, filename):
+        try:
+            with open(str(filename), "r", encoding="raw_unicode_escape") as f:
+                import re
+                line_number = 0
+                while line_number < 2:
+                    line  = f.readline()
+                    match = re.match(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)", line)
+                    if match is not None:
+                        return match.group(1)
+                    line_number += 1
+        except:
+            return
+
     def read_text(self, filename, silent=False):
         if is_image_file(filename):
             return self.read_image(filename)
 
+        encoding = None
+        if str(filename)[-3:] == ".py":
+            encoding = self.read_python_encoding(filename)
+        if encoding is None:
+            encoding = self.encoding
+
         try:
-            with open(str(filename), "r", encoding=self.encoding) as f:
+            with open(str(filename), "r", encoding=encoding) as f:
                 return f.read()
         except FileNotFoundError:
             if not silent:
@@ -487,10 +507,16 @@ class InputOutput:
         if self.dry_run:
             return
 
+        encoding = None
+        if str(filename)[-3:] == ".py":
+            encoding = self.read_python_encoding(filename)
+        if encoding is None:
+            encoding = self.encoding
+
         delay = initial_delay
         for attempt in range(max_retries):
             try:
-                with open(str(filename), "w", encoding=self.encoding, newline=self.newline) as f:
+                with open(str(filename), "w", encoding=encoding, newline=self.newline) as f:
                     f.write(content)
                 return  # Successfully wrote the file
             except PermissionError as err:


### PR DESCRIPTION
Python files can have a comment on their first two lines indicating the file encoding, see [PEP 263](https://peps.python.org/pep-0263/).

By default, aider /add command would fail to read Python files that use a different encoding than utf-8 (or aider encoding setting, not sure, but that's irrelevant as it would still fail on some other files), completely disregarding the encoding declared on the first two lines as per PEP 263.

My code also fixes the writing part, because even if a Python file is read with the proper encoding (the one it declares), then aider would commit it with aider's default encoding (usually utf-8), despite the file comments still stating its original encoding, which can break it and/or render it unusable with Python.