### PR TITLE
handle LookupError in render_tree when tree-sitter lacks a language binding

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -722,19 +722,22 @@ class RepoMap:
             if not code.endswith("\n"):
                 code += "\n"
 
-            context = TreeContext(
-                rel_fname,
-                code,
-                color=False,
-                line_number=False,
-                child_context=False,
-                last_line=False,
-                margin=0,
-                mark_lois=False,
-                loi_pad=0,
-                # header_max=30,
-                show_top_of_file_parent_scope=False,
-            )
+            try:
+                context = TreeContext(
+                    rel_fname,
+                    code,
+                    color=False,
+                    line_number=False,
+                    child_context=False,
+                    last_line=False,
+                    margin=0,
+                    mark_lois=False,
+                    loi_pad=0,
+                    # header_max=30,
+                    show_top_of_file_parent_scope=False,
+                )
+            except (LookupError, ValueError):
+                return ""
             self.tree_context_cache[rel_fname] = {"context": context, "mtime": mtime}
 
         context = self.tree_context_cache[rel_fname]["context"]

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,6 +4,7 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
 
@@ -271,6 +272,21 @@ print(my_function(3, 4))
             self.assertIn("test_file4.json", result)
 
             # close the open cache files, so Windows won't error
+            del repo_map
+
+    def test_render_tree_handles_lookup_error(self):
+        with IgnorantTemporaryDirectory() as temp_dir:
+            rust_file = os.path.join(temp_dir, "main.rs")
+            with open(rust_file, "w") as f:
+                f.write("fn main() {}\n")
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
+
+            with patch("aider.repomap.TreeContext", side_effect=LookupError("no rust")):
+                result = repo_map.render_tree(rust_file, "main.rs", [0])
+
+            self.assertEqual(result, "")
             del repo_map
 
 


### PR DESCRIPTION
when tree_sitter_language_pack is missing a binding for a file's language, TreeContext raises LookupError and the entire repo map crashes with an unhandled exception. catch LookupError (and ValueError for malformed code) in render_tree and return an empty string so the file is skipped gracefully.

Fixes #5473