### PR TITLE
fix: handle MissingStyle in display_user_input (issue #2962)

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -29,6 +29,7 @@ from pygments.token import Token
 from rich.color import ColorParseError
 from rich.columns import Columns
 from rich.console import Console
+from rich.errors import MissingStyle
 from rich.markdown import Markdown
 from rich.style import Style as RichStyle
 from rich.text import Text
@@ -770,7 +771,10 @@ class InputOutput:
         else:
             style = dict()
 
-        self.console.print(Text(inp), **style)
+        try:
+            self.console.print(Text(inp), **style)
+        except MissingStyle:
+            self.console.print(Text(inp))
 
     def user_input(self, inp, log_only=True):
         if not log_only:


### PR DESCRIPTION
**Summary:** Fix crash when `display_user_input()` receives a color style Rich can't resolve by catching `MissingStyle` and falling back to uncolored output.

**Technical Details:**
- **Root Cause:** `confirm_ask()` → `user_input()` → `display_user_input()` → `self.console.print(Text(inp), **style)` raises `MissingStyle` when `user_input_color` contains a string not in Rich's style registry (e.g., invalid hex, unregistered theme token). No error handling exists at this call site.
- **Mechanism:** The user's input is processed, the chat history logged, then `display_user_input()` attempts to print with the style — and crashes before the message reaches the user. The fix wraps the `console.print()` call in `try/except MissingStyle`, falling back to a plain uncolored print.

**Verification:** Confirmed adherence to CONTRIBUTING.md. Ran `python -m pytest tests/ -x -q`. 455 passed, 1 failed (test_voice_init_invalid_format — pre-existing, requires audio hardware, reproduces on main). Pre-commit hooks (isort, black, flake8, codespell) all green.

**Blast Radius:**
- **Impact:** Low. Only affects the `display_user_input` code path in `io.py`.
- **Trade-offs:** Degraded UX (no color) on style resolution failure versus a hard crash. No behavioral change for valid styles. No performance impact.

---

Fixes #2962