### PR TITLE
feat: support custom repo-map classes

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -265,6 +265,11 @@ def get_parser(default_config_files, git_root):
         default=2,
         help="Multiplier for map tokens when no files are specified (default: 2)",
     )
+    group.add_argument(
+        "--map-class",
+        metavar="SPEC",
+        help="Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS",
+    )
 
     ##########
     group = parser.add_argument_group("History Files")

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -326,6 +326,7 @@ class Coder:
         total_cost=0.0,
         analytics=None,
         map_refresh="auto",
+        repo_map_class=None,
         cache_prompts=False,
         num_cache_warming_pings=0,
         suggest_shell_commands=True,
@@ -495,7 +496,8 @@ class Coder:
         has_map_prompt = hasattr(self, "gpt_prompts") and self.gpt_prompts.repo_content_prefix
 
         if use_repo_map and self.repo and has_map_prompt:
-            self.repo_map = RepoMap(
+            repo_map_class = repo_map_class or RepoMap
+            self.repo_map = repo_map_class(
                 map_tokens,
                 self.root,
                 self.main_model,

--- a/aider/main.py
+++ b/aider/main.py
@@ -33,6 +33,7 @@ from aider.llm import litellm  # noqa: F401; properly init litellm on launch
 from aider.models import ModelSettings
 from aider.onboarding import offer_openrouter_oauth, select_default_model
 from aider.repo import ANY_GIT_ERROR, GitRepo
+from aider.repomap_loader import load_repo_map_class
 from aider.report import report_uncaught_exceptions
 from aider.versioncheck import check_version, install_from_main_branch, install_upgrade
 from aider.watch import FileWatcher
@@ -970,6 +971,10 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     analytics.event("auto_commits", enabled=bool(args.auto_commits))
 
     try:
+        repo_map_class = None
+        if args.map_class:
+            repo_map_class = load_repo_map_class(args.map_class, root=git_root)
+
         coder = Coder.create(
             main_model=main_model,
             edit_format=args.edit_format,
@@ -994,6 +999,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             summarizer=summarizer,
             analytics=analytics,
             map_refresh=args.map_refresh,
+            repo_map_class=repo_map_class,
             cache_prompts=args.cache_prompts,
             map_mul_no_files=args.map_multiplier_no_files,
             num_cache_warming_pings=args.cache_keepalive_pings,

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -41,6 +41,7 @@ UPDATING_REPO_MAP_MESSAGE = "Updating repo map"
 
 class RepoMap:
     TAGS_CACHE_DIR = f".aider.tags.cache.v{CACHE_VERSION}"
+    TAGS_CACHE_NAMESPACE = None
 
     warned_files = set()
 
@@ -236,7 +237,11 @@ class RepoMap:
         if file_mtime is None:
             return []
 
-        cache_key = fname
+        repo_map_class = type(self)
+        cache_namespace = repo_map_class.__dict__.get("TAGS_CACHE_NAMESPACE")
+        if cache_namespace is None and type(self) is not RepoMap:
+            cache_namespace = f"{repo_map_class.__module__}.{repo_map_class.__qualname__}"
+        cache_key = (cache_namespace, fname) if cache_namespace else fname
         try:
             val = self.TAGS_CACHE.get(cache_key)  # Issue #1308
         except SQLITE_ERRORS as e:

--- a/aider/repomap_loader.py
+++ b/aider/repomap_loader.py
@@ -1,0 +1,104 @@
+import hashlib
+import importlib
+import importlib.util
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from aider.repomap import RepoMap
+
+
+@contextmanager
+def _prepend_sys_path(path):
+    path = str(Path(path).resolve())
+    sys.path.insert(0, path)
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(path)
+        except ValueError:
+            pass
+
+
+def _split_class_spec(spec):
+    module_or_path, separator, class_name = spec.rpartition(":")
+    if not separator or not module_or_path or not class_name:
+        raise ValueError(
+            "Invalid --map-class value. Use MODULE:CLASS or /path/to/file.py:CLASS."
+        )
+    return module_or_path, class_name
+
+
+def _load_module_from_path(path, root=None):
+    path = Path(path).expanduser()
+    if not path.is_absolute():
+        path = Path(root or Path.cwd()) / path
+    path = path.resolve()
+
+    if not path.is_file():
+        raise ValueError(f"Repo map class file does not exist: {path}")
+
+    module_hash = hashlib.sha256(str(path).encode()).hexdigest()[:12]
+    module_name = f"_aider_repo_map_{module_hash}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Unable to load repo map class file: {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        with _prepend_sys_path(path.parent):
+            spec.loader.exec_module(module)
+    except Exception as err:
+        sys.modules.pop(module_name, None)
+        raise ValueError(f"Unable to load repo map class file {path}: {err}") from err
+    return module
+
+
+def load_repo_map_class(class_spec, root=None):
+    """Load and validate a RepoMap subclass from a module or Python file."""
+    module_or_path, class_name = _split_class_spec(class_spec)
+
+    is_path = (
+        module_or_path.endswith(".py") or "/" in module_or_path or "\\" in module_or_path
+    )
+    if is_path:
+        module = _load_module_from_path(module_or_path, root=root)
+    else:
+        try:
+            if root:
+                with _prepend_sys_path(root):
+                    module = importlib.import_module(module_or_path)
+            else:
+                module = importlib.import_module(module_or_path)
+        except Exception as err:
+            raise ValueError(f"Unable to import repo map module {module_or_path}: {err}") from err
+
+    try:
+        repo_map_class = getattr(module, class_name)
+    except AttributeError as err:
+        raise ValueError(
+            f"Repo map class {class_name!r} was not found in {module_or_path!r}."
+        ) from err
+
+    if not isinstance(repo_map_class, type) or not issubclass(repo_map_class, RepoMap):
+        raise ValueError(
+            f"Repo map class {class_name!r} must inherit from aider.repomap.RepoMap."
+        )
+
+    if repo_map_class is not RepoMap:
+        source_file = getattr(module, "__file__", None)
+        try:
+            source_bytes = Path(source_file).read_bytes() if source_file else None
+        except OSError:
+            source_bytes = None
+        if source_bytes is None:
+            source_hash = "unknown"
+        else:
+            source_hash = hashlib.sha256(source_bytes).hexdigest()[:12]
+        repo_map_class.TAGS_CACHE_NAMESPACE = (
+            f"{repo_map_class.__module__}.{repo_map_class.__qualname__}:{source_hash}"
+        )
+
+    return repo_map_class

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -140,6 +140,9 @@
 ## Multiplier for map tokens when no files are specified (default: 2)
 #map-multiplier-no-files: true
 
+## Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS
+#map-class: xxx
+
 ################
 # History Files:
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -129,6 +129,9 @@
 ## Multiplier for map tokens when no files are specified (default: 2)
 #AIDER_MAP_MULTIPLIER_NO_FILES=true
 
+## Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS
+#AIDER_MAP_CLASS=
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -194,6 +194,9 @@ cog.outl("```")
 ## Multiplier for map tokens when no files are specified (default: 2)
 #map-multiplier-no-files: true
 
+## Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS
+#map-class: xxx
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -169,6 +169,9 @@ cog.outl("```")
 ## Multiplier for map tokens when no files are specified (default: 2)
 #AIDER_MAP_MULTIPLIER_NO_FILES=true
 
+## Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS
+#AIDER_MAP_CLASS=
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -38,7 +38,8 @@ usage: aider [-h] [--model] [--openai-api-key] [--anthropic-api-key]
              [--cache-prompts | --no-cache-prompts]
              [--cache-keepalive-pings] [--map-tokens]
              [--map-refresh] [--map-multiplier-no-files]
-             [--input-history-file] [--chat-history-file]
+             [--map-class] [--input-history-file]
+             [--chat-history-file]
              [--restore-chat-history | --no-restore-chat-history]
              [--llm-history-file] [--dark-mode] [--light-mode]
              [--pretty | --no-pretty] [--stream | --no-stream]
@@ -271,6 +272,10 @@ Environment variable: `AIDER_MAP_REFRESH`
 Multiplier for map tokens when no files are specified (default: 2)  
 Default: 2  
 Environment variable: `AIDER_MAP_MULTIPLIER_NO_FILES`  
+
+### `--map-class SPEC`
+Use a custom RepoMap subclass from MODULE:CLASS or /path/to/file.py:CLASS  
+Environment variable: `AIDER_MAP_CLASS`  
 
 ## History Files:
 

--- a/aider/website/docs/repomap.md
+++ b/aider/website/docs/repomap.md
@@ -103,6 +103,37 @@ the ones which are most often referenced by other portions of the code.
 These are the key pieces of context that the LLM needs to know to understand
 the overall codebase.
 
+## Customizing the repo map
+
+You can customize repo map generation by subclassing `RepoMap` and overriding
+its `get_tags()` method. For example, save this as `custom_map.py` in the root
+of your repository:
+
+```python
+from aider.repomap import RepoMap
+
+
+class CustomRepoMap(RepoMap):
+    def get_tags(self, fname, rel_fname):
+        tags = super().get_tags(fname, rel_fname)
+        # Return the default tags, modified or extended for your project.
+        return tags
+```
+
+Load the class with:
+
+```bash
+aider --map-class custom_map.py:CustomRepoMap
+```
+
+Relative file paths are resolved from the git repository root. You can also
+load an importable Python module:
+
+```bash
+aider --map-class my_package.maps:CustomRepoMap
+```
+
+Custom repo map files execute as Python code, so only load files you trust.
 
 ## More info
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -596,6 +596,49 @@ class TestMain(TestCase):
                 )
                 MockRepoMap.assert_called_once()
 
+    def test_map_class_option(self):
+        with GitTemporaryDirectory():
+            custom_map = Path("custom_map.py")
+            custom_map.write_text(
+                "from aider.repomap import RepoMap\n"
+                "\n"
+                "class CustomRepoMap(RepoMap):\n"
+                "    pass\n"
+            )
+
+            coder = main(
+                [
+                    "--map-class",
+                    "custom_map.py:CustomRepoMap",
+                    "--map-tokens",
+                    "1000",
+                    "--exit",
+                    "--yes",
+                ],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+
+            self.assertEqual(coder.repo_map.__class__.__name__, "CustomRepoMap")
+
+    def test_map_class_option_reports_invalid_class(self):
+        with GitTemporaryDirectory():
+            result = main(
+                [
+                    "--map-class",
+                    "pathlib:Path",
+                    "--map-tokens",
+                    "1000",
+                    "--exit",
+                    "--yes",
+                ],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+
+            self.assertEqual(result, 1)
+
     def test_read_option(self):
         with GitTemporaryDirectory():
             test_file = "test_file.txt"

--- a/tests/basic/test_repomap_loader.py
+++ b/tests/basic/test_repomap_loader.py
@@ -1,0 +1,97 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from aider.io import InputOutput
+from aider.repomap import RepoMap
+from aider.repomap_loader import load_repo_map_class
+
+
+class TestRepoMapLoader(unittest.TestCase):
+    def test_load_class_from_relative_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_path = Path(temp_dir) / "custom_map.py"
+            module_path.write_text(
+                "from aider.repomap import RepoMap\n"
+                "\n"
+                "class CustomRepoMap(RepoMap):\n"
+                "    pass\n"
+            )
+
+            repo_map_class = load_repo_map_class(
+                "custom_map.py:CustomRepoMap", root=temp_dir
+            )
+
+            self.assertTrue(issubclass(repo_map_class, RepoMap))
+            self.assertEqual(repo_map_class.__name__, "CustomRepoMap")
+
+    def test_load_class_from_module(self):
+        repo_map_class = load_repo_map_class("aider.repomap:RepoMap")
+
+        self.assertIs(repo_map_class, RepoMap)
+
+    def test_load_module_relative_to_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_path = Path(temp_dir) / "root_map.py"
+            module_path.write_text(
+                "from aider.repomap import RepoMap\n"
+                "\n"
+                "class RootRepoMap(RepoMap):\n"
+                "    pass\n"
+            )
+
+            repo_map_class = load_repo_map_class(
+                "root_map:RootRepoMap", root=temp_dir
+            )
+
+            self.assertEqual(repo_map_class.__name__, "RootRepoMap")
+
+    def test_reject_invalid_spec(self):
+        with self.assertRaisesRegex(ValueError, "MODULE:CLASS"):
+            load_repo_map_class("custom_map.py")
+
+    def test_reject_missing_file(self):
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            load_repo_map_class("missing.py:CustomRepoMap")
+
+    def test_reject_missing_class(self):
+        with self.assertRaisesRegex(ValueError, "was not found"):
+            load_repo_map_class("aider.repomap:MissingRepoMap")
+
+    def test_reject_non_repo_map_class(self):
+        with self.assertRaisesRegex(ValueError, "must inherit"):
+            load_repo_map_class("pathlib:Path")
+
+    def test_custom_classes_use_separate_tag_caches(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source_file = root / "source.py"
+            source_file.write_text("value = 1\n")
+
+            for module_name, tag_name in (("first_map", "first"), ("second_map", "second")):
+                (root / f"{module_name}.py").write_text(
+                    "from aider.repomap import RepoMap, Tag\n"
+                    "\n"
+                    "class CustomRepoMap(RepoMap):\n"
+                    "    def get_tags_raw(self, fname, rel_fname):\n"
+                    f"        yield Tag(rel_fname, fname, 0, {tag_name!r}, 'def')\n"
+                )
+
+            first_class = load_repo_map_class(
+                "first_map.py:CustomRepoMap", root=temp_dir
+            )
+            second_class = load_repo_map_class(
+                "second_map.py:CustomRepoMap", root=temp_dir
+            )
+            first_map = first_class(root=temp_dir, io=InputOutput())
+            second_map = second_class(root=temp_dir, io=InputOutput())
+
+            try:
+                first_tags = first_map.get_tags(str(source_file), source_file.name)
+                second_tags = second_map.get_tags(str(source_file), source_file.name)
+            finally:
+                first_map.TAGS_CACHE.close()
+                second_map.TAGS_CACHE.close()
+
+            self.assertEqual([tag.name for tag in first_tags], ["first"])
+            self.assertEqual([tag.name for tag in second_tags], ["second"])


### PR DESCRIPTION
Fixes **#4021** - Custom repo-map hooks

Aider currently hard-codes `RepoMap` construction inside the coder, so users cannot customize repository map generation without modifying aider's source. This prevents projects from extending tag selection and rendering for project-specific structures, such as including the fields of small models referenced from `models.py`.

Changes in `aider/repomap_loader.py`, `aider/coders/base_coder.py`, and `aider/repomap.py`:
The new `--map-class` option loads a trusted `RepoMap` subclass from either `MODULE:CLASS` or `path/to/file.py:CLASS`, resolves relative paths from the git repository root, validates that the loaded class inherits from `RepoMap`, and injects it during coder creation. Custom tag caches are namespaced by class and source hash so default and custom implementations cannot reuse stale entries.

The repo-map documentation, generated option reference, YAML sample, and dotenv sample now describe the new configuration. Tests cover file and module loading, relative paths, invalid specifications, CLI integration, and cache isolation. The related repo-map and main test suites pass.

Closes #4021