### PR TITLE
fix: add missing f-prefix on warning print and fix typo

### DIFF
--- a/aider/voice.py
+++ b/aider/voice.py
@@ -146,7 +146,7 @@ class Voice:
         # Check file size and offer to convert to mp3 if too large
         file_size = os.path.getsize(temp_wav)
         if file_size > 24.9 * 1024 * 1024 and self.audio_format == "wav":
-            print("\nWarning: {temp_wav} is too large, switching to mp3 format.")
+            print(f"\nWarning: {temp_wav} is too large, switching to mp3 format.")
             use_audio_format = "mp3"
 
         filename = temp_wav

--- a/benchmark/refactor_tools.py
+++ b/benchmark/refactor_tools.py
@@ -169,7 +169,7 @@ def process(entry):
     ins_fname = docs_dname / "instructions.md"
     ins_fname.write_text(f"""# Refactor {class_name}.{method_name}
 
-Refactor the `{method_name}` method in the `{class_name}` class to be a stand alone, top level function.
+Refactor the `{method_name}` method in the `{class_name}` class to be a standalone, top level function.
 Name the new function `{method_name}`, exactly the same name as the existing method.
 Update any existing `self.{method_name}` calls to work with the new `{method_name}` function.
 """)  # noqa: E501


### PR DESCRIPTION
## Summary

Fix 1 bug and 1 typo:

- **aider/voice.py** line 149: add missing `f` prefix to `print()` statement. Without it, `{temp_wav}` prints as a literal string instead of showing the actual file path when the WAV file exceeds the size limit.
- **benchmark/refactor_tools.py** line 172: fix "stand alone" → "standalone"

The `voice.py` fix is a functional change (users will now see the actual file path in the warning message). The `refactor_tools.py` fix is in a prompt template string.