### PR TITLE
fix: make drop match only the named path

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -913,16 +913,29 @@ class Commands:
     def _normalize_drop_path(path):
         return os.path.normcase(os.path.normpath(path)).replace("\\", "/")
 
-    def _paths_match_for_drop(self, needle, haystack):
-        if self._normalize_drop_path(needle) == self._normalize_drop_path(haystack):
-            return True
+    def _is_drop_directory(self, needle):
+        try:
+            abs_needle = Path(self.coder.abs_root_path(needle)).resolve(strict=False)
+        except OSError:
+            return False
+        return abs_needle.is_dir()
 
+    def _paths_match_for_drop(self, needle, haystack):
         normalized_haystack = self._normalize_drop_path(str(Path(haystack).resolve(strict=False)))
         normalized_abs_needle = self._normalize_drop_path(
             str(Path(self.coder.abs_root_path(needle)).resolve(strict=False))
         )
         if normalized_abs_needle == normalized_haystack:
             return True
+
+        if self._is_drop_directory(needle):
+            normalized_needle_dir = normalized_abs_needle.rstrip("/")
+            if normalized_haystack.startswith(normalized_needle_dir + "/"):
+                return True
+
+        if self._normalize_drop_path(needle) == self._normalize_drop_path(haystack):
+            return True
+
         if "/" not in needle and "\\" not in needle:
             normalized_parent_needle = self._normalize_drop_path(
                 str((Path(self.coder.root).parent / needle).resolve(strict=False))
@@ -953,22 +966,26 @@ class Commands:
         for word in filenames:
             # Expand tilde in the path
             expanded_word = os.path.expanduser(word)
-            if any(c in expanded_word for c in "*?[]"):
+            read_only_matched = [
+                f
+                for f in self.coder.abs_read_only_fnames
+                if self._paths_match_for_drop(expanded_word, f)
+            ]
+            matched_files = [
+                self.coder.get_rel_fname(f)
+                for f in self.coder.abs_fnames
+                if self._paths_match_for_drop(expanded_word, f)
+            ]
+
+            if (
+                not read_only_matched
+                and not matched_files
+                and any(c in expanded_word for c in "*?[]")
+            ):
                 read_only_matched = [
                     f for f in self.coder.abs_read_only_fnames if expanded_word in f
                 ]
                 matched_files = self.glob_filtered_to_repo(expanded_word)
-            else:
-                read_only_matched = [
-                    f
-                    for f in self.coder.abs_read_only_fnames
-                    if self._paths_match_for_drop(expanded_word, f)
-                ]
-                matched_files = [
-                    self.coder.get_rel_fname(f)
-                    for f in self.coder.abs_fnames
-                    if self._paths_match_for_drop(expanded_word, f)
-                ]
 
             for matched_file in read_only_matched:
                 self.coder.abs_read_only_fnames.remove(matched_file)

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -909,6 +909,33 @@ class Commands:
         all_files = [self.quote_fname(fn) for fn in all_files]
         return all_files
 
+    @staticmethod
+    def _normalize_drop_path(path):
+        return os.path.normcase(os.path.normpath(path)).replace("\\", "/")
+
+    def _paths_match_for_drop(self, needle, haystack):
+        if self._normalize_drop_path(needle) == self._normalize_drop_path(haystack):
+            return True
+
+        normalized_haystack = self._normalize_drop_path(str(Path(haystack).resolve(strict=False)))
+        normalized_abs_needle = self._normalize_drop_path(
+            str(Path(self.coder.abs_root_path(needle)).resolve(strict=False))
+        )
+        if normalized_abs_needle == normalized_haystack:
+            return True
+        if "/" not in needle and "\\" not in needle:
+            normalized_parent_needle = self._normalize_drop_path(
+                str((Path(self.coder.root).parent / needle).resolve(strict=False))
+            )
+            if normalized_parent_needle == normalized_haystack:
+                return True
+
+        try:
+            abs_needle = self.coder.abs_root_path(needle)
+            return os.path.samefile(abs_needle, haystack)
+        except (FileNotFoundError, OSError):
+            return False
+
     def cmd_drop(self, args=""):
         "Remove files from the chat session to free up context space"
 
@@ -926,34 +953,26 @@ class Commands:
         for word in filenames:
             # Expand tilde in the path
             expanded_word = os.path.expanduser(word)
-
-            # Handle read-only files with substring matching and samefile check
-            read_only_matched = []
-            for f in self.coder.abs_read_only_fnames:
-                if expanded_word in f:
-                    read_only_matched.append(f)
-                    continue
-
-                # Try samefile comparison for relative paths
-                try:
-                    abs_word = os.path.abspath(expanded_word)
-                    if os.path.samefile(abs_word, f):
-                        read_only_matched.append(f)
-                except (FileNotFoundError, OSError):
-                    continue
+            if any(c in expanded_word for c in "*?[]"):
+                read_only_matched = [
+                    f for f in self.coder.abs_read_only_fnames if expanded_word in f
+                ]
+                matched_files = self.glob_filtered_to_repo(expanded_word)
+            else:
+                read_only_matched = [
+                    f
+                    for f in self.coder.abs_read_only_fnames
+                    if self._paths_match_for_drop(expanded_word, f)
+                ]
+                matched_files = [
+                    self.coder.get_rel_fname(f)
+                    for f in self.coder.abs_fnames
+                    if self._paths_match_for_drop(expanded_word, f)
+                ]
 
             for matched_file in read_only_matched:
                 self.coder.abs_read_only_fnames.remove(matched_file)
                 self.io.tool_output(f"Removed read-only file {matched_file} from the chat")
-
-            # For editable files, use glob if word contains glob chars, otherwise use substring
-            if any(c in expanded_word for c in "*?[]"):
-                matched_files = self.glob_filtered_to_repo(expanded_word)
-            else:
-                # Use substring matching like we do for read-only files
-                matched_files = [
-                    self.coder.get_rel_fname(f) for f in self.coder.abs_fnames if expanded_word in f
-                ]
 
             if not matched_files:
                 matched_files.append(expanded_word)

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -310,7 +310,7 @@ class TestCommands(TestCase):
         commands.cmd_add(f"{exact_file} {suffix_file}")
         self.assertEqual(len(coder.abs_fnames), 2)
 
-        commands.cmd_drop("api/chat/route.ts")
+        commands.cmd_drop(r"api\chat\route.ts")
         self.assertNotIn(str(exact_file.resolve()), coder.abs_fnames)
         self.assertIn(str(suffix_file.resolve()), coder.abs_fnames)
 
@@ -384,7 +384,7 @@ class TestCommands(TestCase):
         commands.cmd_read_only(str(suffix_file))
         self.assertEqual(len(coder.abs_read_only_fnames), 2)
 
-        commands.cmd_drop("api/chat/route.ts")
+        commands.cmd_drop(r"api\chat\route.ts")
         self.assertEqual(len(coder.abs_read_only_fnames), 1)
         self.assertNotIn(str(exact_file.resolve()), coder.abs_read_only_fnames)
         self.assertIn(str(suffix_file.resolve()), coder.abs_read_only_fnames)

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -293,6 +293,47 @@ class TestCommands(TestCase):
         self.assertNotIn(str(Path("test2.py").resolve()), coder.abs_fnames)
         self.assertEqual(len(coder.abs_fnames), initial_count - 1)
 
+    def test_cmd_drop_exact_path_does_not_drop_suffix_match(self):
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        from aider.coders import Coder
+
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        exact_file = Path("api/chat/route.ts")
+        suffix_file = Path("app/api/chat/route.ts")
+        exact_file.parent.mkdir(parents=True, exist_ok=True)
+        suffix_file.parent.mkdir(parents=True, exist_ok=True)
+        exact_file.write_text("exact")
+        suffix_file.write_text("suffix")
+
+        commands.cmd_add(f"{exact_file} {suffix_file}")
+        self.assertEqual(len(coder.abs_fnames), 2)
+
+        commands.cmd_drop("api/chat/route.ts")
+        self.assertNotIn(str(exact_file.resolve()), coder.abs_fnames)
+        self.assertIn(str(suffix_file.resolve()), coder.abs_fnames)
+
+    def test_cmd_drop_glob_keeps_multi_match_behavior(self):
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        from aider.coders import Coder
+
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        exact_file = Path("api/chat/route.ts")
+        suffix_file = Path("app/api/chat/route.ts")
+        exact_file.parent.mkdir(parents=True, exist_ok=True)
+        suffix_file.parent.mkdir(parents=True, exist_ok=True)
+        exact_file.write_text("exact")
+        suffix_file.write_text("suffix")
+
+        commands.cmd_add(f"{exact_file} {suffix_file}")
+        self.assertEqual(len(coder.abs_fnames), 2)
+
+        commands.cmd_drop("**/route.ts")
+        self.assertEqual(len(coder.abs_fnames), 0)
+
     def test_cmd_drop_without_glob(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, fancy_input=False, yes=True)
@@ -324,6 +365,29 @@ class TestCommands(TestCase):
         self.assertNotIn(str(Path("file2.txt").resolve()), coder.abs_fnames)
         self.assertNotIn(str(Path("file3.py").resolve()), coder.abs_fnames)
         self.assertEqual(len(coder.abs_fnames), 0)
+
+    def test_cmd_drop_read_only_exact_path_does_not_drop_suffix_match(self):
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        from aider.coders import Coder
+
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        exact_file = Path("api/chat/route.ts")
+        suffix_file = Path("app/api/chat/route.ts")
+        exact_file.parent.mkdir(parents=True, exist_ok=True)
+        suffix_file.parent.mkdir(parents=True, exist_ok=True)
+        exact_file.write_text("exact")
+        suffix_file.write_text("suffix")
+
+        commands.cmd_read_only(str(exact_file))
+        commands.cmd_read_only(str(suffix_file))
+        self.assertEqual(len(coder.abs_read_only_fnames), 2)
+
+        commands.cmd_drop("api/chat/route.ts")
+        self.assertEqual(len(coder.abs_read_only_fnames), 1)
+        self.assertNotIn(str(exact_file.resolve()), coder.abs_read_only_fnames)
+        self.assertIn(str(suffix_file.resolve()), coder.abs_read_only_fnames)
 
     def test_cmd_add_bad_encoding(self):
         # Initialize the Commands and InputOutput objects


### PR DESCRIPTION
`/drop` was using substring matching for non-glob paths. That made a command like `/drop api\chat\route.ts` remove both `api\chat\route.ts` and `app\api\chat\route.ts` when both files were in chat.

This keeps bare `/drop` and explicit glob behavior intact, but makes non-glob editable and read-only drops use exact path identity instead of substring containment.

Closes #4176

The duplicate-path reproduction from `emincangencer`'s comment shaped the editable and read-only regression tests.

Validation:
- `rtk python -m pytest tests/basic/test_commands.py -k cmd_drop -v`
  - `6 passed, 67 deselected` (run with `TEMP/TMP/TMPDIR=D:\Repos\tmp`)
- `rtk python -m pytest tests/basic/test_commands.py::TestCommands::test_cmd_add_drop_directory tests/basic/test_commands.py::TestCommands::test_cmd_read_only_with_square_brackets -v`
  - `2 passed`
- `rtk pre-commit run --all-files`
  - `isort`, `black`, `flake8`, and `codespell` all passed
