### PR TITLE
fix: add AIDER_CHAT_MODE env var for --chat-mode alias (issue #5367)

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -866,6 +866,16 @@ def get_parser(default_config_files, git_root):
     # Add deprecated model shortcut arguments
     add_deprecated_model_args(parser, group)
 
+    # Register AIDER_CHAT_MODE env var for --chat-mode alias.
+    # configargparse auto_env_var_prefix only derives from the first option
+    # string (--edit-format -> AIDER_EDIT_FORMAT), missing the --chat-mode alias.
+    # Support both env var names for backward compatibility.
+    for action in parser._actions:
+        if hasattr(action, "option_strings") and "--edit-format" in action.option_strings:
+            action.env_var = "AIDER_CHAT_MODE"
+            if "AIDER_EDIT_FORMAT" in os.environ and "AIDER_CHAT_MODE" not in os.environ:
+                os.environ["AIDER_CHAT_MODE"] = os.environ["AIDER_EDIT_FORMAT"]
+
     return parser
 
 


### PR DESCRIPTION
**Summary:** Add `AIDER_CHAT_MODE` env var support for the `--chat-mode` / `--edit-format` argument. Previously only `AIDER_EDIT_FORMAT` was recognized (auto-derived from `--edit-format`), but the `--chat-mode` alias was missing its own env var.

**Technical Details:**
- **Root Cause:** `configargparse.auto_env_var_prefix` derives env var names from the first option string only. For `--edit-format` / `--chat-mode`, only `AIDER_EDIT_FORMAT` is auto-generated; `AIDER_CHAT_MODE` is not.
- **Mechanism:** Set `action.env_var = "AIDER_CHAT_MODE"` on the argument after parser creation. For backward compatibility, also inject `AIDER_CHAT_MODE` from `AIDER_EDIT_FORMAT` if only the latter is set. Priority: CLI > `AIDER_CHAT_MODE` > `AIDER_EDIT_FORMAT` > config file > default.

**Verification:** Confirmed adherence to CONTRIBUTING.md. Ran `python -m pytest tests/`. 455 passed, 1 pre-existing env failure (test_voice requires audio hardware). Pre-commit hooks (isort, black, flake8, codespell) all green. Manual E2E:
- `AIDER_CHAT_MODE=ask` → `edit_format=ask`
- `AIDER_EDIT_FORMAT=architect` → `edit_format=architect` (backward compat)
- CLI `--chat-mode ask` + env var → CLI wins

**Blast Radius:**
- **Impact:** Low. Adds a new env var. Existing `AIDER_EDIT_FORMAT` usage continues to work.
- **Trade-offs:** When both `AIDER_CHAT_MODE` and `AIDER_EDIT_FORMAT` are set, `AIDER_CHAT_MODE` takes priority.

---

Fixes #5367