### PR TITLE
fix: prevent edit application in ask mode (issue #5374)

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -2294,6 +2294,8 @@ class Coder:
         return res
 
     def apply_updates(self):
+        if self.edit_format == "ask":
+            return set()
         edited = set()
         try:
             edits = self.get_edits()


### PR DESCRIPTION
## Summary

Prevent file modifications in `ask` mode, which documents that aider "will discuss your code and answer questions about it, but never make changes."

## Technical Details

**Root Cause:** `Coder.apply_updates()` in `base_coder.py` processes and applies LLM edit blocks regardless of `edit_format`. When the LLM hallucinates edit blocks in `ask` mode, the edits are applied to files, violating the documented behavior.

**Mechanism:** The call chain `run_one()` → `send_message()` → `apply_updates()` → `get_edits()` → `prepare_to_edit()` → `apply_edits()` has no guard for `ask` mode. The fix adds an early return at the entry of `apply_updates()` when `edit_format == "ask"`, short-circuiting the entire edit pipeline.

## Verification

- Confirmed adherence to CONTRIBUTING.md
- Ran `python3 -m pytest tests/basic/test_coder.py tests/basic/test_commands.py tests/basic/test_editblock.py tests/basic/test_udiff.py tests/basic/test_repo.py tests/basic/test_io.py tests/basic/test_main.py tests/basic/test_exceptions.py` — 268 passed, 0 failed
- Pre-commit hooks passed (isort, black, flake8, codespell)

## Blast Radius

- **Impact:** Low — `ask` mode only. No behavioral change for `code`, `architect`, or other edit formats.
- **Trade-offs:** None. AskCoder is subclassed from Coder and inherits `apply_updates()`; the guard is intentionally at the shared method entry point since only AskCoder should skip edits.

Closes #5374