### PR TITLE
fix: don't crash linting on compile errors without line info (#3358)

### DIFF
--- a/aider/linter.py
+++ b/aider/linter.py
@@ -179,8 +179,15 @@ def lint_python_compile(fname, code):
         compile(code, fname, "exec")  # USE TRACEBACK BELOW HERE
         return
     except Exception as err:
-        end_lineno = getattr(err, "end_lineno", err.lineno)
-        line_numbers = list(range(err.lineno - 1, end_lineno))
+        # Not every compile error carries usable line info: a source string
+        # with null bytes raises ValueError (no lineno at all), and some
+        # SyntaxErrors have lineno=None. Guard both instead of crashing.
+        lineno = getattr(err, "lineno", None)
+        if lineno is None:
+            line_numbers = []
+        else:
+            end_lineno = getattr(err, "end_lineno", None) or lineno
+            line_numbers = list(range(lineno - 1, end_lineno))
 
         tb_lines = traceback.format_exception(type(err), err, err.__traceback__)
         last_file_i = 0

--- a/tests/basic/test_linter.py
+++ b/tests/basic/test_linter.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from aider.dump import dump  # noqa
-from aider.linter import Linter
+from aider.linter import Linter, LintResult, lint_python_compile
 
 
 class TestLinter(unittest.TestCase):
@@ -78,6 +78,33 @@ class TestLinter(unittest.TestCase):
             # The result should contain the error message
             self.assertIsNotNone(result)
             self.assertIn("Error message", result.text)
+
+
+class TestLintPythonCompile(unittest.TestCase):
+    def test_null_bytes_do_not_crash(self):
+        # compile() raises ValueError (no `lineno` attribute) on null bytes.
+        # This used to crash linting entirely (issue #3358).
+        result = lint_python_compile("test.py", "x = 1\0y = 2")
+        self.assertIsInstance(result, LintResult)
+        self.assertEqual(result.lines, [])
+        self.assertTrue(result.text)
+
+    def test_syntax_error_with_none_lineno_does_not_crash(self):
+        # Some compile errors carry lineno=None; `err.lineno - 1` used to
+        # raise TypeError (issue #3358).
+        with patch("aider.linter.compile", side_effect=SyntaxError("bad")):
+            result = lint_python_compile("test.py", "whatever")
+        self.assertIsInstance(result, LintResult)
+        self.assertEqual(result.lines, [])
+
+    def test_normal_syntax_error_still_reports_line(self):
+        # Regression guard: the happy path must keep reporting the error line.
+        result = lint_python_compile("test.py", "def f(:\n    pass\n")
+        self.assertIsInstance(result, LintResult)
+        self.assertIn(0, result.lines)
+
+    def test_valid_code_returns_none(self):
+        self.assertIsNone(lint_python_compile("test.py", "x = 1\n"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`lint_python_compile` (in `aider/linter.py`) assumed every compile error carries `lineno` / `end_lineno`. Two real cases break that assumption and crash linting for the whole file — reported as *"Uncaught TypeError in linter.py"* in #3358 (and the dup #3378, "source code string cannot contain null bytes"):

- A source string containing **null bytes** raises `ValueError` with **no `lineno` attribute at all**, so `getattr(err, "end_lineno", err.lineno)` itself raised `AttributeError`.
- Some `SyntaxError`s carry **`lineno=None`**, so `err.lineno - 1` raised `TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'`.

Confirmed on current `main` (Python 3.13): `compile("x=1\0y=2", ...)` raises a `SyntaxError` with `lineno=None`, and the existing code crashes with exactly that `TypeError`.

## Fix

Read the line info defensively and fall back to an empty line list when it's missing/`None`, so the compile error is still surfaced to the user instead of taking down linting:

```python
lineno = getattr(err, "lineno", None)
if lineno is None:
    line_numbers = []
else:
    end_lineno = getattr(err, "end_lineno", None) or lineno
    line_numbers = list(range(lineno - 1, end_lineno))
```

## Tests

Added regression tests in `tests/basic/test_linter.py`:
- null bytes no longer crash
- `SyntaxError` with `lineno=None` no longer crashes
- normal syntax error still reports its line (happy-path guard)
- valid code still returns `None`

`pytest tests/basic/test_linter.py` → 10 passed, 1 skipped (Windows-only).

Fixes #3358