### PR TITLE
docs: document Anthropic-compatible API endpoints

### DIFF
--- a/aider/website/docs/llms/anthropic.md
+++ b/aider/website/docs/llms/anthropic.md
@@ -45,6 +45,34 @@ You can use `aider --model <model-name>` to use any other Anthropic model.
 For example, if you want to use a specific version of Opus
 you could do `aider --model claude-3-opus-20240229`.
 
+## Anthropic-compatible endpoints
+
+Aider can also connect to third-party providers that implement the Anthropic Messages API.
+Set `ANTHROPIC_API_BASE` to the provider's root URL, without `/v1/messages`, and set
+`ANTHROPIC_API_KEY` to the key issued by that provider.
+
+For example, to connect to [apiToken.sale](https://apitoken.sale):
+
+```
+# Mac/Linux
+export ANTHROPIC_API_BASE=https://api.apitoken.sale
+export ANTHROPIC_API_KEY=<provider-key>
+
+# Windows, restart shell after setx
+setx ANTHROPIC_API_BASE https://api.apitoken.sale
+setx ANTHROPIC_API_KEY <provider-key>
+```
+
+Use an `anthropic/` model name when starting aider:
+
+```bash
+aider --model anthropic/claude-sonnet-4-6
+```
+
+{: .note }
+apiToken.sale is a third-party provider, not an Anthropic service, and its keys are not
+issued by Anthropic. Review the provider's terms and data-handling policies before use.
+
 ## Thinking tokens
 
 Aider can work with Sonnet 3.7's new thinking tokens, but does not ask Sonnet to use


### PR DESCRIPTION
## Summary

Document how Aider can connect to third-party endpoints that implement the Anthropic Messages API by setting `ANTHROPIC_API_BASE`, with apiToken.sale as a tested example.

This uses Aider's existing `anthropic/` model path and the current LiteLLM integration; no application code or provider-specific routing is added. This documentation contribution was AI-assisted and manually validated.

## Changes

- explain that `ANTHROPIC_API_BASE` takes the provider root URL without `/v1/messages`
- add Mac/Linux and Windows environment examples
- show an explicit `anthropic/claude-sonnet-4-6` launch command
- clarify that apiToken.sale is a third-party service and its keys are not Anthropic-issued

## Validation

- `git diff --check`
- `codespell aider/website/docs/llms/anthropic.md`
- production Jekyll build with Ruby 3.3
- rendered callout, heading, code blocks, and link inspected in the generated HTML
- `https://apitoken.sale` returned HTTP 200

## Proof of working

Tested from current Aider `main` (`5dc9490b`) with its pinned LiteLLM 1.82.3 and a provider-issued test key supplied only through the process environment:

- Aider v0.86.3.dev53 connected through `https://api.apitoken.sale` using `anthropic/claude-sonnet-4-6`
- streaming edit completed and Aider applied the requested change to a temporary file
- basic, streaming, and forced tool-use calls through the pinned LiteLLM dependency all completed successfully

No credentials, response contents, or temporary test files are included in this PR.
