### PR TITLE
fix: bump tree-sitter-c-sharp to 0.23.5 to fix source build on OpenBSD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -411,7 +411,7 @@ tqdm==4.67.3
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
-tree-sitter-c-sharp==0.23.1
+tree-sitter-c-sharp==0.23.5
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -560,7 +560,7 @@ transformers==5.3.0
     # via sentence-transformers
 tree-sitter==0.25.2
     # via tree-sitter-language-pack
-tree-sitter-c-sharp==0.23.1
+tree-sitter-c-sharp==0.23.5
     # via tree-sitter-language-pack
 tree-sitter-embedded-template==0.25.0
     # via tree-sitter-language-pack

--- a/requirements/tree-sitter.in
+++ b/requirements/tree-sitter.in
@@ -1,3 +1,8 @@
     
 tree-sitter==0.23.2; python_version < "3.10"
 tree-sitter==0.25.2; python_version >= "3.10"
+
+# Versions 0.23.1-0.23.4 of tree-sitter-c-sharp do not bundle the
+# tree_sitter/parser.h header, causing source builds to fail on platforms
+# without pre-built wheels (e.g. OpenBSD).
+tree-sitter-c-sharp>=0.23.5


### PR DESCRIPTION
**Fixes #5307 - tree-sitter-c-sharp source build failure on OpenBSD**
On OpenBSD and other platforms without pre-built wheels, tree-sitter-c-sharp builds from source. Versions 0.23.1 through 0.23.4 do not bundle the tree_sitter/parser.h header in their source distribution, causing the C compiler to fail with: `fatal error: tree_sitter/parser.h: No such file or directory`.
**Change**: Bump tree-sitter-c-sharp from 0.23.1 to 0.23.5, which includes the necessary headers for source builds.
Files modified:
- requirements.txt: 0.23.1 -> 0.23.5
- requirements/common-constraints.txt: 0.23.1 -> 0.23.5
- requirements/tree-sitter.in: added tree-sitter-c-sharp>=0.23.5 constraint with explanatory comment