### PR TITLE
fix: continue after --test failures

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -1058,9 +1058,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             io.tool_error("No --test-cmd provided.")
             analytics.event("exit", reason="No test command provided")
             return 1
-        coder.commands.cmd_test(args.test_cmd)
-        if io.placeholder:
-            coder.run(io.placeholder)
+        test_errors = coder.commands.cmd_test(args.test_cmd)
+        if test_errors:
+            coder.run(with_message=test_errors)
 
     if args.commit:
         if args.dry_run:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -338,6 +338,36 @@ class TestMain(TestCase):
 
         os.remove(message_file_path)
 
+    def test_test_flag_runs_with_failing_test_output(self):
+        test_errors = "I ran this command:\n\npytest\n\nAnd got this output:\n\nFAILED test.py\n"
+
+        with patch("aider.coders.Coder.create") as MockCoder:
+            mock_coder = MockCoder.return_value
+            mock_coder.commands.cmd_test.return_value = test_errors
+
+            main(
+                ["--yes", "--test", "--test-cmd", "pytest"],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+
+            mock_coder.commands.cmd_test.assert_called_once_with("pytest")
+            mock_coder.run.assert_called_once_with(with_message=test_errors)
+
+    def test_test_flag_does_not_run_when_tests_pass(self):
+        with patch("aider.coders.Coder.create") as MockCoder:
+            mock_coder = MockCoder.return_value
+            mock_coder.commands.cmd_test.return_value = None
+
+            main(
+                ["--yes", "--test", "--test-cmd", "pytest"],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+
+            mock_coder.commands.cmd_test.assert_called_once_with("pytest")
+            mock_coder.run.assert_not_called()
+
     def test_encodings_arg(self):
         fname = "foo.py"
 


### PR DESCRIPTION
## Summary

This makes the `--test` startup flag continue into a model run when the configured test command fails.

`cmd_test()` already returns the formatted failing test output that gets added to the chat, but the `--test` path in `main()` was discarding that return value. This PR passes the returned failure message to `coder.run(with_message=...)`, so `aider --test` can continue with the test failure context instead of stopping after adding the output to chat.

Fixes #4214.

## Details

Before this change, `aider --test` would run the configured test command and add non-zero output to the chat, but it would not ask the model to respond to that failure. This differed from `aider -m "/test"`, which continues with the failure output and lets the model attempt to help.

This change keeps the passing-test behavior unchanged: if the test command succeeds and `cmd_test()` returns no failure message, `--test` does not trigger an extra model run.

## Tests

```text
.\.venv\Scripts\python -m pytest tests/basic/test_main.py -k "test_test_flag"