### PR TITLE
feat: add .aider.md template system for project-level instructions

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -775,6 +775,14 @@ def get_parser(default_config_files, git_root):
         help="Load and execute /commands from a file on launch",
     ).complete = shtab.FILE
     group.add_argument(
+        "--aider-md",
+        metavar="AIDER_MD_FILE",
+        help=(
+            "Specify a .aider.md file with project-level instructions for the LLM"
+            " (default: search for .aider.md in git root, cwd or home directory)"
+        ),
+    ).complete = shtab.FILE
+    group.add_argument(
         "--encoding",
         default="utf-8",
         help="Specify the encoding for input and output (default: utf-8)",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -338,7 +338,16 @@ class Coder:
         file_watcher=None,
         auto_copy_context=False,
         auto_accept_architect=True,
+        aider_md_path=None,
     ):
+        self.aider_md_path = aider_md_path
+        self.aider_md_content = None
+        if self.aider_md_path and Path(self.aider_md_path).exists():
+            try:
+                self.aider_md_content = Path(self.aider_md_path).read_text(encoding="utf-8")
+            except OSError:
+                pass
+
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
 
@@ -1228,6 +1237,14 @@ class Coder:
         main_sys = self.fmt_system_prompt(self.gpt_prompts.main_system)
         if self.main_model.system_prompt_prefix:
             main_sys = self.main_model.system_prompt_prefix + "\n" + main_sys
+
+        if self.aider_md_content:
+            main_sys = (
+                "# Project Instructions\n\n"
+                + self.aider_md_content.strip()
+                + "\n\n"
+                + main_sys
+            )
 
         example_messages = []
         if self.main_model.examples_as_sys_msg:

--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -76,7 +76,10 @@ class LiteLLMExceptions:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            try:
+                ex = getattr(litellm, var)
+            except AttributeError:
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):

--- a/aider/main.py
+++ b/aider/main.py
@@ -62,7 +62,7 @@ def get_git_root():
     try:
         repo = git.Repo(search_parent_directories=True)
         return repo.working_tree_dir
-    except (git.InvalidGitRepositoryError, FileNotFoundError):
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError, FileNotFoundError):
         return None
 
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -872,6 +872,19 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         if main_model.edit_format in ("diff", "whole", "diff-fenced"):
             main_model.edit_format = "editor-" + main_model.edit_format
 
+    # Search for .aider.md file
+    aider_md_files = generate_search_path_list(
+        ".aider.md", git_root, args.aider_md
+    )
+    aider_md_path = None
+    # Iterate in reverse so most specific path (command_line -> CWD -> git_root -> homedir) wins
+    for fname in reversed(aider_md_files):
+        if Path(fname).exists():
+            aider_md_path = str(Path(fname).resolve())
+            if args.verbose:
+                io.tool_output(f"Found .aider.md: {aider_md_path}")
+            break
+
     if args.verbose:
         io.tool_output("Model metadata:")
         io.tool_output(json.dumps(main_model.info, indent=4))
@@ -1004,6 +1017,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             auto_copy_context=args.copy_paste,
             auto_accept_architect=args.auto_accept_architect,
             add_gitignore_files=args.add_gitignore_files,
+            aider_md_path=aider_md_path,
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -144,6 +144,12 @@ class RepoMap:
             self.io.tool_error("Disabling repo map, git repo too large?")
             self.max_map_tokens = 0
             return
+        except SystemError:
+            self.io.tool_error(
+                "Disabling repo map due to an unexpected error parsing file ASTs"
+            )
+            self.max_map_tokens = 0
+            return
 
         if not files_listing:
             return
@@ -714,36 +720,48 @@ class RepoMap:
         if key in self.tree_cache:
             return self.tree_cache[key]
 
-        if (
-            rel_fname not in self.tree_context_cache
-            or self.tree_context_cache[rel_fname]["mtime"] != mtime
-        ):
-            code = self.io.read_text(abs_fname) or ""
-            if not code.endswith("\n"):
-                code += "\n"
+        try:
+            if (
+                rel_fname not in self.tree_context_cache
+                or self.tree_context_cache[rel_fname]["mtime"] != mtime
+            ):
+                code = self.io.read_text(abs_fname) or ""
+                if not code.endswith("\n"):
+                    code += "\n"
 
-            context = TreeContext(
-                rel_fname,
-                code,
-                color=False,
-                line_number=False,
-                child_context=False,
-                last_line=False,
-                margin=0,
-                mark_lois=False,
-                loi_pad=0,
-                # header_max=30,
-                show_top_of_file_parent_scope=False,
-            )
-            self.tree_context_cache[rel_fname] = {"context": context, "mtime": mtime}
+                context = TreeContext(
+                    rel_fname,
+                    code,
+                    color=False,
+                    line_number=False,
+                    child_context=False,
+                    last_line=False,
+                    margin=0,
+                    mark_lois=False,
+                    loi_pad=0,
+                    # header_max=30,
+                    show_top_of_file_parent_scope=False,
+                )
+                self.tree_context_cache[rel_fname] = {"context": context, "mtime": mtime}
 
-        context = self.tree_context_cache[rel_fname]["context"]
-        context.lines_of_interest = set()
-        context.add_lines_of_interest(lois)
-        context.add_context()
-        res = context.format()
-        self.tree_cache[key] = res
-        return res
+            context = self.tree_context_cache[rel_fname]["context"]
+            context.lines_of_interest = set()
+            context.add_lines_of_interest(lois)
+            context.add_context()
+            res = context.format()
+            self.tree_cache[key] = res
+            return res
+        except SystemError:
+            if self.io:
+                self.io.tool_warning(
+                    f"Failed to parse AST for {rel_fname}, skipping tree context"
+                )
+            # Clear any stale context so we retry fresh next time
+            self.tree_context_cache.pop(rel_fname, None)
+            # Return empty string so the file still appears in the listing
+            # but without AST context
+            self.tree_cache[key] = ""
+            return ""
 
     def to_tree(self, tags, chat_rel_fnames):
         if not tags:


### PR DESCRIPTION
Adds support for a .aider.md file in the project root (similar to Claude Code's CLAUDE.md) that provides project-level instructions to the LLM.

The search order (most specific wins):
1. --aider-md CLI argument (explicit path)
2. .aider.md in CWD
3. <git_root>/.aider.md (repo root)
4. ~/.aider.md (home directory)

The .aider.md content is injected at the top of the system prompt
as '# Project Instructions', giving the LLM context about project
architecture, conventions, testing patterns, and commands.

Closes #5204