### PR TITLE
Don't crash on /read-only when a pattern can't be globbed

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1353,12 +1353,20 @@ class Commands:
                 matches = [path_obj]
             else:
                 # If literal path doesn't exist, try globbing
-                if is_abs:
-                    # For absolute paths, glob it
-                    matches = [Path(p) for p in glob.glob(expanded_pattern)]
-                else:
-                    # For relative paths and globs, use glob from the root directory
-                    matches = list(Path(self.coder.root).glob(expanded_pattern))
+                try:
+                    if is_abs:
+                        # For absolute paths, glob it
+                        matches = [Path(p) for p in glob.glob(expanded_pattern)]
+                    else:
+                        # For relative paths and globs, use glob from the root directory
+                        matches = list(Path(self.coder.root).glob(expanded_pattern))
+                except (OSError, ValueError, NotImplementedError) as err:
+                    # Path.glob() raises NotImplementedError for non-relative
+                    # patterns (e.g. a Windows drive-relative path), and globbing
+                    # can otherwise raise OSError/ValueError. Report it instead of
+                    # letting the exception crash aider.
+                    self.io.tool_error(f"Unable to match files for {pattern!r}: {err}")
+                    matches = []
 
             if not matches:
                 self.io.tool_error(f"No matches found for: {pattern}")

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -1486,6 +1486,23 @@ class TestCommands(TestCase):
         finally:
             os.unlink(external_file_path)
 
+    def test_cmd_read_only_handles_unsupported_glob_pattern(self):
+        # Path.glob() raises NotImplementedError for non-relative patterns (e.g. a
+        # Windows drive-relative path). cmd_read_only must report it, not crash.
+        with GitTemporaryDirectory():
+            io = InputOutput(pretty=False, fancy_input=False, yes=False)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            def boom(self, *args, **kwargs):
+                raise NotImplementedError("Non-relative patterns are unsupported")
+
+            with mock.patch.object(Path, "glob", boom):
+                # Must not raise — a pattern glob can't handle is reported, not fatal.
+                commands.cmd_read_only("some/relative/pattern*")
+
+            self.assertEqual(len(coder.abs_read_only_fnames), 0)
+
     def test_cmd_drop_read_only_with_relative_path(self):
         with ChdirTemporaryDirectory() as repo_dir:
             test_file = Path("test_file.txt")


### PR DESCRIPTION
On Windows, /read-only with a drive-relative pattern crashes aider entirely — Path.glob() raises NotImplementedError ('Non-relative patterns are unsupported') and it wasn't caught. Wrapped the glob calls in cmd_read_only so a pattern that can't be globbed is reported as an error instead of taking down the whole app. Added a test. Fixes #5311