### PR TITLE
fix: normalize OPENAI_API_BASE by stripping trailing /chat/completions

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -618,7 +618,18 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     # Handle deprecated model shortcut args
     handle_deprecated_model_args(args, io)
     if args.openai_api_base:
-        os.environ["OPENAI_API_BASE"] = args.openai_api_base
+        # Normalize OPENAI_API_BASE by stripping trailing /chat/completions to
+        # prevent double-pathing. litellm/openai library appends /chat/completions
+        # to the base URL, so users should NOT include it in --openai-api-base.
+        # This catches common mistakes like:
+        #   .../v1/chat/completions        ->  .../v1
+        #   .../openai/chat/completions    ->  .../openai
+        #   .../compat/chat/completions    ->  .../compat
+        base_url = args.openai_api_base.rstrip("/")
+        chat_completions_suffix = "/chat/completions"
+        if base_url.endswith(chat_completions_suffix):
+            base_url = base_url[: -len(chat_completions_suffix)]
+        os.environ["OPENAI_API_BASE"] = base_url
     if args.openai_api_version:
         io.tool_warning(
             "--openai-api-version is deprecated, use --set-env OPENAI_API_VERSION=<value>"


### PR DESCRIPTION
**Fixes #5468 - Can't connect Cloudflare gateway**

When users set `--openai-api-base`, they commonly include the full endpoint path (`/chat/completions`, `/openai/chat/completions`, `/compat/chat/completions`). But litellm's openai library appends `/chat/completions` to the base URL, creating double-path URLs like `.../chat/completions/chat/completions`.

**Changes in `aider/main.py`:**

Added URL normalization for `OPENAI_API_BASE` — strips trailing `/chat/completions` so:
- `.../compat/chat/completions` → `.../compat` → litellm produces `.../compat/chat/completions` ✓
- `.../openai/chat/completions` → `.../openai` → litellm produces `.../openai/chat/completions` ✓
- `.../v1/chat/completions` → `.../v1` → litellm produces `.../v1/chat/completions` ✓

This fixes Cloudflare Gateway connections and any other OpenAI-compatible proxy where users include the full endpoint path.