### PR TITLE
fix(history): retain recent messages during summarization

### DIFF
--- a/aider/history.py
+++ b/aider/history.py
@@ -73,16 +73,16 @@ class ChatSummary:
         model_max_input_tokens = self.models[0].info.get("max_input_tokens") or 4096
         model_max_input_tokens -= 512  # reserve buffer for safety
 
-        keep = []
         total = 0
-
-        # Iterate in original order, summing tokens until limit
-        for tokens, msg in sized_head:
-            total += tokens
-            if total > model_max_input_tokens:
+        start_index = len(sized_head)
+        for i in range(len(sized_head) - 1, -1, -1):
+            tokens, _msg = sized_head[i]
+            if total + tokens > model_max_input_tokens:
                 break
-            keep.append(msg)
-        # No need to reverse lists back and forth
+            total += tokens
+            start_index = i
+
+        keep = [msg for _tokens, msg in sized_head[start_index:]]
 
         summary = self.summarize_all(keep)
 

--- a/tests/basic/test_history.py
+++ b/tests/basic/test_history.py
@@ -80,6 +80,60 @@ class TestChatSummary(TestCase):
         self.assertLess(len(result), len(messages))
         self.assertEqual(result[0]["content"], "Summary")
 
+    def test_summarize_uses_most_recent_head_within_model_context(self):
+        self.mock_model.info = {"max_input_tokens": 522}
+        self.chat_summary.max_tokens = 10
+        for message_count in (12, 8192):
+            with self.subTest(message_count=message_count):
+                messages = [
+                    {
+                        "role": "user" if index % 2 == 0 else "assistant",
+                        "content": f"Message {index}",
+                    }
+                    for index in range(message_count)
+                ]
+
+                with mock.patch.object(
+                    self.chat_summary,
+                    "summarize_all",
+                    return_value=[{"role": "user", "content": "Summary"}],
+                ) as summarize_all:
+                    result = self.chat_summary.summarize_real(messages)
+
+                expected_tail = messages[-2:]
+                expected_head = messages[-7:-2]
+                summarize_all.assert_called_once_with(expected_head)
+                self.assertEqual(
+                    result,
+                    [{"role": "user", "content": "Summary"}] + expected_tail,
+                )
+
+    def test_summarize_handles_nonpositive_model_context_budget(self):
+        self.chat_summary.max_tokens = 10
+        messages = [
+            {
+                "role": "user" if index % 2 == 0 else "assistant",
+                "content": f"Message {index}",
+            }
+            for index in range(12)
+        ]
+
+        for max_input_tokens in (512, 511):
+            with self.subTest(max_input_tokens=max_input_tokens):
+                self.mock_model.info = {"max_input_tokens": max_input_tokens}
+                with mock.patch.object(
+                    self.chat_summary,
+                    "summarize_all",
+                    return_value=[{"role": "user", "content": "Summary"}],
+                ) as summarize_all:
+                    result = self.chat_summary.summarize_real(messages)
+
+                summarize_all.assert_called_once_with([])
+                self.assertEqual(
+                    result,
+                    [{"role": "user", "content": "Summary"}] + messages[-2:],
+                )
+
     def test_fallback_to_second_model(self):
         mock_model1 = mock.Mock(spec=Model)
         mock_model1.name = "gpt-4"


### PR DESCRIPTION
## Summary

- restore the newest budget-fitting head suffix during chat summarization
- preserve chronological order, the unsummarized tail, and existing recursion
- cover exact boundaries, nonpositive budgets, call count, and large histories

PR #3764 replaced the previous reverse/select/reverse logic with forward iteration. That also changed selection from the newest head suffix to the oldest prefix, so recent eligible messages could be omitted while much older messages were retained.

Fixes #5440.

## Autoresearch

Running autoresearch with Weco reproduced the regression and tested candidate fixes against deterministic context-retention and scaling gates:

https://dashboard.weco.ai/share/DrDbVZz3X8a69GvOUew-jxkxDJw0aE7N

- context_retention_score: 20.0 to 100.0
- 14 repeated strict candidate evaluations: 100.0
- linear scaling retained through a 50,000-message fixture

## Validation

- pytest tests/basic/test_history.py tests/basic/test_coder.py -q: 49 passed, 29 subtests passed
- focused regression tests: 8 passed, 4 subtests passed
- Ruff and flake8 pass
- git diff --check passes
