### PR TITLE
Add Squad (Copilot CLI + Claude Opus 4.8) to polyglot leaderboard: 98.7% pass rate

### DIFF
--- a/aider/website/_data/polyglot_leaderboard.yml
+++ b/aider/website/_data/polyglot_leaderboard.yml
@@ -1854,3 +1854,29 @@
   versions: 0.86.2.dev
   seconds_per_case: 104.0
   total_cost: 0.8756
+
+- dirname: 2026-06-25--squad-copilot-cli-opus-4.8
+  test_cases: 225
+  model: Squad (Copilot CLI + Claude Opus 4.8)
+  edit_format: whole
+  commit_hash: 6cbb679
+  pass_rate_1: 98.7
+  pass_rate_2: 98.7
+  pass_num_1: 222
+  pass_num_2: 222
+  percent_cases_well_formed: 100.0
+  error_outputs: 0
+  num_malformed_responses: 0
+  num_with_malformed_responses: 0
+  user_asks: 0
+  lazy_comments: 0
+  syntax_errors: 0
+  indentation_errors: 0
+  exhausted_context_windows: 0
+  test_timeouts: 0
+  total_tests: 225
+  command: copilot --yolo --agent squad
+  date: 2026-06-25
+  versions: copilot-cli-1.0.64
+  seconds_per_case: 221.0
+  total_cost: 0.0000


### PR DESCRIPTION
## Summary

Adding benchmark results for **Squad** - a multi-agent orchestration system built on GitHub Copilot CLI - to the polyglot leaderboard.

## Results

| Language | Attempt 1 | Attempt 2 |
|----------|-----------|-----------|
| Python | 34/34 (100%) | 34/34 (100%) |
| Go | 39/39 (100%) | 39/39 (100%) |
| JavaScript | 49/49 (100%) | 49/49 (100%) |
| Java | 46/47 (97.9%) | 46/47 (97.9%) |
| Rust | 30/30 (100%) | 30/30 (100%) |
| C++ | 24/26 (92.3%) | 24/26 (92.3%) |
| **Total** | **222/225 (98.7%)** | **222/225 (98.7%)** |

## How it works

Squad operates as a coding agent via GitHub Copilot CLI:

1. Receives the exercise directory (instructions + starter code + test files)
2. Reads and understands the problem
3. Writes a complete solution
4. If tests fail on attempt 1, reads the error output and iterates

**Command:** \\copilot --yolo --agent squad\\
**Model:** Claude Opus 4.8 (via Copilot CLI)
**Time:** ~221 seconds per exercise average

## Reproducibility

All raw data, execution logs, and the runner script are publicly available:
https://github.com/tamirdresher/squad-polyglot-benchmark

## Notes

- Squad is not built on Aider - it is a separate coding agent system (GitHub Copilot CLI with multi-agent orchestration)
- Related discussion: #5321
- Cost is 0.00 because Copilot CLI uses a subscription model (no per-token billing)
- total_cost 0.0000 reflects this - there is no API cost to report