### PR TITLE
docs: add OpenPaths (OpenAI-compatible gateway)

### DIFF
--- a/aider/website/docs/llms.md
+++ b/aider/website/docs/llms.md
@@ -38,6 +38,14 @@ It can also access
 local models that provide an
 [Open AI compatible API](/docs/llms/openai-compat.html).
 
+## Gateways
+{: .no_toc }
+
+Aider can connect to OpenAI-compatible gateways that provide access to many models
+through a single API, such as
+[OpenRouter](/docs/llms/openrouter.html) and
+[OpenPaths](/docs/llms/openpaths.html).
+
 ## Use a capable model
 {: .no_toc }
 

--- a/aider/website/docs/llms/openpaths.md
+++ b/aider/website/docs/llms/openpaths.md
@@ -1,0 +1,47 @@
+---
+parent: Connecting to LLMs
+nav_order: 500
+---
+
+# OpenPaths
+
+Aider can connect to [models provided by OpenPaths](https://openpaths.io),
+an OpenAI-compatible gateway that gives you access to many models through a single API.
+You'll need an [OpenPaths API key](https://openpaths.io/account).
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your API key and endpoint:
+
+```
+# Mac/Linux:
+export OPENAI_API_BASE=https://openpaths.io/v1
+export OPENAI_API_KEY=<key>
+
+# Windows:
+setx OPENAI_API_BASE https://openpaths.io/v1
+setx OPENAI_API_KEY <key>
+# ... restart shell after setx commands
+```
+
+Start working with aider and OpenPaths on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# Prefix the model name with openai/ to use the OpenAI-compatible path
+aider --model openai/openpaths/auto
+
+# Or pick a model better suited to coding
+aider --model openai/openpaths/auto-code
+```
+
+You can browse the available models at
+[https://openpaths.io/v1/models](https://openpaths.io/v1/models).
+
+See the [model warnings](warnings.html)
+section for information on warnings which will occur
+when working with models that aider is not familiar with.


### PR DESCRIPTION
## What

Adds documentation for connecting Aider to [OpenPaths](https://openpaths.io), an OpenAI-compatible gateway (similar to OpenRouter) that provides access to many models through a single API.

## Changes

- Add `aider/website/docs/llms/openpaths.md`, mirroring the existing provider pages (`openai-compat.md` / `openrouter.md`) and their Jekyll front-matter. It shows installing aider, setting `OPENAI_API_BASE=https://openpaths.io/v1` and `OPENAI_API_KEY`, and running e.g. `aider --model openai/openpaths/auto`.
- Link the new page from the "Connecting to LLMs" overview (`llms.md`) alongside OpenRouter.

Docs-only and additive. No Python/code changes — Aider routes via LiteLLM, so OpenPaths works through the existing OpenAI-compatible path.

## Testing

Markdown-only change. The new page reuses the same Jekyll front-matter (`parent: Connecting to LLMs`, `nav_order: 500`) as the other gateway/provider pages, so it appears in the sidebar under "Connecting to LLMs" like the existing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)