### PR TITLE
fix: handle UnicodeDecodeError when reading .aider_ignore file (issue #5276)

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -514,7 +514,9 @@ class GitRepo:
         if mtime != self.aider_ignore_ts:
             self.aider_ignore_ts = mtime
             self.ignore_file_cache = {}
-            lines = self.aider_ignore_file.read_text().splitlines()
+            lines = self.aider_ignore_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()
             self.aider_ignore_spec = pathspec.PathSpec.from_lines(
                 pathspec.patterns.GitWildMatchPattern,
                 lines,


### PR DESCRIPTION
## Summary

Fix `UnicodeDecodeError` when reading `.aider_ignore` on Windows with non-UTF-8 system locales.

## Technical Details

**Root Cause:** `repo.py:517` calls `Path.read_text()` without specifying an encoding. Python falls back to the system default encoding (cp949 on Korean Windows, cp1252 on Western EU, gbk on Chinese). When the `.aider_ignore` file contains UTF-8 bytes un-decodable by the active codepage, `UnicodeDecodeError` is raised.

**Mechanism:** The crash propagates from `refresh_aider_ignore()` → `ignored_file()` → `get_tracked_files()` → `base_coder.py:get_addable_relative_files()`, preventing aider from starting or adding files on affected systems.

The patch adds `encoding='utf-8', errors='replace'` to the `read_text()` call, explicitly decoding as UTF-8 and replacing any undecodable bytes with the replacement character rather than crashing.

## Verification

- Confirmed adherence to CONTRIBUTING.md
- Ran `python3 -m pytest tests/basic/test_repo.py` — 21/21 passed
- Ran `python3 -m pytest tests/basic/` — 455/455 non-voice tests passed (1 pre-existing PortAudio skip, 1 pre-existing PortAudio failure)
- Pre-commit hooks passed (isort, black, flake8, codespell)

## Blast Radius

- **Impact:** Medium — crashes hard on startup for affected Windows configurations. Zero impact on Linux/macOS where default encoding is already UTF-8.
- **Trade-offs:** None. `errors='replace'` is already the established pattern in aider's I/O layer (io.py L493, L566, L1131). Worst case: an undecodable byte becomes U+FFFD in a gitignore pattern name, which is effectively non-existent in real usage.

Closes #5276