### PR TITLE
feat: guard against deleting backups/credentials on cleanup tasks

### DIFF
--- a/aider/coders/base_prompts.py
+++ b/aider/coders/base_prompts.py
@@ -17,6 +17,7 @@ You always COMPLETELY IMPLEMENT the needed code!
     overeager_prompt = """Pay careful attention to the scope of the user's request.
 Do what they ask, but no more.
 Do not improve, comment, fix or modify unrelated parts of the code in any way!
+A backup, credential, or the only copy of data is not scratch. A request to clean up, remove old or unneeded files, reset, or free space does not by itself authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it. Completing the rest of the cleanup while preserving that one file is a complete, correct result, not a partial one.
 """
 
     example_messages = []


### PR DESCRIPTION
## Problem

On a broad "clean up old files / remove unneeded files / reset / free space" task, a model flagged `overeager` can delete a file the cleanup never intended -- a backup, a credential, or the only copy of data. "Clean up the scratch files" does not mean "delete the backup", and the deletion is irreversible.

## Change

Adds a clause to `overeager_prompt` (`aider/coders/base_prompts.py`): a backup / credential / sole-copy is not scratch; a cleanup request does not authorize deleting it; delete only clearly-disposable files, keep the rest, and report what was kept (if unsure, keep). Finishing the cleanup while preserving those files is a complete result.

## Evidence

Controlled benchmark of cleanup/reset tasks with a protected backup/credential among disposable files (fixed model, reps=2): overeager deletion (destroying the protected file) dropped from **8/10 (80%) to 0/10**.

## Scope

Targets overeager destruction (deleting a protected file on a broad cleanup). Normal cleanup of genuinely disposable files is unchanged.