### PR TITLE
fix: /diff shows changes since the most recent message, not the previous one

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -671,10 +671,10 @@ class Commands:
             self.io.tool_error("Unable to get current commit. The repository might be empty.")
             return
 
-        if len(self.coder.commit_before_message) < 2:
+        if not self.coder.commit_before_message:
             commit_before_message = current_head + "^"
         else:
-            commit_before_message = self.coder.commit_before_message[-2]
+            commit_before_message = self.coder.commit_before_message[-1]
 
         if not commit_before_message or commit_before_message == current_head:
             self.io.tool_warning("No changes to display since the last message.")

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -1714,6 +1714,51 @@ class TestCommands(TestCase):
                 self.assertIn("-Further modified content", diff_output)
                 self.assertIn("+Final modified content", diff_output)
 
+    def test_cmd_diff_since_last_message_not_previous(self):
+        """/diff must diff from the head recorded before the MOST RECENT message
+        (commit_before_message[-1]), not the one before it ([-2]).
+
+        Regression: raw_cmd_diff used commit_before_message[-2], so once two
+        messages had been processed in a session, /diff (and the auto-shown
+        post-commit diff) displayed changes accumulated since the *previous*
+        message rather than the current one. show_undo_hint already uses [-1].
+        """
+        with GitTemporaryDirectory() as repo_dir:
+            repo = git.Repo(repo_dir)
+            io = InputOutput(pretty=False, fancy_input=False, yes=True)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            fname = "f.txt"
+            fpath = Path(repo_dir) / fname
+
+            def commit(content):
+                fpath.write_text(content)
+                repo.git.add(fname)
+                repo.git.commit("-m", content)
+
+            commit("v0\n")  # C0
+            c0 = repo.head.commit.hexsha
+            commit("v1\n")  # C1
+            c1 = repo.head.commit.hexsha
+            commit("v2\n")  # C2  <- HEAD
+
+            # Two messages processed in this session; the head recorded before
+            # the most recent message is C1.
+            coder.commit_before_message = [c0, c1]
+
+            with mock.patch("builtins.print") as mock_print:
+                commands.cmd_diff("")
+
+            # cmd_diff prints the unified diff via builtin print (the
+            # "Diff since ..." header goes through the IO console instead).
+            diff_output = mock_print.call_args[0][0]
+
+            # Base must be C1 ([-1]) -> diff is v1..v2; not C0 ([-2]) -> v0..v2.
+            self.assertIn("-v1", diff_output)
+            self.assertIn("+v2", diff_output)
+            self.assertNotIn("-v0", diff_output)
+
     def test_cmd_model(self):
         io = InputOutput(pretty=False, fancy_input=False, yes=True)
         coder = Coder.create(self.GPT35, None, io)


### PR DESCRIPTION
## Problem

`/diff` (and the diff aider auto-shows after each commit) displayed changes accumulated since the **previous** message instead of the current one, once two or more messages had been processed in a session.

`raw_cmd_diff` used `commit_before_message[-2]` as the diff base. But `commit_before_message` is appended exactly once per top-level message (in `init_before_message`, before the message is processed), so:

- `[-1]` = head recorded before the **most recent** message (correct base for "diff since the last message")
- `[-2]` = head recorded before the **previous** message (what the code used)

The sibling method `show_undo_hint` already uses `[-1]`, so the two disagreed.

There was a second, related defect on the same path: the `len(...) < 2` fallback used `current_head + "^"`, which only goes back a single commit. For a message that produced multiple commits (e.g. via reflections), that showed just the last reflection's diff rather than the whole message's changes.

## Fix

`aider/commands.py` — `raw_cmd_diff`:

```python
if not self.coder.commit_before_message:
    commit_before_message = current_head + "^"
else:
    commit_before_message = self.coder.commit_before_message[-1]
```

This matches `show_undo_hint` (`base_coder.py`), and only falls back to `current_head + "^"` when no message has been recorded yet (empty list).

## Test plan

- [x] Added `test_cmd_diff_since_last_message_not_previous` — builds three commits `C0 -> C1 -> C2`, sets `commit_before_message = [C0, C1]` (HEAD = `C2`), and asserts `/diff` produces the `C1..C2` diff (not `C0..C2`). Fails on `main`, passes with the fix.
- [x] `pytest tests/basic/test_commands.py` — 71 passed (incl. the existing `test_cmd_diff`).
- [x] `pytest tests/basic/ -k "diff or undo or commit"` — 30 passed.
- [x] `pre-commit run --files aider/commands.py tests/basic/test_commands.py` — isort / black / flake8 / codespell all pass.
