### PR TITLE
fix: narrow broad exception handling

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -676,14 +676,14 @@ class InputOutput:
 
             except EOFError:
                 raise
+            except UnicodeEncodeError as err:
+                self.tool_error(str(err))
+                return ""
             except Exception as err:
                 import traceback
 
                 self.tool_error(str(err))
                 self.tool_error(traceback.format_exc())
-                return ""
-            except UnicodeEncodeError as err:
-                self.tool_error(str(err))
                 return ""
             finally:
                 if self.file_watcher:

--- a/aider/linter.py
+++ b/aider/linter.py
@@ -178,9 +178,10 @@ def lint_python_compile(fname, code):
     try:
         compile(code, fname, "exec")  # USE TRACEBACK BELOW HERE
         return
-    except Exception as err:
-        end_lineno = getattr(err, "end_lineno", err.lineno)
-        line_numbers = list(range(err.lineno - 1, end_lineno))
+    except (SyntaxError, ValueError, OverflowError) as err:
+        lineno = getattr(err, "lineno", None) or 1
+        end_lineno = getattr(err, "end_lineno", None) or lineno
+        line_numbers = list(range(lineno - 1, end_lineno))
 
         tb_lines = traceback.format_exception(type(err), err, err.__traceback__)
         last_file_i = 0

--- a/benchmark/refactor_tools.py
+++ b/benchmark/refactor_tools.py
@@ -132,8 +132,8 @@ def find_non_self_methods(path):
         with open(filename, "r") as file:
             try:
                 node = ast.parse(file.read(), filename=filename)
-            except:  # noqa: E722
-                pass
+            except (SyntaxError, UnicodeDecodeError):
+                continue
             checker = SelfUsageChecker()
             checker.visit(node)
             for method in checker.non_self_methods:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -173,6 +173,18 @@ class TestInputOutput(unittest.TestCase):
             self.assertEqual(result, "test input")
             mock_input.assert_called_once()
 
+    def test_get_input_handles_unicode_encode_error_without_traceback(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        io.prompt_session = MagicMock()
+        error = UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogates not allowed")
+        io.prompt_session.prompt.side_effect = error
+
+        with patch.object(io, "tool_error") as mock_tool_error:
+            result = io.get_input("", [], [], MagicMock())
+
+        self.assertEqual(result, "")
+        mock_tool_error.assert_called_once_with(str(error))
+
     @patch("builtins.input")
     def test_confirm_ask_explicit_yes_required(self, mock_input):
         io = InputOutput(pretty=False, fancy_input=False)

--- a/tests/basic/test_linter.py
+++ b/tests/basic/test_linter.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from aider.dump import dump  # noqa
-from aider.linter import Linter
+from aider.linter import Linter, lint_python_compile
 
 
 class TestLinter(unittest.TestCase):
@@ -78,6 +78,17 @@ class TestLinter(unittest.TestCase):
             # The result should contain the error message
             self.assertIsNotNone(result)
             self.assertIn("Error message", result.text)
+
+    def test_lint_python_compile_handles_errors_without_line_numbers(self):
+        cases = ["x = 1\0", 'x = "\ud800"']
+
+        for code in cases:
+            with self.subTest(code=repr(code)):
+                result = lint_python_compile("test.py", code)
+
+                self.assertIsNotNone(result)
+                self.assertEqual(result.lines, [0])
+                self.assertTrue(result.text)
 
 
 if __name__ == "__main__":

--- a/tests/basic/test_refactor_tools.py
+++ b/tests/basic/test_refactor_tools.py
@@ -1,0 +1,44 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from benchmark.refactor_tools import find_non_self_methods
+
+
+class TestRefactorTools(unittest.TestCase):
+    def test_find_non_self_methods_skips_invalid_python(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            invalid_file = Path(temp_dir) / "invalid.py"
+            invalid_file.write_text("class Broken(:\n")
+
+            self.assertEqual(find_non_self_methods(str(invalid_file)), [])
+
+    def test_find_non_self_methods_does_not_reuse_stale_ast(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            valid_file = Path(temp_dir) / "valid.py"
+            valid_file.write_text("class Example:\n    def candidate(self):\n        return 1\n")
+            invalid_file = Path(temp_dir) / "invalid.py"
+            invalid_file.write_text("class Broken(:\n")
+
+            with patch(
+                "benchmark.refactor_tools.find_python_files",
+                return_value=[str(valid_file), str(invalid_file)],
+            ):
+                methods = find_non_self_methods(temp_dir)
+
+            self.assertEqual(len(methods), 1)
+            self.assertEqual(methods[0][0], str(valid_file))
+
+    def test_find_non_self_methods_propagates_keyboard_interrupt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_file = Path(temp_dir) / "source.py"
+            source_file.write_text("value = 1\n")
+
+            with patch("benchmark.refactor_tools.ast.parse", side_effect=KeyboardInterrupt):
+                with self.assertRaises(KeyboardInterrupt):
+                    find_non_self_methods(str(source_file))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Fixes** [**#5459**](https://github.com/Aider-AI/aider/issues/5459) **- Exception type too broad in error handling**

Several exception handlers either caught more than they could safely handle or were ordered so that a specific handler could never run. In `benchmark/refactor_tools.py`, a bare `except:` around `ast.parse()` swallowed `KeyboardInterrupt` and continued with an uninitialized or stale AST node. The Python compile linter also assumed every caught exception had a numeric line number, while interactive input handled `UnicodeEncodeError` through the preceding broad `Exception` branch.

**Changes in** **benchmark/refactor_tools.py:**

Replaced the bare `except:` with explicit `SyntaxError` and `UnicodeDecodeError` handling. Files that cannot be parsed are skipped, while `KeyboardInterrupt`, `SystemExit`, and unexpected errors propagate normally.

**Changes in** **aider/linter.py:**

Narrowed compile error handling to the documented compile-time failure types and added safe fallback line numbers for errors that do not provide location metadata.

**Changes in** **aider/io.py:**

Moved the `UnicodeEncodeError` handler before `Exception` so the intended concise encoding fallback is reachable instead of emitting a full traceback.

Regression tests cover invalid Python files, stale AST reuse, `KeyboardInterrupt` propagation, compile errors without line numbers, and the interactive Unicode encoding path.