### PR TITLE
fix: don't double-bill DeepSeek cache-hit tokens

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -2089,7 +2089,7 @@ class Coder:
         if input_cost_per_token_cache_hit:
             # must be deepseek
             cost += input_cost_per_token_cache_hit * cache_hit_tokens
-            cost += (prompt_tokens - input_cost_per_token_cache_hit) * input_cost_per_token
+            cost += (prompt_tokens - cache_hit_tokens) * input_cost_per_token
         else:
             # hard code the anthropic adjustments, no-ops for other models since cache_x_tokens==0
             cost += cache_write_tokens * input_cost_per_token * 1.25

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,38 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_compute_costs_from_tokens_deepseek_cache_hit(self):
+        # DeepSeek-style pricing has a separate (cheaper) rate for cache-hit
+        # tokens. The cache-hit tokens should be billed at the cache-hit rate and
+        # the remaining (cache-miss) tokens at the full input rate. Regression
+        # test for a bug that subtracted the per-token *price*
+        # (input_cost_per_token_cache_hit) from the token *count* (prompt_tokens),
+        # which billed nearly all prompt tokens at the full rate on top of the
+        # cache-hit charge -- double-billing the cache-hit tokens.
+        with GitTemporaryDirectory():
+            coder = Coder.create(self.GPT35, None, io=InputOutput())
+            coder.main_model.info = {
+                "input_cost_per_token": 0.00000027,
+                "output_cost_per_token": 0.0000011,
+                "input_cost_per_token_cache_hit": 0.00000007,
+            }
+
+            prompt_tokens = 10_000
+            cache_hit_tokens = 8_000
+            completion_tokens = 500
+            cache_write_tokens = 0
+
+            cost = coder.compute_costs_from_tokens(
+                prompt_tokens, completion_tokens, cache_write_tokens, cache_hit_tokens
+            )
+
+            expected = (
+                cache_hit_tokens * 0.00000007
+                + (prompt_tokens - cache_hit_tokens) * 0.00000027
+                + completion_tokens * 0.0000011
+            )
+            self.assertAlmostEqual(cost, expected, places=10)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`Coder.compute_costs_from_tokens()` (`aider/coders/base_coder.py`) double-bills cache-hit tokens on the DeepSeek pricing branch:

```python
if input_cost_per_token_cache_hit:
    # must be deepseek
    cost += input_cost_per_token_cache_hit * cache_hit_tokens
    cost += (prompt_tokens - input_cost_per_token_cache_hit) * input_cost_per_token
```

The second line subtracts `input_cost_per_token_cache_hit` — a per-token **price** (a tiny fraction, e.g. `7e-8`) — from `prompt_tokens`, which is a token **count**. It should subtract `cache_hit_tokens` (the count of tokens already charged at the cache-hit rate on the line above).

The comment directly above states the intent:

```
# deepseek
# prompt_cache_hit_tokens + prompt_cache_miss_tokens
#    == prompt_tokens == total tokens that were sent
```

So the split should be: cache-hit tokens at the cache-hit rate, and the **remaining (cache-miss) tokens** at the full input rate — i.e. `(prompt_tokens - cache_hit_tokens)`.

Because `input_cost_per_token_cache_hit` is ≈ 0 next to a token count, `prompt_tokens - input_cost_per_token_cache_hit ≈ prompt_tokens`, so the entire prompt is billed at the full input rate **on top of** the cache-hit charge — the cache-hit tokens are billed twice.

## Fix

```python
cost += (prompt_tokens - cache_hit_tokens) * input_cost_per_token
```

## Impact

Worked example (`input_cost_per_token=2.7e-7`, `input_cost_per_token_cache_hit=7e-8`, `prompt_tokens=10000`, `cache_hit_tokens=8000`):

| | cost |
|---|---|
| Before | `0.00326` |
| After (correct) | `0.00110` |

~3× overstatement of the input cost whenever DeepSeek reports cache hits (the default streaming path). This inflates the `Cost: $… message / $… session` report and `total_cost`.

## Test

Added `test_compute_costs_from_tokens_deepseek_cache_hit` to `tests/basic/test_coder.py`.

- Before the fix it fails (`0.00381 != 0.00165`).
- After the fix it passes.
- Full `tests/basic/test_coder.py`: **43 passed** (was 42), no regressions.
