### PR TITLE
docs: add DaoXE OpenAI-compatible gateway guide

### DIFF
--- a/aider/website/docs/llms.md
+++ b/aider/website/docs/llms.md
@@ -37,6 +37,8 @@ Aider can work also with local models, for example using [Ollama](/docs/llms/oll
 It can also access
 local models that provide an
 [Open AI compatible API](/docs/llms/openai-compat.html).
+It can also connect to multi-model gateways such as
+[DaoXE](/docs/llms/daoxe.html).
 
 ## Use a capable model
 {: .no_toc }

--- a/aider/website/docs/llms/daoxe.md
+++ b/aider/website/docs/llms/daoxe.md
@@ -1,0 +1,53 @@
+---
+parent: Connecting to LLMs
+nav_order: 500
+---
+
+# DaoXE
+
+Aider can connect to [DaoXE](https://daoxe.com), a multi-model multi-protocol AI
+API gateway for developers. DaoXE exposes an OpenAI-compatible Chat Completions
+endpoint at `https://daoxe.com/v1`, and also supports OpenAI Responses and
+Anthropic Messages endpoints outside aider's OpenAI-compatible path.
+
+You'll need a DaoXE API key from your [DaoXE account](https://daoxe.com).
+
+> DaoXE is **not available in mainland China**.
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your API key and endpoint:
+
+```
+# Mac/Linux:
+export OPENAI_API_BASE=https://daoxe.com/v1
+export OPENAI_API_KEY=<key>
+
+# Windows:
+setx OPENAI_API_BASE https://daoxe.com/v1
+setx OPENAI_API_KEY <key>
+# ... restart shell after setx commands
+```
+
+Start working with aider and DaoXE on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# Use an exact model ID currently available to your DaoXE account
+aider --model openai/<model-id>
+```
+
+Choose the model ID from your DaoXE account catalog or the public
+[models and pricing page](https://daoxe.com/pricing). Account availability can
+vary, so prefer the model list returned for your key.
+
+Public setup examples and a low-cost smoke/compare benchmark:
+[DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+
+See the [model warnings](warnings.html)
+section for information on warnings which will occur
+when working with models that aider is not familiar with.

--- a/aider/website/docs/llms/openai-compat.md
+++ b/aider/website/docs/llms/openai-compat.md
@@ -34,6 +34,22 @@ cd /to/your/project
 aider --model openai/<model-name>
 ```
 
+
+
+## Example: DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway with an
+OpenAI-compatible endpoint.
+
+```
+export OPENAI_API_BASE=https://daoxe.com/v1
+export OPENAI_API_KEY=<key>
+aider --model openai/<model-id>
+```
+
+DaoXE is not available in mainland China. See the dedicated
+[DaoXE guide](daoxe.html) for more detail.
+
 See the [model warnings](warnings.html)
 section for information on warnings which will occur
 when working with models that aider is not familiar with.


### PR DESCRIPTION
## Summary
- Add a dedicated **DaoXE** LLM guide under Connecting to LLMs.
- Document `OPENAI_API_BASE=https://daoxe.com/v1` + `OPENAI_API_KEY` usage with `aider --model openai/<model-id>`.
- Cross-link from the OpenAI-compatible APIs page and the LLMs overview.
- Note multi-protocol scope and mainland-China unavailability.
- Link public examples: https://github.com/seven7763/DaoXE-AI

## Disclosure
I am affiliated with DaoXE.

## Test plan
- [ ] Confirm docs render on the site
- [ ] Links resolve (`daoxe.html`, daoxe.com, DaoXE-AI)