### PR TITLE
Keep trailing tool output in split_chat_history_markdown

### DIFF
--- a/aider/utils.py
+++ b/aider/utils.py
@@ -189,6 +189,7 @@ def split_chat_history_markdown(text, include_tool=False):
 
     append_msg("assistant", assistant)
     append_msg("user", user)
+    append_msg("tool", tool)
 
     if not include_tool:
         messages = [m for m in messages if m["role"] != "tool"]

--- a/tests/basic/test_utils.py
+++ b/tests/basic/test_utils.py
@@ -1,6 +1,6 @@
 import os
 
-from aider.utils import safe_abs_path
+from aider.utils import safe_abs_path, split_chat_history_markdown
 
 
 def test_safe_abs_path_symlink_loop(tmp_path):
@@ -13,3 +13,11 @@ def test_safe_abs_path_symlink_loop(tmp_path):
     # safe_abs_path must not raise, and must return an absolute path
     result = safe_abs_path(str(link_a))
     assert os.path.isabs(result)
+
+
+def test_split_chat_history_keeps_trailing_tool():
+    # A history ending in a tool ("> ") line must not drop that content when
+    # include_tool=True. The end-of-loop flush skipped the tool buffer, so a
+    # trailing tool message was lost.
+    messages = split_chat_history_markdown("> trailing tool output\n", include_tool=True)
+    assert messages == [{"role": "tool", "content": "trailing tool output\n"}]


### PR DESCRIPTION
split_chat_history_markdown flushes the assistant and user buffers at the end of parsing but not the tool buffer, so a history ending in a '> ' tool line loses that content when include_tool=True. Added the missing tool flush plus a test.