### PR TITLE
fix: don't discard model output past a literal reasoning close tag

### DIFF
--- a/aider/reasoning_tags.py
+++ b/aider/reasoning_tags.py
@@ -25,14 +25,23 @@ def remove_reasoning_content(res, reasoning_tag):
     if not reasoning_tag:
         return res
 
+    open_tag = f"<{reasoning_tag}>"
+    closing_tag = f"</{reasoning_tag}>"
+    # Whether the response contained an opening tag. Captured before the
+    # balanced-block substitution below removes it.
+    had_open_tag = open_tag in res
+
     # Try to match the complete tag pattern first
     pattern = f"<{reasoning_tag}>.*?</{reasoning_tag}>"
     res = re.sub(pattern, "", res, flags=re.DOTALL).strip()
 
-    # If closing tag exists but opening tag might be missing, remove everything before closing
-    # tag
-    closing_tag = f"</{reasoning_tag}>"
-    if closing_tag in res:
+    # Only treat a remaining closing tag as an orphan reasoning close when no
+    # opening tag was present at all (e.g. a continuation whose opening tag
+    # was emitted in a prior chunk); in that case the text before it is
+    # reasoning and is dropped. If there was an opening tag, any closing tag
+    # still left after the substitution above is a *literal* occurrence in
+    # the model's answer (e.g. inside code or prose) and must be preserved.
+    if not had_open_tag and closing_tag in res:
         # Split on the closing tag and keep everything after it
         parts = res.split(closing_tag, 1)
         res = parts[1].strip() if len(parts) > 1 else res

--- a/tests/basic/test_reasoning.py
+++ b/tests/basic/test_reasoning.py
@@ -399,6 +399,27 @@ End"""
         text = "Just regular text"
         self.assertEqual(remove_reasoning_content(text, "think"), text)
 
+    def test_remove_reasoning_content_literal_closing_tag(self):
+        """A literal </think> in the model's answer (e.g. inside code or
+        prose) must not be discarded when the response also contained a real
+        (balanced) reasoning block.
+
+        Regression: the orphan-close heuristic split on the first remaining
+        </think> after stripping balanced blocks, silently dropping the real
+        answer that preceded a literal </think>.
+        """
+        text = "<think>reasoning here</think>Here is code: print('</think>')"
+        expected = "Here is code: print('</think>')"
+        self.assertEqual(remove_reasoning_content(text, "think"), expected)
+
+    def test_remove_reasoning_content_orphan_closing_tag_stripped(self):
+        """When no opening tag is present at all (e.g. a continuation where
+        the opening tag was emitted in a prior chunk), an orphan </think> is
+        still stripped along with the reasoning text that preceded it."""
+        text = "leftover reasoning here</think>actual answer"
+        expected = "actual answer"
+        self.assertEqual(remove_reasoning_content(text, "think"), expected)
+
     def test_send_with_reasoning(self):
         """Test that reasoning content from the 'reasoning' attribute is properly formatted
         and output."""


### PR DESCRIPTION
## Problem

For models with a `reasoning_tag` (e.g. DeepSeek-R1 → `think`), `remove_reasoning_content` silently discarded part of the model's real answer whenever the answer contained a literal closing tag (e.g. `</think>` inside code, markup, or prose) **and** the response also contained a real reasoning block.

What happens: the function first strips balanced `<think>...</think>` blocks, then has a fallback that drops everything before any *remaining* `</think>` (intended for the continuation case where the opening tag was emitted in a prior chunk). That fallback fired unconditionally, so a literal `</think>` in the answer was mistaken for an orphan reasoning close.

```
in:  <think>r</think>Here is code: print('</think>')
was: ')
now: Here is code: print('</think>')
```

This function runs on every assistant response for reasoning-tag models (`Coder.remove_reasoning_content`) and on every commit-message / chat-summarization call (`Model.simple_send_with_retries`), so the truncation was silent and the shortened text was what reached edit parsing / commit-message generation.

## Fix

`aider/reasoning_tags.py` — only treat a remaining `</tag>` as an orphan close when the response contained **no** opening tag at all (the continuation case). When an opening tag was present, any `</tag>` left after the balanced-block substitution is a literal occurrence in the answer and is preserved.

The legitimate orphan-close behaviour (continuation whose `<tag>` was in a prior chunk) is unchanged.

## Test plan

- [x] Added `test_remove_reasoning_content_literal_closing_tag` — reproduces the truncation on `main` (returns `')'`), passes with the fix.
- [x] Added `test_remove_reasoning_content_orphan_closing_tag_stripped` — locks in that a genuine orphan close (no opening tag) is still stripped.
- [x] `pytest tests/basic/test_reasoning.py tests/basic/test_models.py` — 34 passed (incl. the existing `test_remove_reasoning_content` and the integration tests that drive `coder.remove_reasoning_content()` with mocked streaming).
- [x] `pre-commit run --files aider/reasoning_tags.py tests/basic/test_reasoning.py` — isort / black / flake8 / codespell all pass.
