### PR TITLE
Confirm before a whole-file rewrite silently drops most of a file

### DIFF
--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -125,6 +125,23 @@ class WholeFileCoder(Coder):
         for path, fname_source, new_lines in edits:
             full_path = self.abs_root_path(path)
             new_lines = "".join(new_lines)
+            # Guard against silent data loss: a whole-file rewrite that's drastically
+            # shorter than the current file almost always means the model saw incomplete
+            # context (a truncated read, an oversized file, a hallucination). Confirm first.
+            if Path(full_path).exists():
+                current = self.io.read_text(full_path, silent=True) or ""
+                cur_n = current.count("\n") + 1
+                new_n = new_lines.count("\n") + 1
+                if cur_n >= 10 and new_n < cur_n * 0.5:
+                    if not self.io.confirm_ask(
+                        f"{path}: the rewrite is {new_n} lines vs {cur_n} now"
+                        f" - write it and drop {cur_n - new_n} lines?",
+                        default="n",
+                    ):
+                        self.io.tool_warning(
+                            f"Skipped {path} to avoid losing {cur_n - new_n} lines."
+                        )
+                        continue
             self.io.write_text(full_path, new_lines)
 
     def do_live_diff(self, full_path, new_lines, final):

--- a/tests/basic/test_wholefile_no_data_loss.py
+++ b/tests/basic/test_wholefile_no_data_loss.py
@@ -1,0 +1,49 @@
+"""Regression test for the Aider PR: a drastic whole-file shrink must not be
+written silently (it's almost always data loss from incomplete context).
+
+Drop this into aider's suite as tests/basic/test_wholefile_no_data_loss.py.
+It needs NO LLM call — it calls apply_edits() directly with a shrinking edit,
+which is exactly the code path the fix guards.
+
+  with the fix  -> PASS  (apply_edits asks before overwriting; file preserved)
+  without it    -> FAIL  (file silently clobbered down to 2 lines)
+"""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from aider.coders import Coder
+from aider.io import InputOutput
+from aider.models import Model
+
+
+class TestWholeFileNoDataLoss(unittest.TestCase):
+    def test_drastic_shrink_is_confirmed_not_silent(self):
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as d:
+            os.chdir(d)                       # so the coder's root is this temp dir
+            try:
+                with open("mod.py", "w") as fh:
+                    fh.write("".join("line%d = %d\n" % (i, i) for i in range(20)))
+
+                io = InputOutput(yes=False)
+                coder = Coder.create(
+                    main_model=Model("gpt-4o"), io=io, fnames=["mod.py"],
+                    edit_format="whole", use_git=False,
+                )
+                # a whole-file rewrite that returns only 2 of the 20 lines
+                edits = [("mod.py", "chat", ["line0 = 0\n", "line1 = 1\n"])]
+
+                with patch.object(io, "confirm_ask", return_value=False) as ask:
+                    coder.apply_edits(edits)
+
+                ask.assert_called()                                  # it asked first
+                with open("mod.py") as fh:
+                    self.assertEqual(len(fh.read().splitlines()), 20)  # nothing lost
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While testing how Aider handles incomplete tool input, I found a case where the `whole` edit format can silently delete code: `WholeFileCoder.apply_edits` writes the model's output straight to disk without comparing it to the current file. So if the model returns a much shorter rewrite — truncated context, a large file, or a hallucinated short version — the rest of the file is overwritten and lost, with no warning.

This adds a small guard: if a rewrite is <50% the size of an existing file (≥10 lines), confirm before writing (default: no), otherwise skip and warn. Includes a regression test that fails on `main` and passes with the change. Happy to tune the threshold or wording.
