### PR TITLE
perf(repo): cache unchanged tracked file lists

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -80,6 +80,7 @@ class GitRepo:
 
         self.normalized_path = {}
         self.tree_files = {}
+        self.tracked_files_cache = None
 
         self.attribute_author = attribute_author
         self.attribute_committer = attribute_committer
@@ -430,6 +431,24 @@ class GitRepo:
 
         return diffs
 
+    def _get_tracked_files_cache_key(self, commit, index):
+        if self.subtree_only:
+            return None
+
+        try:
+            index_stat = os.stat(index.path)
+        except OSError:
+            return None
+
+        return (
+            commit,
+            index_stat.st_mtime_ns,
+            index_stat.st_ctime_ns,
+            index_stat.st_size,
+            index_stat.st_ino,
+            self.aider_ignore_ts,
+        )
+
     def get_tracked_files(self):
         if not self.repo:
             return []
@@ -444,10 +463,18 @@ class GitRepo:
             self.io.tool_output("Is your git repo corrupted?")
             return []
 
+        self.refresh_aider_ignore()
+        index = self.repo.index
+        cache_key = self._get_tracked_files_cache_key(commit, index)
+        cached = self.tracked_files_cache
+        if cache_key is not None and cached is not None and cache_key == cached[0]:
+            return list(cached[1])
+
+        cacheable = True
         files = set()
         if commit:
             if commit in self.tree_files:
-                files = self.tree_files[commit]
+                files = set(self.tree_files[commit])
             else:
                 try:
                     iterator = commit.tree.traverse()
@@ -476,14 +503,18 @@ class GitRepo:
                 self.tree_files[commit] = set(files)
 
         # Add staged files
-        index = self.repo.index
         try:
             staged_files = [path for path, _ in index.entries.keys()]
             files.update(self.normalize_path(path) for path in staged_files)
         except ANY_GIT_ERROR as err:
+            cacheable = False
             self.io.tool_error(f"Unable to read staged files: {err}")
 
         res = [fname for fname in files if not self.ignored_file(fname)]
+        if cache_key is not None and cacheable:
+            self.tracked_files_cache = (cache_key, tuple(res))
+        else:
+            self.tracked_files_cache = None
 
         return res
 
@@ -507,10 +538,15 @@ class GitRepo:
 
         self.aider_ignore_last_check = current_time
 
-        if not self.aider_ignore_file.is_file():
+        if self.aider_ignore_file.is_file():
+            mtime = self.aider_ignore_file.stat().st_mtime
+        else:
+            if self.aider_ignore_ts:
+                self.aider_ignore_ts = 0
+                self.aider_ignore_spec = None
+                self.ignore_file_cache = {}
             return
 
-        mtime = self.aider_ignore_file.stat().st_mtime
         if mtime != self.aider_ignore_ts:
             self.aider_ignore_ts = mtime
             self.ignore_file_cache = {}

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -479,6 +479,108 @@ class TestRepo(unittest.TestCase):
         # Assert that coder.get_tracked_files() returns the three filenames
         self.assertEqual(set(tracked_files), set(created_files))
 
+    def test_get_tracked_files_caches_unchanged_repo(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            for name in ("one.txt", "two.txt"):
+                Path(name).touch()
+                raw_repo.git.add(name)
+            raw_repo.git.commit("-m", "initial")
+
+            git_repo = GitRepo(InputOutput(), None, None)
+            with patch.object(
+                git_repo,
+                "ignored_file",
+                wraps=git_repo.ignored_file,
+            ) as ignored_file:
+                first = git_repo.get_tracked_files()
+                first.append("caller-mutation.txt")
+                second = git_repo.get_tracked_files()
+
+            self.assertEqual(set(second), {"one.txt", "two.txt"})
+            self.assertEqual(ignored_file.call_count, 2)
+            self.assertIsInstance(git_repo.tracked_files_cache, tuple)
+
+    def test_get_tracked_files_cache_tracks_staging_and_unstaging(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            first = Path("first.txt")
+            first.touch()
+            raw_repo.git.add(str(first))
+            raw_repo.git.commit("-m", "initial")
+
+            git_repo = GitRepo(InputOutput(), None, None)
+            self.assertEqual(git_repo.get_tracked_files(), [str(first)])
+
+            second = Path("second.txt")
+            second.touch()
+            raw_repo.git.add(str(second))
+            self.assertEqual(
+                set(git_repo.get_tracked_files()),
+                {str(first), str(second)},
+            )
+
+            raw_repo.git.reset("HEAD", "--", str(second))
+            self.assertEqual(git_repo.get_tracked_files(), [str(first)])
+
+    def test_get_tracked_files_cache_tracks_aiderignore_lifecycle(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            tracked = Path("tracked.txt")
+            tracked.touch()
+            raw_repo.git.add(str(tracked))
+            raw_repo.git.commit("-m", "initial")
+
+            aiderignore = Path(".aiderignore")
+            git_repo = GitRepo(InputOutput(), None, None, str(aiderignore))
+            self.assertEqual(git_repo.get_tracked_files(), [str(tracked)])
+
+            aiderignore.write_text("tracked.txt\n")
+            git_repo.aider_ignore_last_check = 0
+            self.assertEqual(git_repo.get_tracked_files(), [])
+
+            aiderignore.unlink()
+            git_repo.aider_ignore_last_check = 0
+            self.assertEqual(git_repo.get_tracked_files(), [str(tracked)])
+
+    def test_get_tracked_files_does_not_cache_subtree_only(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            tracked = Path("tracked.txt")
+            tracked.touch()
+            raw_repo.git.add(str(tracked))
+            raw_repo.git.commit("-m", "initial")
+
+            git_repo = GitRepo(InputOutput(), None, None, subtree_only=True)
+            self.assertEqual(git_repo.get_tracked_files(), [str(tracked)])
+            self.assertIsNone(git_repo.tracked_files_cache)
+
+    def test_get_tracked_files_cache_uses_linked_worktree_index(self):
+        with GitTemporaryDirectory():
+            raw_repo = git.Repo()
+            tracked = Path("tracked.txt")
+            tracked.touch()
+            raw_repo.git.add(str(tracked))
+            raw_repo.git.commit("-m", "initial")
+
+            with tempfile.TemporaryDirectory() as parent:
+                linked = Path(parent) / "linked"
+                raw_repo.git.worktree("add", "-b", "cache-test", str(linked))
+                try:
+                    linked_repo = git.Repo(linked)
+                    git_repo = GitRepo(InputOutput(), None, str(linked))
+                    self.assertEqual(git_repo.get_tracked_files(), [str(tracked)])
+
+                    staged = linked / "staged.txt"
+                    staged.touch()
+                    linked_repo.git.add(str(staged.relative_to(linked)))
+                    self.assertEqual(
+                        set(git_repo.get_tracked_files()),
+                        {str(tracked), str(staged.relative_to(linked))},
+                    )
+                finally:
+                    raw_repo.git.worktree("remove", "--force", str(linked))
+
     def test_get_tracked_files_with_new_staged_file(self):
         with GitTemporaryDirectory():
             # new repo


### PR DESCRIPTION
## Summary

- cache unchanged `get_tracked_files()` results using the HEAD, linked-worktree index fingerprint, and `.aiderignore` revision
- return an isolated list to each caller and bypass the cache for `subtree_only`
- prevent staged entries from polluting the cached commit tree and clear ignore state when `.aiderignore` is deleted
- add regression coverage for cache hits, staging/unstaging, ignore lifecycle, linked worktrees, caller mutation, and subtree behavior

## Why

A normal startup reads tracked files three times for repository sanity checking, analytics, and the first coder announcement. The existing tree and ignore caches avoid some underlying work, but each call still enumerates the index and filters the full path set.

The deterministic evaluator records 18 filter checks on current `main` and 6 with this patch, a 66.7% reduction. Same-host diagnostics for the two repeated calls were:

| Repository shape | Tracked files | Before | After | Change |
| --- | ---: | ---: | ---: | ---: |
| Qwen Code checkout | 6,673 | 32.97 ms | 0.237 ms | -99.28% |
| OpenClaw checkout | 23,450 | 140.6-143.7 ms | 0.596 ms | -99.58% |

Timing is hardware-sensitive, so the deterministic filter-count reduction is the primary metric. The first full traversal remains live and unchanged.

## Correctness

The cache key includes the current commit plus the linked-worktree index `mtime`, `ctime`, size, and inode. `.aiderignore` refresh runs before key construction. Cache publication is one atomic tuple, cached tuples are copied before returning, and `subtree_only` retains the uncached path.

The hardening pass also fixed two existing stale-list cases that would make caching unsafe:

- staged new files no longer mutate the cached commit-tree set, so unstaging removes them from the result
- deleting `.aiderignore` clears its parsed rules and per-file ignore cache

## Validation

- `31 passed`: `tests/basic/test_repo.py` and `tests/basic/test_sanity_check_repo.py`
- strict evaluator twice: `startup_filter_checks: 6`, with all invalidation gates passing
- baseline twice: `startup_filter_checks: 18`
- full suite excluding PortAudio-dependent voice tests: `489 passed, 1 skipped, 67 subtests passed`
- `uvx ruff check --fix .` completed; scoped Ruff, Black 23.3.0, Flake8, and `git diff --check` pass
- independent review: no remaining blockers

Evaluator: https://gist.github.com/dexhunter/2ffab8097fdb0596cd87e4a036bf8478

Autoresearch trace: https://dashboard.weco.ai/share/pdxUKJGLSVmX2kwiZGMvrlRvdgCm7Mpk

Fixes #5447

## Risk

The result cache is disabled if the Git index cannot be fingerprinted or when `subtree_only` is active. No public API or CLI behavior changes. The main residual risk is platform-specific index metadata behavior; linked-worktree coverage is included, and any key uncertainty falls back to recomputation rather than caching.
