### PR TITLE
fix: don't crash on startup when ~/.aider/oauth-keys.env is unreadable (issue #5462)

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -368,11 +368,14 @@ def load_dotenv_files(git_root, dotenv_fname, encoding="utf-8"):
 
     # Explicitly add the OAuth keys file to the beginning of the list
     oauth_keys_file = Path.home() / ".aider" / "oauth-keys.env"
-    if oauth_keys_file.exists():
-        # Insert at the beginning so it's loaded first (and potentially overridden)
-        dotenv_files.insert(0, str(oauth_keys_file.resolve()))
-        # Remove duplicates if it somehow got included by generate_search_path_list
-        dotenv_files = list(dict.fromkeys(dotenv_files))
+    try:
+        if oauth_keys_file.exists():
+            # Insert at the beginning so it's loaded first (and potentially overridden)
+            dotenv_files.insert(0, str(oauth_keys_file.resolve()))
+            # Remove duplicates if it somehow got included by generate_search_path_list
+            dotenv_files = list(dict.fromkeys(dotenv_files))
+    except OSError as e:
+        print(f"OSError checking {oauth_keys_file}: {e}")
 
     loaded = []
     for fname in dotenv_files:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -58,6 +58,17 @@ class TestMain(TestCase):
         main(["--yes", "foo.txt", "--exit"], input=DummyInput(), output=DummyOutput())
         self.assertTrue(os.path.exists("foo.txt"))
 
+    def test_load_dotenv_files_unreadable_oauth_keys(self):
+        """Unreadable ~/.aider/oauth-keys.env should not crash startup (#5462)."""
+        with GitTemporaryDirectory() as git_dir:
+            git_dir = Path(git_dir)
+            fake_home = git_dir / "fake_home"
+            fake_home.mkdir()
+            os.environ["HOME"] = str(fake_home)
+            with patch("aider.main.Path.exists", side_effect=PermissionError("denied")):
+                loaded = load_dotenv_files(git_dir, None)
+            self.assertEqual(loaded, [])
+
     @patch("aider.repo.GitRepo.get_commit_message", return_value="mock commit message")
     def test_main_with_empty_git_dir_new_files(self, _):
         make_repo()


### PR DESCRIPTION
## Summary

Fixes #5462 — aider crashes on startup with an uncaught `PermissionError` when the OAuth keys file `~/.aider/oauth-keys.env` cannot be stat'ed (e.g. an unreadable home directory in a Docker/container mount, a root-owned `~/.aider`, or a Windows ACL-denied path).

## Root cause

`pathlib.Path.exists()` only swallows `OSError` errnos in `_IGNORED_ERRNOS` (`ENOENT`, `ENOTDIR`, `EBADF`, `ENAMETOOLONG`) and re-raises `EACCES` as `PermissionError`. `load_dotenv_files()` is called unconditionally on every startup (`main.py`), and the OAuth-keys check was the only `Path` access in that function not guarded by `try/except OSError` — the surrounding `.resolve()` calls and the `.env` load loop already handle this case.

## Change

- Wrap the `oauth_keys_file.exists()` check in `try/except OSError`, logging and continuing — matching the existing pattern a few lines below in the same function.
- Add `test_load_dotenv_files_unreadable_oauth_keys` which reproduces the exact crash (fails with `PermissionError` at `main.py:371` pre-fix) and asserts startup continues cleanly post-fix.

## Validation

- New test fails without the fix with the same `PermissionError` as issue #5462; passes with the fix.
- `python -m pytest tests/basic/test_main.py -q` → **77 passed**.
