### PR TITLE
Fix IndexError in strip_quoted_wrapping for filename-only content

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -351,7 +351,7 @@ def strip_quoted_wrapping(res, fname=None, fence=DEFAULT_FENCE):
     if fname and res[0].strip().endswith(Path(fname).name):
         res = res[1:]
 
-    if res[0].startswith(fence[0]) and res[-1].startswith(fence[1]):
+    if res and res[0].startswith(fence[0]) and res[-1].startswith(fence[1]):
         res = res[1:-1]
 
     res = "\n".join(res)

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -89,6 +89,11 @@ class TestUtils(unittest.TestCase):
         result = eb.strip_quoted_wrapping(input_text)
         self.assertEqual(result, expected_output)
 
+    def test_strip_quoted_wrapping_only_filename(self):
+        # When res contains only the filename line, stripping it should not raise IndexError
+        result = eb.strip_quoted_wrapping("filename.py", "filename.py")
+        self.assertEqual(result, "")
+
     def test_find_original_update_blocks(self):
         edit = """
 Here's the change:


### PR DESCRIPTION
strip_quoted_wrapping raised IndexError when a block's content was just a filename line — after dropping that line res is empty, and the fence check then indexed res[0]/res[-1]. Added the same 'if res' guard the trailing-newline check right below it already uses, plus a test. This may be the cause of #3855.