### PR TITLE
docs: add TokenMix as an OpenAI-compatible LLM provider

### DIFF
--- a/aider/website/docs/llms/tokenmix.md
+++ b/aider/website/docs/llms/tokenmix.md
@@ -1,0 +1,38 @@
+---
+parent: Connecting to LLMs
+nav_order: 510
+---
+
+# TokenMix
+
+Aider can connect to [TokenMix](https://tokenmix.ai/), an OpenAI-compatible API gateway
+with 300+ models across 17 vendors — including OpenAI, Anthropic and Google models,
+plus Chinese models that are otherwise hard to access from outside China
+(Qwen, DeepSeek, Doubao, GLM, Kimi, Hunyuan).
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your key and endpoint using TokenMix's OpenAI-compatible base URL:
+
+```
+export OPENAI_API_BASE=https://api.tokenmix.ai/v1 # Mac/Linux
+export OPENAI_API_KEY=<your-tokenmix-key>          # Mac/Linux
+
+setx OPENAI_API_BASE https://api.tokenmix.ai/v1    # Windows, restart shell after setx
+setx OPENAI_API_KEY <your-tokenmix-key>            # Windows, restart shell after setx
+```
+
+Start working with aider, prefixing model names with `openai/`:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+aider --model openai/deepseek/deepseek-v3.2
+# or
+aider --model openai/qwen/qwen3.7-max
+```
+
+See the [model warnings](https://aider.chat/docs/llms/warnings.html) section for working with unfamiliar models.


### PR DESCRIPTION
## Summary

Adds a docs page for connecting aider to **TokenMix**, following the same OpenAI-compatible pattern used by the OpenRouter and OpenAI-compatible API pages.

TokenMix is an OpenAI-compatible API gateway exposing 300+ models across 17 vendors (OpenAI, Anthropic, Google, plus Chinese models such as Qwen, DeepSeek, Doubao, GLM, Kimi and Hunyuan) behind one base URL (`https://api.tokenmix.ai/v1`) and one key. Aider reaches it through its existing OpenAI-compatible support by setting `OPENAI_API_BASE` and the `openai/` model prefix — no code changes.

## Changes

- Add `aider/website/docs/llms/tokenmix.md` with `parent: Connecting to LLMs` so it nests under the LLM connection docs automatically.

Example model IDs are live entries in the TokenMix catalog.
