### PR TITLE
fix(models): honor custom_openai metadata during environment validation

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -745,6 +745,10 @@ class Model(ModelSettings):
         if res:
             return res
 
+        provider = self.info.get("litellm_provider", "").lower()
+        if provider == "custom_openai":
+            return dict(keys_in_environment=True, missing_keys=[])
+
         # https://github.com/BerriAI/litellm/issues/3190
 
         model = self.name
@@ -769,7 +773,6 @@ class Model(ModelSettings):
         if res["missing_keys"]:
             return res
 
-        provider = self.info.get("litellm_provider", "").lower()
         if provider == "cohere_chat":
             return validate_variables(["COHERE_API_KEY"])
         if provider == "gemini":

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -254,6 +254,38 @@ class TestModels(unittest.TestCase):
         # Verify check_pip_install_extra was not called
         mock_check_pip.assert_not_called()
 
+    @patch("aider.models.Model.get_model_info")
+    @patch("aider.models.litellm.validate_environment")
+    def test_custom_openai_metadata_bypasses_litellm_validation(
+        self, mock_validate_environment, mock_get_model_info
+    ):
+        """Test that metadata-backed custom_openai models bypass litellm validation."""
+        mock_get_model_info.return_value = {"litellm_provider": "custom_openai"}
+
+        model = Model("custom_openai/my-openai-model")
+
+        self.assertTrue(model.keys_in_environment)
+        self.assertEqual(model.missing_keys, [])
+        mock_validate_environment.assert_not_called()
+
+    @patch("aider.models.Model.get_model_info")
+    @patch("aider.models.litellm.validate_environment")
+    def test_non_custom_metadata_still_uses_litellm_validation(
+        self, mock_validate_environment, mock_get_model_info
+    ):
+        """Test that only the exact custom_openai provider bypasses litellm validation."""
+        mock_get_model_info.return_value = {"litellm_provider": "custom_openai_plus"}
+        mock_validate_environment.return_value = {
+            "keys_in_environment": False,
+            "missing_keys": ["SOME_KEY"],
+        }
+
+        model = Model("custom_openai/my-openai-model")
+
+        self.assertFalse(model.keys_in_environment)
+        self.assertEqual(model.missing_keys, ["SOME_KEY"])
+        mock_validate_environment.assert_called_once_with("custom_openai/my-openai-model")
+
     def test_get_repo_map_tokens(self):
         # Test default case (no max_input_tokens in info)
         model = Model("gpt-4")

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -260,7 +260,11 @@ class TestModels(unittest.TestCase):
         self, mock_validate_environment, mock_get_model_info
     ):
         """Test that metadata-backed custom_openai models bypass litellm validation."""
-        mock_get_model_info.return_value = {"litellm_provider": "custom_openai"}
+        mock_get_model_info.return_value = {"litellm_provider": "custom_openai", "mode": "chat"}
+        mock_validate_environment.return_value = {
+            "keys_in_environment": False,
+            "missing_keys": ["OPENAI_API_KEY"],
+        }
 
         model = Model("custom_openai/my-openai-model")
 
@@ -274,7 +278,10 @@ class TestModels(unittest.TestCase):
         self, mock_validate_environment, mock_get_model_info
     ):
         """Test that only the exact custom_openai provider bypasses litellm validation."""
-        mock_get_model_info.return_value = {"litellm_provider": "custom_openai_plus"}
+        mock_get_model_info.return_value = {
+            "litellm_provider": "custom_openai_plus",
+            "mode": "chat",
+        }
         mock_validate_environment.return_value = {
             "keys_in_environment": False,
             "missing_keys": ["SOME_KEY"],


### PR DESCRIPTION
Current `Model.validate_environment()` still lets metadata-backed `custom_openai/<model>` names fall through LiteLLM environment validation, so aider can report a missing `OPENAI_API_KEY` even when the model metadata already declares `litellm_provider: custom_openai`.

This keeps the fix in `aider/models.py`: metadata-declared `custom_openai` models stop forcing aider-side API-key validation, while every non-custom provider stays on the existing fast path, LiteLLM validation, AWS_PROFILE adjustment, and provider-specific checks. A prefix-only `custom_openai/` name still does not bypass validation.

Closes #4955

Tests:
- `python -m pytest tests/basic/test_models.py -k "custom_openai_metadata_bypasses_litellm_validation or non_custom_metadata_still_uses_litellm_validation" -v`
- `python -m pytest tests/basic/test_aws_credentials.py -v`
- `pre-commit run --all-files`
