### PR TITLE
Checking for read-only file in git root if not in current directory

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -686,8 +686,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         elif not path.exists() and git_root:
             # try to find file in git_root
             path = Path(git_root).joinpath(fn)
-            if path.exists():
-                read_only_fnames.append(str(path))
+            read_only_fnames.append(str(path))
         else:
             read_only_fnames.append(str(path))
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -683,6 +683,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         path = Path(fn).expanduser().resolve()
         if path.is_dir():
             read_only_fnames.extend(str(f) for f in path.rglob("*") if f.is_file())
+        elif not path.exists() and git_root:
+            # try to find file in git_root
+            path = Path(git_root).joinpath(fn)
+            if path.exists():
+                read_only_fnames.append(str(path))
         else:
             read_only_fnames.append(str(path))
 


### PR DESCRIPTION
If opening aider in a subdirectory of a git repo, it will still read the .aider.conf.yml in the git root directory. However, for any files under `read:` in the .yml file, it will read that list of files and then assume the files are in the current subdirectory i.e. it won't assume that the files listed in the .yml file in the git root are located relative to the git root directory. So aider fails in opening those files since it is looking for them in the current directory and not in the git repo's root.

This commit adds a check to main.py where, when it is iterating through the list of files passed to it as read-only, it will check if each file exists in the current directory. And if not, it will check for it in the git repo's root.