### PR TITLE
fix: suppress unsupported temperature for Codex mini

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -435,6 +435,10 @@ class Model(ModelSettings):
                 self.accepts_settings.append("reasoning_effort")
 
     def apply_generic_model_settings(self, model):
+        if "codex-mini" in model:
+            self.use_temperature = False
+            return  # <--
+
         if "/o3-mini" in model:
             self.edit_format = "diff"
             self.use_repo_map = True

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -493,6 +493,16 @@ class TestModels(unittest.TestCase):
         model.use_temperature = 0.7
         self.assertEqual(model.use_temperature, 0.7)
 
+    @patch(
+        "aider.models.Model.validate_environment",
+        return_value={"keys_in_environment": True, "missing_keys": []},
+    )
+    def test_codex_mini_sets_use_temperature_false(self, _mock_validate_environment):
+        for model_name in ("codex-mini", "openai/codex-mini", "openrouter/openai/codex-mini"):
+            with self.subTest(model_name=model_name):
+                model = Model(model_name)
+                self.assertFalse(model.use_temperature)
+
     @patch("aider.models.litellm.completion")
     def test_request_timeout_default(self, mock_completion):
         # Test default timeout is used when not specified in extra_params
@@ -506,6 +516,22 @@ class TestModels(unittest.TestCase):
             temperature=0,
             timeout=600,  # Default timeout
         )
+
+    @patch("aider.models.litellm.completion", create=True)
+    @patch(
+        "aider.models.Model.validate_environment",
+        return_value={"keys_in_environment": True, "missing_keys": []},
+    )
+    def test_codex_mini_send_completion_omits_temperature(
+        self, _mock_validate_environment, mock_completion
+    ):
+        messages = [{"role": "user", "content": "Hello"}]
+        for model_name in ("codex-mini", "openai/codex-mini", "openrouter/openai/codex-mini"):
+            with self.subTest(model_name=model_name):
+                model = Model(model_name)
+                model.send_completion(messages, functions=None, stream=False)
+                self.assertNotIn("temperature", mock_completion.call_args.kwargs)
+                mock_completion.reset_mock()
 
     @patch("aider.models.litellm.completion")
     def test_request_timeout_from_extra_params(self, mock_completion):


### PR DESCRIPTION
Codex mini models routed through LiteLLM can reject the `temperature` parameter. Aider already has a per-model `use_temperature` setting, but Codex mini currently falls through with the default request shape and sends `temperature=0`.

This uses the existing model-setting path to mark Codex mini as `use_temperature=False`, while leaving the centralized `send_completion()` request builder and normal temperature behavior intact.

Closes #4039

The follow-up question from `coogle` shaped the scope here: disable unsupported LiteLLM parameters for affected models without changing unrelated request construction.

Tests:
- `rtk python -m pytest tests/basic/test_models.py -v`
- `rtk pre-commit run --all-files`

Latest checks:
- `rtk python -m pytest tests/basic/test_models.py::TestModels::test_codex_mini_send_completion_omits_temperature tests/basic/test_models.py::TestModels::test_codex_mini_sets_use_temperature_false -v`
  - Passed (2/2). Both plain and provider-prefixed Codex mini variants still resolve `use_temperature=False` and omit `temperature` in `send_completion`.
- `rtk python -m pytest tests/basic/test_models.py -v`
  - Failed in this environment. `litellm` import crashes during `aider.llm` lazy load with `AttributeError: module aiohttp has no attribute ConnectionTimeoutError`, which affects existing constructor-heavy tests outside this change.
- `rtk pre-commit run --all-files`
  - Initially failed because `black` reformatted `tests/basic/test_models.py`.
  - Re-run passed after formatting.
