### PR TITLE
Fix IndexError in udiff find_diffs on a +++ header with no --- line

### DIFF
--- a/aider/coders/udiff_coder.py
+++ b/aider/coders/udiff_coder.py
@@ -369,8 +369,8 @@ def process_fenced_block(lines, start_line_num):
         if len(line) < 2:
             continue
 
-        if line.startswith("+++ ") and hunk[-2].startswith("--- "):
-            if hunk[-3] == "\n":
+        if line.startswith("+++ ") and len(hunk) >= 2 and hunk[-2].startswith("--- "):
+            if len(hunk) >= 3 and hunk[-3] == "\n":
                 hunk = hunk[:-3]
             else:
                 hunk = hunk[:-2]

--- a/tests/basic/test_udiff.py
+++ b/tests/basic/test_udiff.py
@@ -114,6 +114,13 @@ These changes will add the `--check-update` option to the command-line interface
         self.assertEqual(len(edits), 2)
         self.assertEqual(len(edits[0][1]), 3)
 
+    def test_find_diffs_plus_header_without_minus_does_not_crash(self):
+        # A malformed diff whose "+++ " line isn't preceded by a "--- " line used
+        # to raise IndexError (hunk[-2] on a one-element hunk). It must parse
+        # without crashing so the malformed-edit retry path can handle it.
+        content = "\n```diff\n+++ onlyplus\n@@ ... @@\n-a\n+b\n```\n"
+        find_diffs(content)  # should not raise
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
find_diffs crashed with IndexError on a malformed unified diff where a '+++ ' line isn't preceded by a '--- ' line — it indexed hunk[-2]/hunk[-3] on a one-element hunk. Added length guards so it parses without crashing and the normal malformed-edit retry can kick in instead. Added a test.