### PR TITLE
Add timeout to URL tests

### DIFF
--- a/tests/basic/test_urls.py
+++ b/tests/basic/test_urls.py
@@ -11,5 +11,5 @@ def test_urls():
     ]
     for attr in url_attributes:
         url = getattr(urls, attr)
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         assert response.status_code == 200, f"URL {url} returned status code {response.status_code}"


### PR DESCRIPTION
## Summary
- add an explicit timeout to the URL smoke test requests

## Why
The URL smoke test currently calls `requests.get()` without a timeout. If a remote endpoint accepts the connection but stalls, the test job can hang much longer than intended. A bounded timeout keeps the test behavior predictable while preserving the same status-code assertion.

## Tests
- `uv run --no-project --with pytest --with requests python -m pytest tests/basic/test_urls.py`