### PR TITLE
fix: tolerate platform info lookup failures

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1128,7 +1128,7 @@ class Coder:
         platform_text = ""
         try:
             platform_text = f"- Platform: {platform.platform()}\n"
-        except KeyError:
+        except Exception:
             # Skip platform info if it can't be retrieved
             platform_text = "- Platform information unavailable\n"
 

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1327,6 +1327,17 @@ This command will print 'Hello, World!' to the console."""
             with patch("os.environ.get", return_value=None) as mock_env_get:
                 self.assertIsNone(coder.get_user_language())
 
+    def test_get_platform_info_handles_platform_failure(self):
+        io = InputOutput()
+        coder = Coder.create(self.GPT35, None, io=io)
+
+        with patch("aider.coders.base_coder.platform.platform", side_effect=OSError("timeout")):
+            platform_info = coder.get_platform_info()
+
+        self.assertIn("- Platform information unavailable\n", platform_info)
+        self.assertIn("- Shell:", platform_info)
+        self.assertIn("- Current date:", platform_info)
+
     def test_architect_coder_auto_accept_true(self):
         with GitTemporaryDirectory():
             io = InputOutput(yes=True)


### PR DESCRIPTION
Fixes #3464.

`Coder.get_platform_info()` uses `platform.platform()` while building prompt context. On Windows, that call can fail while collecting WMI-backed metadata; since platform text is only auxiliary context, aider should fall back instead of aborting startup.

This keeps the existing unavailable-platform fallback, but applies it to any exception raised by `platform.platform()`. The rest of the platform info block still includes shell and date information.

Validation:
- `/tmp/aider-platform-test/bin/python -m pytest tests/basic/test_coder.py::TestCoder::test_get_platform_info_handles_platform_failure tests/basic/test_coder.py::TestCoder::test_get_user_language -q`
- `/tmp/aider-platform-test/bin/python -m flake8 aider/coders/base_coder.py tests/basic/test_coder.py`
- `git diff --check`