### PR TITLE
fix(io): handle MemoryError in read_text

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -469,6 +469,10 @@ class InputOutput:
             if not silent:
                 self.tool_error(f"{filename}: unable to read: {err}")
             return
+        except MemoryError:
+            if not silent:
+                self.tool_error(f"{filename}: file too large to read into memory")
+            return
         except UnicodeError as e:
             if not silent:
                 self.tool_error(f"{filename}: {e}")
@@ -538,7 +542,7 @@ class InputOutput:
         show = ""
         if rel_fnames:
             rel_read_only_fnames = [
-                get_rel_fname(fname, root) for fname in (abs_read_only_fnames or [])
+                get_rel_fname(fname, root) for fname in abs_read_only_fnames or []
             ]
             show = self.format_files_for_input(rel_fnames, rel_read_only_fnames)
 

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -71,6 +71,34 @@ class TestInputOutput(unittest.TestCase):
             self.assertFalse(io.pretty)
             self.assertIsNone(io.prompt_session)
 
+    def test_read_text_handles_memory_error(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.side_effect = MemoryError
+
+        with (
+            patch("aider.io.open", return_value=mock_file),
+            patch.object(io, "tool_error") as mock_tool_error,
+        ):
+            result = io.read_text("huge.txt")
+
+        self.assertIsNone(result)
+        mock_tool_error.assert_called_once_with("huge.txt: file too large to read into memory")
+
+    def test_read_text_handles_memory_error_silent(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.side_effect = MemoryError
+
+        with (
+            patch("aider.io.open", return_value=mock_file),
+            patch.object(io, "tool_error") as mock_tool_error,
+        ):
+            result = io.read_text("huge.txt", silent=True)
+
+        self.assertIsNone(result)
+        mock_tool_error.assert_not_called()
+
     def test_autocompleter_get_command_completions(self):
         # Step 3: Mock the commands object
         commands = MagicMock()


### PR DESCRIPTION
## Summary
- catch `MemoryError` from `InputOutput.read_text()` instead of letting it crash the process
- report a clear file-too-large error unless the caller requested `silent=True`
- add regression tests for visible and silent reads

Fixes #5387

## Verification
- `uv run --no-project --with black black --line-length 100 --preview aider/io.py tests/basic/test_io.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=/tmp/aider-20260703 uv run --no-project --with pytest --with prompt-toolkit --with rich --with pygments --with oslex python -m pytest tests/basic/test_io.py -k read_text` (2 passed)
- Full `tests/basic/test_io.py` currently has an unrelated pre-existing `test_color_initialization` failure in this non-interactive/dumb-terminal environment.