### PR TITLE
fix: catch SystemError in render_tree when tree-sitter AST parsing fails

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -76,7 +76,10 @@ class LiteLLMExceptions:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            try:
+                ex = getattr(litellm, var)
+            except AttributeError:
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):

--- a/aider/main.py
+++ b/aider/main.py
@@ -62,7 +62,7 @@ def get_git_root():
     try:
         repo = git.Repo(search_parent_directories=True)
         return repo.working_tree_dir
-    except (git.InvalidGitRepositoryError, FileNotFoundError):
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError):
         return None
 
 

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -144,6 +144,12 @@ class RepoMap:
             self.io.tool_error("Disabling repo map, git repo too large?")
             self.max_map_tokens = 0
             return
+        except SystemError:
+            self.io.tool_error(
+                "Disabling repo map due to an unexpected error parsing file ASTs"
+            )
+            self.max_map_tokens = 0
+            return
 
         if not files_listing:
             return
@@ -714,36 +720,48 @@ class RepoMap:
         if key in self.tree_cache:
             return self.tree_cache[key]
 
-        if (
-            rel_fname not in self.tree_context_cache
-            or self.tree_context_cache[rel_fname]["mtime"] != mtime
-        ):
-            code = self.io.read_text(abs_fname) or ""
-            if not code.endswith("\n"):
-                code += "\n"
+        try:
+            if (
+                rel_fname not in self.tree_context_cache
+                or self.tree_context_cache[rel_fname]["mtime"] != mtime
+            ):
+                code = self.io.read_text(abs_fname) or ""
+                if not code.endswith("\n"):
+                    code += "\n"
 
-            context = TreeContext(
-                rel_fname,
-                code,
-                color=False,
-                line_number=False,
-                child_context=False,
-                last_line=False,
-                margin=0,
-                mark_lois=False,
-                loi_pad=0,
-                # header_max=30,
-                show_top_of_file_parent_scope=False,
-            )
-            self.tree_context_cache[rel_fname] = {"context": context, "mtime": mtime}
+                context = TreeContext(
+                    rel_fname,
+                    code,
+                    color=False,
+                    line_number=False,
+                    child_context=False,
+                    last_line=False,
+                    margin=0,
+                    mark_lois=False,
+                    loi_pad=0,
+                    # header_max=30,
+                    show_top_of_file_parent_scope=False,
+                )
+                self.tree_context_cache[rel_fname] = {"context": context, "mtime": mtime}
 
-        context = self.tree_context_cache[rel_fname]["context"]
-        context.lines_of_interest = set()
-        context.add_lines_of_interest(lois)
-        context.add_context()
-        res = context.format()
-        self.tree_cache[key] = res
-        return res
+            context = self.tree_context_cache[rel_fname]["context"]
+            context.lines_of_interest = set()
+            context.add_lines_of_interest(lois)
+            context.add_context()
+            res = context.format()
+            self.tree_cache[key] = res
+            return res
+        except SystemError:
+            if self.io:
+                self.io.tool_warning(
+                    f"Failed to parse AST for {rel_fname}, skipping tree context"
+                )
+            # Clear any stale context so we retry fresh next time
+            self.tree_context_cache.pop(rel_fname, None)
+            # Return empty string so the file still appears in the listing
+            # but without AST context
+            self.tree_cache[key] = ""
+            return ""
 
     def to_tree(self, tags, chat_rel_fnames):
         if not tags:


### PR DESCRIPTION
TreeContext.walk_tree() from grep_ast can raise SystemError with 'unknown opcode' when parsing certain files. Since SystemError inherits from BaseException (not Exception), it would crash aider entirely.

This wraps the TreeContext creation and usage in render_tree() with a try/except SystemError that gracefully skips the AST context for that file, logs a warning, and clears the cache so we retry fresh if needed.

Also adds a separate except SystemError in get_repo_map() as a safety net with an accurate error message.

Closes #5244