### PR TITLE
fix: handle MemoryError when reading text files

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -469,6 +469,10 @@ class InputOutput:
             if not silent:
                 self.tool_error(f"{filename}: unable to read: {err}")
             return
+        except MemoryError:
+            if not silent:
+                self.tool_error(f"{filename}: file is too large to read into memory")
+            return
         except UnicodeError as e:
             if not silent:
                 self.tool_error(f"{filename}: {e}")

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -13,6 +13,20 @@ from aider.utils import ChdirTemporaryDirectory
 
 
 class TestInputOutput(unittest.TestCase):
+    def read_text_with_memory_error(self, io, silent=False):
+        class MemoryErrorFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+            def read(self):
+                raise MemoryError
+
+        with patch("builtins.open", return_value=MemoryErrorFile()):
+            return io.read_text("huge.txt", silent=silent)
+
     def test_line_endings_validation(self):
         # Test valid line endings
         for ending in ["platform", "lf", "crlf"]:
@@ -29,6 +43,32 @@ class TestInputOutput(unittest.TestCase):
         self.assertIn("platform", str(cm.exception))
         self.assertIn("crlf", str(cm.exception))
         self.assertIn("lf", str(cm.exception))
+
+    def test_read_text_handles_memory_error(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+
+        with patch.object(io, "tool_error") as mock_tool_error:
+            try:
+                result = self.read_text_with_memory_error(io)
+            except MemoryError:
+                result = "raised"
+
+            self.assertIsNone(result)
+            mock_tool_error.assert_called_once_with(
+                "huge.txt: file is too large to read into memory"
+            )
+
+    def test_read_text_memory_error_silent(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+
+        with patch.object(io, "tool_error") as mock_tool_error:
+            try:
+                result = self.read_text_with_memory_error(io, silent=True)
+            except MemoryError:
+                result = "raised"
+
+            self.assertIsNone(result)
+            mock_tool_error.assert_not_called()
 
     def test_no_color_environment_variable(self):
         with patch.dict(os.environ, {"NO_COLOR": "1"}):


### PR DESCRIPTION
## Summary

Fixes #5387.

`InputOutput.read_text()` now handles `MemoryError` when reading a text file, avoiding an uncaught traceback if a file is too large to load into memory.

## Changes

- Catch `MemoryError` in `InputOutput.read_text()`
- Return `None` consistently with other file read failures
- Respect `silent=True` by suppressing the error message
- Add regression tests for normal and silent `MemoryError` handling

## Testing

- `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/basic/test_io.py -q`
- `env -u NO_COLOR TERM=xterm-256color HOME=/private/tmp/aider-test-home .venv/bin/python -m pytest tests/basic/test_commands.py -k "cmd_add or read_only" -q`

Note: I also tried `tests/basic tests/help`; it reached `124 passed` before stalling and was interrupted after 4:15.