### PR TITLE
Enforce repo-root containment for model-driven edits

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -573,6 +573,21 @@ class Coder:
         self.abs_root_path_cache[key] = res
         return res
 
+    def is_path_in_root(self, path):
+        """Return True if `path` (resolved against the repo root) stays within the root.
+
+        Model-supplied edit paths may contain `..` segments or be absolute, which
+        would otherwise let an edit escape the repository root. This mirrors the
+        containment check already enforced by the interactive ``/add`` command
+        (see Commands.cmd_add) so that model-driven edits get the same protection.
+        """
+        try:
+            abs_path = Path(self.abs_root_path(path)).resolve()
+            root = Path(self.root).resolve()
+        except (OSError, RuntimeError, ValueError):
+            return False
+        return abs_path == root or abs_path.is_relative_to(root)
+
     fences = all_fences
     fence = fences[0]
 
@@ -2190,6 +2205,15 @@ class Coder:
 
     def allowed_to_edit(self, path):
         full_path = self.abs_root_path(path)
+
+        # Refuse edits that resolve outside the repo root (e.g. `..` traversal or
+        # absolute paths). This guard is independent of the confirmation prompts
+        # below, so it is enforced even when --yes-always is set. It matches the
+        # containment check already applied by the /add command.
+        if not self.is_path_in_root(path):
+            self.io.tool_error(f"Skipping edits to {path} which is not within {self.root}")
+            return
+
         if self.repo:
             need_to_add = not self.repo.path_in_repo(path)
         else:

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -101,6 +101,93 @@ class TestCoder(unittest.TestCase):
             self.assertTrue(coder.allowed_to_edit("added.txt"))
             self.assertTrue(coder.need_commit_before_edits)
 
+    def test_allowed_to_edit_outside_root(self):
+        # A model-chosen edit path that escapes the repo root (via `..` or an
+        # absolute path) must be refused, even with --yes-always (io.yes=True).
+        #
+        # The git repo is created in a nested subdir so the "outside root" target
+        # still lands inside the (auto-cleaned) temp dir, keeping the test from
+        # touching the shared OS temp directory even when run against old code.
+        with GitTemporaryDirectory() as temp_dir:
+            outside_dir = Path(temp_dir).resolve()
+            workspace = outside_dir / "workspace"
+            workspace.mkdir()
+            os.chdir(workspace)
+
+            repo = git.Repo.init(workspace)
+            repo.config_writer().set_value("user", "name", "Test User").release()
+            repo.config_writer().set_value("user", "email", "t@example.com").release()
+
+            fname = Path("added.txt")
+            fname.touch()
+            repo.git.add(str(fname))
+            repo.git.commit("-m", "init")
+
+            # --yes-always: confirm prompts would auto-approve, so the only thing
+            # that can stop an out-of-root write is the containment guard.
+            io = InputOutput(yes=True)
+            coder = Coder.create(self.GPT35, None, io, fnames=["added.txt"])
+
+            traversal_rel = os.path.join("..", "pwned_rel.txt")
+            traversal_abs = str(outside_dir / "pwned_abs.txt")
+
+            # The gate must refuse both relative-traversal and absolute escapes.
+            self.assertFalse(coder.allowed_to_edit(traversal_rel))
+            self.assertFalse(coder.allowed_to_edit(traversal_abs))
+
+            # And it must not have created/touched anything outside the root.
+            self.assertFalse((outside_dir / "pwned_rel.txt").exists())
+            self.assertFalse((outside_dir / "pwned_abs.txt").exists())
+
+            # In-root edits are still allowed (no regression).
+            self.assertTrue(coder.allowed_to_edit("new_in_root.txt"))
+
+    def test_editblock_create_file_outside_root_blocked(self):
+        # End-to-end: an edit block that names an out-of-root file must not be
+        # written to disk, even under --yes-always.
+        with GitTemporaryDirectory() as temp_dir:
+            outside_dir = Path(temp_dir).resolve()
+            workspace = outside_dir / "workspace"
+            workspace.mkdir()
+            os.chdir(workspace)
+
+            repo = git.Repo.init(workspace)
+            repo.config_writer().set_value("user", "name", "Test User").release()
+            repo.config_writer().set_value("user", "email", "t@example.com").release()
+
+            fname = Path("added.txt")
+            fname.write_text("one\n")
+            repo.git.add(str(fname))
+            repo.git.commit("-m", "init")
+
+            io = InputOutput(yes=True)
+            coder = Coder.create(
+                self.GPT35,
+                "diff",
+                io,
+                fnames=["added.txt"],
+            )
+
+            target = outside_dir / "pwned_editblock.txt"
+            self.assertFalse(target.exists())
+
+            # SEARCH/REPLACE block creating a brand-new file outside the root.
+            coder.partial_response_content = (
+                "Here you go:\n\n"
+                "../pwned_editblock.txt\n"
+                "<<<<<<< SEARCH\n"
+                "=======\n"
+                "owned\n"
+                ">>>>>>> REPLACE\n"
+            )
+
+            coder.apply_updates()
+
+            self.assertFalse(
+                target.exists(),
+                "edit block escaped the repo root and wrote an out-of-root file",
+            )
+
     def test_get_files_content(self):
         tempdir = Path(tempfile.mkdtemp())
 


### PR DESCRIPTION
Edit paths chosen by the model (via SEARCH/REPLACE, whole-file, udiff, etc.) flowed through allowed_to_edit -> abs_root_path, which resolves `..` segments and absolute paths but never verified the result stayed inside the repo root. The only gate for a new out-of-root path was a "Create new file?" confirmation, which is auto-approved under --yes-always, so a model-supplied path like `../../../tmp/pwned.py` could be written outside the workspace.

Add a Coder.is_path_in_root() containment helper and reject out-of-root edit paths at the top of allowed_to_edit(), independent of the confirmation prompts so it holds even with --yes-always. This mirrors the containment check the interactive /add command already applies (Commands.cmd_add) and the is_relative_to() checks already used in watch.py and commands.py.

In-root edits are unaffected; only paths escaping the root are refused.

Adds regression tests covering both the allowed_to_edit gate (relative `..` and absolute escapes) and the end-to-end edit-block write path under --yes-always.