### PR TITLE
fix: replace surrogate chars before completion requests

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import platform
+import re
 import sys
 import time
 from dataclasses import dataclass, fields
@@ -29,6 +30,20 @@ request_timeout = 600
 
 DEFAULT_MODEL_NAME = "gpt-4o"
 ANTHROPIC_BETA_HEADER = "prompt-caching-2024-07-31,pdfs-2024-09-25"
+SURROGATE_RE = re.compile("[\ud800-\udfff]")
+
+
+def replace_surrogates(value):
+    if isinstance(value, str):
+        return SURROGATE_RE.sub("\ufffd", value)
+    if isinstance(value, list):
+        return [replace_surrogates(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(replace_surrogates(item) for item in value)
+    if isinstance(value, dict):
+        return {replace_surrogates(key): replace_surrogates(item) for key, item in value.items()}
+    return value
+
 
 OPENAI_MODELS = """
 o1
@@ -1021,7 +1036,7 @@ class Model(ModelSettings):
             kwargs["timeout"] = request_timeout
         if self.verbose:
             dump(kwargs)
-        kwargs["messages"] = messages
+        kwargs["messages"] = replace_surrogates(messages)
 
         # Are we using github copilot?
         if "GITHUB_COPILOT_TOKEN" in os.environ:

--- a/tests/basic/test_sendchat.py
+++ b/tests/basic/test_sendchat.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -53,6 +54,24 @@ class TestSendChat(unittest.TestCase):
 
         assert response == mock_response
         mock_completion.assert_called_once()
+
+    @patch("litellm.completion")
+    def test_send_completion_replaces_surrogate_characters(self, mock_completion):
+        messages = [
+            {
+                "role": "user",
+                "content": "bad surrogate: \udcb0",
+                "extra": [{"text": "nested \ud800 value"}],
+            }
+        ]
+
+        Model(self.mock_model).send_completion(messages, functions=None, stream=False)
+
+        called_messages = mock_completion.call_args.kwargs["messages"]
+        assert called_messages[0]["content"] == "bad surrogate: \ufffd"
+        assert called_messages[0]["extra"][0]["text"] == "nested \ufffd value"
+        json.dumps(called_messages, ensure_ascii=False).encode("utf-8")
+        assert messages[0]["content"] == "bad surrogate: \udcb0"
 
     @patch("litellm.completion")
     def test_send_completion_with_functions(self, mock_completion):


### PR DESCRIPTION
Fixes #3460.

Some inputs can contain lone Unicode surrogate code points. Those strings cannot be encoded as UTF-8 when httpx serializes the completion request JSON, which can abort the send path before the model request is made.

This replaces surrogate code points in completion messages with the Unicode replacement character at the model request boundary, while leaving the original message objects unchanged. Normal Unicode text, including non-ASCII content, is preserved.

Validation:
- `.venv/bin/python -m pytest tests/basic/test_sendchat.py::TestSendChat::test_send_completion_replaces_surrogate_characters -q` -> 1 passed
- `.venv/bin/python -m pytest tests/basic/test_sendchat.py -q` -> 13 passed
- `.venv/bin/pre-commit run black --files aider/models.py tests/basic/test_sendchat.py` -> passed
- `.venv/bin/pre-commit run isort --files aider/models.py tests/basic/test_sendchat.py` -> passed
- `.venv/bin/pre-commit run flake8 --files aider/models.py tests/basic/test_sendchat.py` -> passed
- `.venv/bin/pre-commit run codespell --files aider/models.py tests/basic/test_sendchat.py` -> passed
- `git diff --check origin/main...HEAD` -> passed