### PR TITLE
Fix path traversal in the patch coder via "*** Move to:"

### DIFF
--- a/aider/coders/patch_coder.py
+++ b/aider/coders/patch_coder.py
@@ -546,6 +546,27 @@ class PatchCoder(Coder):
         action = PatchAction(type=ActionType.ADD, path="", new_content="\n".join(added_lines))
         return action, index
 
+    def _assert_within_root(self, rel_path, abs_path):
+        """Reject a patch target that resolves outside the repository root.
+
+        Patch paths -- including ``*** Move to:`` targets -- come straight from
+        the LLM response. Without this check a path such as ``../../.bashrc``
+        would resolve outside the project, letting a patch create, overwrite or
+        delete files anywhere the user can write. The move target in particular
+        never passes through the in-chat edit confirmation, so this is the only
+        guard standing between LLM output and an arbitrary-file write.
+
+        Args:
+            rel_path: The path as written in the patch (used for the message).
+            abs_path: The resolved absolute path to validate.
+
+        Raises:
+            DiffError: If ``abs_path`` is not inside the repository root.
+        """
+        root = pathlib.Path(self.root).resolve()
+        if not pathlib.Path(abs_path).resolve().is_relative_to(root):
+            raise DiffError(f"Refusing to edit path outside the project root: {rel_path}")
+
     def apply_edits(self, edits: List[PatchAction]):
         """
         Applies the parsed PatchActions to the corresponding files.
@@ -561,6 +582,8 @@ class PatchCoder(Coder):
             # action.path is the canonical path within the action logic
             full_path = self.abs_root_path(action.path)
             path_obj = pathlib.Path(full_path)
+            # The path is LLM-supplied; never let an edit land outside the repo.
+            self._assert_within_root(action.path, full_path)
 
             try:
                 if action.type == ActionType.ADD:
@@ -603,6 +626,10 @@ class PatchCoder(Coder):
                     target_full_path = (
                         self.abs_root_path(action.move_path) if action.move_path else full_path
                     )
+                    if action.move_path:
+                        # The move target skips the edit confirmation entirely,
+                        # so this is the only check keeping it inside the repo.
+                        self._assert_within_root(action.move_path, target_full_path)
                     target_path_obj = pathlib.Path(target_full_path)
 
                     if action.move_path:

--- a/tests/basic/test_patch.py
+++ b/tests/basic/test_patch.py
@@ -1,0 +1,115 @@
+import unittest
+from pathlib import Path
+
+from aider.coders import Coder
+from aider.dump import dump  # noqa: F401
+from aider.io import InputOutput
+from aider.models import Model
+from aider.utils import GitTemporaryDirectory
+
+
+class TestPatchCoderSecurity(unittest.TestCase):
+    """Path-confinement tests for the patch coder.
+
+    The patch coder takes file paths -- including ``*** Move to:`` targets --
+    straight from the LLM response. These tests pin that such paths cannot
+    escape the repository root, while a legitimate in-repo move still works.
+    """
+
+    def setUp(self):
+        """Set up a cheap model handle shared by the tests."""
+        self.GPT35 = Model("gpt-3.5-turbo")
+
+    def test_rejects_move_outside_repo(self):
+        """A ``*** Move to:`` path that escapes the repo must be refused.
+
+        The move target never passes the in-chat edit confirmation, so an
+        out-of-root target must be rejected outright rather than silently
+        overwriting a file outside the project and deleting the source.
+        """
+        with GitTemporaryDirectory() as repo_dir:
+            src = Path(repo_dir) / "sample.txt"
+            src.write_text("Original content\n")
+
+            outside = Path(repo_dir).parent / "escape_victim.txt"
+            outside.write_text("PRECIOUS\n")
+            self.addCleanup(lambda: outside.exists() and outside.unlink())
+
+            # yes=False: refuse every confirmation. The source file is added to
+            # the chat, so the source edit needs no confirmation -- only the
+            # missing move-target guard stands between the LLM and the write.
+            io = InputOutput(yes=False)
+            coder = Coder.create(self.GPT35, "patch", io=io, fnames=[str(src)])
+
+            coder.partial_response_content = (
+                "*** Begin Patch\n"
+                "*** Update File: sample.txt\n"
+                "*** Move to: ../escape_victim.txt\n"
+                "@@\n"
+                "-Original content\n"
+                "+Hacked content\n"
+                "*** End Patch\n"
+            )
+
+            coder.apply_updates()
+
+            # The out-of-repo file is untouched and the source still exists.
+            self.assertEqual(outside.read_text(), "PRECIOUS\n")
+            self.assertTrue(src.exists())
+            self.assertEqual(src.read_text(), "Original content\n")
+
+    def test_apply_edits_rejects_add_outside_repo(self):
+        """``apply_edits`` refuses an ADD whose path escapes the repo.
+
+        Driven at the ``apply_edits`` level with a constructed action so the
+        ``action.path`` guard is exercised directly, independent of the
+        separate new-file confirmation in ``allowed_to_edit``.
+        """
+        from aider.coders.patch_coder import ActionType, PatchAction
+
+        with GitTemporaryDirectory() as repo_dir:
+            outside = Path(repo_dir).parent / "escape_added.txt"
+            self.addCleanup(lambda: outside.exists() and outside.unlink())
+
+            io = InputOutput(yes=True)
+            coder = Coder.create(self.GPT35, "patch", io=io)
+
+            action = PatchAction(
+                type=ActionType.ADD,
+                path="../escape_added.txt",
+                new_content="pwned\n",
+            )
+            with self.assertRaises(ValueError):
+                coder.apply_edits([("../escape_added.txt", action)])
+
+            self.assertFalse(outside.exists())
+
+    def test_allows_move_within_repo(self):
+        """A legitimate in-repo move still applies (no false positive)."""
+        with GitTemporaryDirectory() as repo_dir:
+            src = Path(repo_dir) / "sample.txt"
+            src.write_text("Original content\n")
+
+            io = InputOutput(yes=True)
+            coder = Coder.create(self.GPT35, "patch", io=io, fnames=[str(src)])
+
+            coder.partial_response_content = (
+                "*** Begin Patch\n"
+                "*** Update File: sample.txt\n"
+                "*** Move to: renamed.txt\n"
+                "@@\n"
+                "-Original content\n"
+                "+Updated content\n"
+                "*** End Patch\n"
+            )
+
+            coder.apply_updates()
+
+            moved = Path(repo_dir) / "renamed.txt"
+            self.assertTrue(moved.exists())
+            self.assertEqual(moved.read_text(), "Updated content\n")
+            self.assertFalse(src.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What

The `patch` edit format resolves file paths that come straight from the
LLM response. A `*** Move to:` target is `.strip()`'d and passed to
`abs_root_path()`, which only calls `Path.resolve()` - it doesn't confine
the result to the repository. On top of that, the move destination never
goes through the "allow edits to this file?" confirmation: `prepare_to_edit()`
only checks the *source* path of each edit, not the move target.

So the patch coder can be made to write outside the project and delete the
original file, with no user prompt.

### Why it matters

Anytime the model's output can be influenced - a malicious/backdoored
model, or prompt injection from file or web content pulled into the chat -
a crafted patch can overwrite or create files anywhere the user can write
(`~/.bashrc`, `~/.ssh/authorized_keys`, `~/.aider.conf.yml`, ...) and
remove the source. That's an arbitrary file write / overwrite (CWE-22,
CWE-862).

### Reproduction

With `notes.txt` added to the chat, the model returns:

    *** Begin Patch
    *** Update File: notes.txt
    *** Move to: ../escaped.txt
    @@
    -old
    +new
    *** End Patch

Before this change, `../escaped.txt` (outside the repo) is written and
`notes.txt` is deleted - even with every confirmation declined.

### Fix

Add `_assert_within_root()` and call it on every path `apply_edits()`
writes to: the action path and the move target. It reuses the
`is_relative_to(root)` check aider already uses for user-supplied paths
(`commands.py`, `watch.py`), so out-of-repo paths are rejected with a
clear error.

### Tests

`tests/basic/test_patch.py`: out-of-repo move refused (nothing written,
source preserved), out-of-repo add refused, in-repo move still works.
`pytest tests/basic/test_patch.py` and `tests/basic/test_coder.py` pass;
black and isort are clean.

### Scope

This covers the patch coder's write paths. Hardening the shared
new-file path (`allowed_to_edit` -> `touch_file`, which can create an
empty file outside the root under a confirmation that does show the
path) is a smaller separate follow-up.