### PR TITLE
Refactor benchmark tests for cleanup_test_output

### DIFF
--- a/benchmark/test_benchmark.py
+++ b/benchmark/test_benchmark.py
@@ -1,47 +1,34 @@
 # flake8: noqa: E501
 
 import unittest
+from pathlib import Path
 
 from benchmark import cleanup_test_output
 
 
 class TestCleanupTestOutput(unittest.TestCase):
-    def test_cleanup_test_output(self):
-        # Test case with timing info
+    def setUp(self):
+        self.testdir = Path("tmp.benchmarks/2024-01-01/python/exercises/practice/two-fer")
+
+    def test_removes_timing_info(self):
         output = "Ran 5 tests in 0.003s\nOK"
-        expected = "\nOK"
-        self.assertEqual(cleanup_test_output(output), expected)
+        expected = "Ran 5 tests \nOK"
+        self.assertEqual(cleanup_test_output(output, self.testdir), expected)
 
-        # Test case without timing info
+    def test_output_without_timing_is_unchanged(self):
         output = "OK"
-        expected = "OK"
-        self.assertEqual(cleanup_test_output(output), expected)
+        self.assertEqual(cleanup_test_output(output, self.testdir), "OK")
 
-    def test_cleanup_test_output_lines(self):
-        # Test case with timing info
-        output = """F
-======================================================================
-FAIL: test_cleanup_test_output (test_benchmark.TestCleanupTestOutput.test_cleanup_test_output)
-----------------------------------------------------------------------
-Traceback (most recent call last):
-  File "/Users/gauthier/Projects/aider/benchmark/test_benchmark.py", line 14, in test_cleanup_test_output
-    self.assertEqual(cleanup_test_output(output), expected)
-AssertionError: 'OK' != 'OKx'
-- OK
-+ OKx
-?   +
-"""
+    def test_replaces_testdir_path_with_its_name(self):
+        output = f"FAILED {self.testdir}/two_fer.py::test_name - AssertionError"
+        expected = "FAILED two-fer/two_fer.py::test_name - AssertionError"
+        self.assertEqual(cleanup_test_output(output, self.testdir), expected)
 
-        expected = """F
-====
-FAIL: test_cleanup_test_output (test_benchmark.TestCleanupTestOutput.test_cleanup_test_output)
-----
-Traceback (most recent call last):
-  File "/Users/gauthier/Projects/aider/benchmark/test_benchmark.py", line 14, in test_cleanup_test_output
-    self.assertEqual(cleanup_test_output(output), expected)
-AssertionError: 'OK' != 'OKx'
-- OK
-+ OKx
-?   +
-"""
-        self.assertEqual(cleanup_test_output(output), expected)
+    def test_removes_timing_and_path_together(self):
+        output = f"1 failed in 2.50s\n{self.testdir}/two_fer.py"
+        expected = "1 failed \ntwo-fer/two_fer.py"
+        self.assertEqual(cleanup_test_output(output, self.testdir), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`benchmark/test_benchmark.py`  the only test file for the benchmark harness has been broken since mid-2023 and currently cannot run at all. This was independently flagged in a note on #5136:

> `python -m unittest benchmark/test_benchmark.py` is currently blocked by the existing benchmark test import/signature mismatch (`cleanup_test_output()` now requires `testdir`).

This PR fixes the tests so the suite runs and passes again, and adds coverage for the `testdir` behavior that was never tested.

**Root cause:** the tests were written against a 2023 version of `cleanup_test_output`. The function has since changed in two ways the tests never tracked:

1. **Signature drift.** `cleanup_test_output(output)` became `cleanup_test_output(output, testdir)` when testdir-path scrubbing was added (replacing the full test directory path with `testdir.name` in test output). Both existing tests still call it with one argument → immediate `TypeError`.
2. **Behavior drift.** The second test asserts that long `====` / `----` separator lines are truncated to `====` / `----`. That truncation was removed from `cleanup_test_output` after the June 2023 commit that introduced it ("remove long ==--- lines to save tokens") and no longer exists in the function, so the assertion tests phantom behavior.
3. **Stale expected value.** The first test expects `"Ran 5 tests in 0.003s\nOK"` → `"\nOK"`, but the current regex `r"\bin \d+\.\d+s\b"` only removes the timing substring, yielding `"Ran 5 tests \nOK"` (leading text and trailing space are preserved).

**Reproduction** (on `main`, from inside `benchmark/`):

```
$ python -m unittest test_benchmark -v
TypeError: cleanup_test_output() missing 1 required positional argument: 'testdir'
```

## Modifications

All changes are confined to `benchmark/test_benchmark.py`. No production code is touched — the tests are updated to match the current, long-standing behavior of `cleanup_test_output`.

1. Added a `setUp` providing a realistic `testdir` `Path` matching the harness layout (`tmp.benchmarks/<date>/<lang>/exercises/practice/<exercise>`), and passed it to every call.
2. Corrected the timing-removal test's expected value to `"Ran 5 tests \nOK"` per the actual regex behavior.
3. Removed the `====`/`----` truncation test — that behavior no longer exists in `cleanup_test_output`.
4. Added two new tests for previously untested behavior:
   - the testdir path is replaced with `testdir.name` in output (this is what anonymizes absolute paths before test output is fed back to the LLM)
   - timing removal and path replacement compose correctly in one output

Test inputs are built with f-strings off `str(self.testdir)`, so path-separator differences make the tests pass identically on Windows and POSIX.

## Tests

```
$ cd benchmark && python -m unittest test_benchmark -v
test_output_without_timing_is_unchanged ... ok
test_removes_timing_and_path_together ... ok
test_removes_timing_info ... ok
test_replaces_testdir_path_with_its_name ... ok

```

Note: `python -m unittest test_benchmark` must be run from inside `benchmark/` so that `benchmark.py` (which imports its sibling modules `prompts` and `plots` as top-level modules) resolves correctly. Running via pytest from the repo root resolves `benchmark` to the package (`benchmark/__init__.py`) rather than the module and fails on import — a pre-existing quirk, noted under out-of-scope below.

## Impact

- No production code changes; `cleanup_test_output` is untouched.
- Unblocks the test-suite note left on #5136.
- Restores a working baseline so future changes to the harness can actually be tested.

## Out of scope (possible follow-ups)

- The `benchmark/__init__.py` vs `benchmark.py` name collision that prevents running these tests via pytest with default import mode.
- Broader unit coverage for `benchmark.py` (`run_unit_tests` command selection, `summarize_results`), which currently has none.