### PR TITLE
fix: stop retrying API Timeout errors to prevent terminal spam with local models

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -51,8 +51,8 @@ EXCEPTIONS = [
     ExInfo("UnsupportedParamsError", True, None),
     ExInfo(
         "Timeout",
-        True,
-        "The API provider timed out without returning a response. They may be down or overloaded.",
+        False,
+        "The API provider timed out without returning a response. They may be down or overloaded. Try increasing the timeout with --timeout or try again later.",
     ),
 ]
 


### PR DESCRIPTION
**Fixes #5471 - litellm.Timeout spam with LM Studio local models**

When using a local LM Studio model, timeout errors occur on background API calls (summarizer, repo-map refresh) that compete with the main chat request for the model's attention. Each timeout triggers up to 9 retries with exponential backoff, each printing the error + description + retry message, creating 27+ lines of spam. The summarizer eventually fails with "summarizer unexpectedly failed for all models."

**Changes in `aider/exceptions.py`:**

- Changed `Timeout` exception `retry` from `True` to `False`
- Updated description to suggest `--timeout` flag for users with consistently slow models

For local models, retrying a timeout is pointless (the model is busy processing another request). For cloud APIs, 9 retries with 600s per-attempt timeouts waste ~90 minutes -- failing fast is better UX and users can simply re-send their message.