### PR TITLE
docs: fixed dev requirements path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ If you need to mock or create test data, consider adding it to the test files or
 The project uses `pytest` as the testing framework, which is installed as a development dependency. To install the development dependencies, run the following command:
 
 ```
-pip install -r requirements-dev.txt
+pip install -r requirements/requirements-dev.txt
 ```
 
 ### Managing Dependencies


### PR DESCRIPTION
#### summary

Fixed the development requirements install command in CONTRIBUTING.md to point to
the existing requirements/requirements-dev.txt file.

The command was in #### Test Requirements section

#### Testing

change in docs only.