### PR TITLE
fix: catch NoSuchPathError in get_git_root to prevent crash

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -76,7 +76,10 @@ class LiteLLMExceptions:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            try:
+                ex = getattr(litellm, var)
+            except AttributeError:
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):

--- a/aider/main.py
+++ b/aider/main.py
@@ -62,7 +62,7 @@ def get_git_root():
     try:
         repo = git.Repo(search_parent_directories=True)
         return repo.working_tree_dir
-    except (git.InvalidGitRepositoryError, FileNotFoundError):
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError):
         return None
 
 


### PR DESCRIPTION
When git.Repo() is called on a path with special characters (e.g., $ in the path), GitPython raises NoSuchPathError. The get_git_root() function only caught InvalidGitRepositoryError and FileNotFoundError, letting NoSuchPathError crash aider on startup.

Added git.NoSuchPathError to the except clause so get_git_root() gracefully returns None instead of crashing.

Closes #2957