### PR TITLE
fix: reject /add of files in a sibling dir sharing the root's name prefix

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -847,7 +847,7 @@ class Commands:
             abs_file_path = self.coder.abs_root_path(matched_file)
 
             if (
-                not abs_file_path.startswith(self.coder.root)
+                not Path(abs_file_path).is_relative_to(self.coder.root)
                 and not is_image_file(matched_file)
                 and self.coder.auto_commits
             ):

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -506,6 +506,40 @@ class TestCommands(TestCase):
 
             self.assertEqual(len(coder.abs_fnames), 0)
 
+    def test_cmd_add_abs_path_in_sibling_dir_with_prefix(self):
+        """An absolute path inside a sibling directory whose name starts with
+        the repo root's name must be rejected.
+
+        Regression: the within-root guard used str.startswith(), so a path
+        like /tmp/x/repoXYZ/secret.env was wrongly accepted when the repo
+        root was /tmp/x/repo (no trailing path separator), leaking an
+        out-of-tree file into the chat / to the LLM.
+        See https://github.com/Aider-AI/aider/issues/178
+        """
+        with ChdirTemporaryDirectory() as tmp_dname:
+            root = Path("repo")
+            root.mkdir()
+            os.chdir(str(root))
+
+            make_repo()
+
+            io = InputOutput(pretty=False, fancy_input=False, yes=False)
+            from aider.coders import Coder
+
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            # Sibling dir whose name shares the root's prefix, holding a real file.
+            sibling = Path(tmp_dname) / "repoXYZ"
+            sibling.mkdir()
+            outside_file = sibling / "secret.env"
+            outside_file.touch()
+
+            commands.cmd_add(str(outside_file.resolve()))
+
+            self.assertNotIn(str(outside_file.resolve()), coder.abs_fnames)
+            self.assertEqual(len(coder.abs_fnames), 0)
+
     def test_cmd_add_filename_with_special_chars(self):
         with ChdirTemporaryDirectory():
             io = InputOutput(pretty=False, fancy_input=False, yes=False)


### PR DESCRIPTION
## Problem

`/add <absolute_path>` could add a file that lives **outside** the repo root into the chat (and therefore into the LLM context) whenever the file lived in a sibling directory whose name started with the repo root's name.

Example: with the repo rooted at `/tmp/x/repo`, the following was accepted:

```
/add /tmp/x/repoXYZ/secret.env
```

because `/tmp/x/repoXYZ/secret.env`.startswith(`/tmp/x/repo`) is `True` (string prefix, no path separator).

This is the same class of out-of-tree leak that #178 addressed, but on the **literal absolute-path branch** of `cmd_add` — the glob branch (`glob_filtered_to_repo`) was already protected by `Path.is_relative_to()`, so the gap only showed up for explicit absolute paths / autocomplete-provided paths.

## Root cause

`aider/commands.py`, inside `cmd_add`'s containment guard:

```python
if (
    not abs_file_path.startswith(self.coder.root)   # str prefix, no separator
    and not is_image_file(matched_file)
    and self.coder.auto_commits
):
```

`self.coder.root` has no trailing path separator, so `startswith` matches any sibling directory whose name shares the root's prefix.

## Fix

Use a real path-containment check, matching what `glob_filtered_to_repo` already does:

```python
if (
    not Path(abs_file_path).is_relative_to(self.coder.root)
    and not is_image_file(matched_file)
    and self.coder.auto_commits
):
```

`Path.is_relative_to` is available on all supported Python versions (3.10+).

## Test plan

- [x] Added `test_cmd_add_abs_path_in_sibling_dir_with_prefix` — reproduces the leak on the old code (fails on `main`) and passes after the fix.
- [x] `pytest tests/basic/test_commands.py` — full file green (70 tests), including the existing out-of-root / absolute-path / read-only-external tests (`test_cmd_add_from_outside_root`, `test_cmd_add_abs_filename`, `test_cmd_add_read_only_with_external_file`, …).
- [x] `pre-commit run --files aider/commands.py tests/basic/test_commands.py` — isort / black / flake8 / codespell all pass.

Relates to #178.
