### PR TITLE
Fix /read-only completions being case-sensitive when filtering suggestions

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -740,7 +740,7 @@ class Commands:
         # Add completions from the 'add' command
         add_completions = self.completions_add()
         for completion in add_completions:
-            if after_command in completion:
+            if after_command.lower() in completion.lower():
                 all_completions.append(
                     Completion(
                         text=completion,

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -1648,6 +1648,22 @@ class TestCommands(TestCase):
             # Check if all files were removed from abs_read_only_fnames
             self.assertEqual(len(coder.abs_read_only_fnames), 0)
 
+    def test_completions_raw_read_only_case_insensitive(self):
+        from prompt_toolkit.document import Document
+
+        with GitTemporaryDirectory():
+            io = InputOutput(pretty=False, fancy_input=False, yes=False)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            text = "/read-only m"
+            doc = Document(text, cursor_position=len(text))
+            with mock.patch.object(commands, "completions_add", return_value=["MyFile.txt"]):
+                completions = list(commands.completions_raw_read_only(doc, None))
+
+            texts = [c.text for c in completions]
+            self.assertIn("MyFile.txt", texts)
+
     def test_cmd_diff(self):
         with GitTemporaryDirectory() as repo_dir:
             repo = git.Repo(repo_dir)


### PR DESCRIPTION
Typing /read-only m would not suggest MyFile.txt even though /add m would, because completions_raw_read_only() filtered with the case-sensitive in operator while the /add path uses case-insensitive matching. The fix lowercases both sides of the check in commands.py:743. Fixes #2223.