### PR TITLE
upgrade litellm to 1.91.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -151,10 +151,9 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==7.2.1
+importlib-metadata==8.9.0
     # via
     #   -c requirements/common-constraints.txt
-    #   -r requirements/requirements.in
     #   litellm
 importlib-resources==6.5.2
     # via
@@ -181,7 +180,7 @@ jsonschema-specifications==2025.9.1
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
-litellm==1.82.3
+litellm==1.91.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -434,8 +433,6 @@ typer==0.24.1
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   huggingface-hub
@@ -443,8 +440,6 @@ typing-extensions==4.15.0
     #   posthog
     #   pydantic
     #   pydantic-core
-    #   referencing
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -206,10 +206,8 @@ idna==3.11
     #   yarl
 imgcat==0.6.0
     # via -r requirements/requirements-dev.in
-importlib-metadata==7.2.1
-    # via
-    #   -r requirements/requirements.in
-    #   litellm
+importlib-metadata==8.9.0
+    # via litellm
 importlib-resources==6.5.2
     # via -r requirements/requirements.in
 iniconfig==2.3.0
@@ -238,7 +236,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 kiwisolver==1.5.0
     # via matplotlib
-litellm==1.82.3
+litellm==1.91.0
     # via -r requirements/requirements.in
 llama-index-core==0.14.18
     # via llama-index-embeddings-huggingface
@@ -568,6 +566,8 @@ tree-sitter-language-pack==0.13.0
     # via grep-ast
 tree-sitter-yaml==0.7.2
     # via tree-sitter-language-pack
+triton==3.6.0
+    # via torch
 typer==0.24.1
     # via
     #   -r requirements/requirements-dev.in
@@ -575,9 +575,7 @@ typer==0.24.1
     #   transformers
 typing-extensions==4.15.0
     # via
-    #   aiosignal
     #   altair
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   grpcio
@@ -589,10 +587,8 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pyee
-    #   referencing
     #   sentence-transformers
     #   sqlalchemy
-    #   starlette
     #   streamlit
     #   torch
     #   typing-inspect
@@ -613,6 +609,8 @@ uv==0.10.11
     # via -r requirements/requirements-dev.in
 virtualenv==21.2.0
     # via pre-commit
+watchdog==6.0.0
+    # via streamlit
 watchfiles==1.1.1
     # via -r requirements/requirements.in
 wcwidth==0.6.0

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -143,7 +143,6 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
     #   altair
-    #   referencing
     #   streamlit
 tzdata==2025.3
     # via
@@ -153,3 +152,7 @@ urllib3==2.6.3
     # via
     #   -c requirements/common-constraints.txt
     #   requests
+watchdog==6.0.0
+    # via
+    #   -c requirements/common-constraints.txt
+    #   streamlit

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -343,6 +343,10 @@ transformers==5.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   sentence-transformers
+triton==3.6.0
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 typer==0.24.1
     # via
     #   -c requirements/common-constraints.txt
@@ -351,8 +355,6 @@ typer==0.24.1
 typing-extensions==4.15.0
     # via
     #   -c requirements/common-constraints.txt
-    #   aiosignal
-    #   anyio
     #   huggingface-hub
     #   llama-index-core
     #   llama-index-workflows

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -39,11 +39,6 @@ oslex
 # >3.5 seems to not be available for py3.10
 networkx<3.5
 
-# GitHub Release action failing on "KeyError: 'home-page'"
-# https://github.com/pypa/twine/blob/6fbf880ee60915cf1666348c4bdd78a10415f2ac/twine/__init__.py#L40
-# Uses importlib-metadata
-importlib-metadata<8.0.0
-
 # The proper dependency is litellm[proxy], but it installs
 # mcp which is a pywin32 dependency that fails on linux CI.
 fastapi


### PR DESCRIPTION
- for multi-region Vertex AI support

[Release Notes | liteLLM](https://docs.litellm.ai/release_notes)