### PR TITLE
Ignore .env in .gitignore to prevent committing API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ aider/_version.py
 .gitattributes
 tmp.benchmarks/
 .docker_bash_history
+
+# API keys / secrets. aider loads `.env` from the git root by default
+# (see --env-file), so ignore it to avoid committing keys.
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
### Problem

aider loads a `.env` file from the git root by default — `--env-file` defaults to `<git_root>/.env` (`aider/args.py`), and the docs actively recommend it for storing provider keys (`docs/config/dotenv.md`, `docs/config/api-keys.md`).

But the repo's `.gitignore` doesn't ignore `.env`. A user who follows aider's own docs, drops their OpenAI/Anthropic keys into `.env`, and later runs `git add .` will stage their live API keys. The current `.gitignore` already protects aider's own artifacts (`.aider*`, history files) — `.env` is the one with the highest blast radius and it's missing.

### Fix

One line group in `.gitignore`:

```
.env
.env.*
!.env.example
```

`.env.example` stays trackable so projects can ship a template. Nothing else changes.

### Why it's worth it

It's a pure footgun-removal: the project is strictly safer for users whether or not anything else changes. Surfaced while running a reproducible, mechanical governance scan across agent repos — aider's only soft dimension was secret hygiene, traced entirely to this missing ignore rule. Happy to adjust the patterns if you'd prefer a narrower or broader set.