### PR TITLE
fix(repo): use GitPython default object database

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -121,8 +121,7 @@ class GitRepo:
             self.io.tool_error("Files are in different git repos.")
             raise FileNotFoundError
 
-        # https://github.com/gitpython-developers/GitPython/issues/427
-        self.repo = git.Repo(repo_paths.pop(), odbt=git.GitDB)
+        self.repo = git.Repo(repo_paths.pop())
         self.root = utils.safe_abs_path(self.repo.working_tree_dir)
 
         if aider_ignore_file:

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -19,6 +19,12 @@ class TestRepo(unittest.TestCase):
     def setUp(self):
         self.GPT35 = Model("gpt-3.5-turbo")
 
+    def test_uses_default_git_object_database(self):
+        with GitTemporaryDirectory():
+            git_repo = GitRepo(InputOutput(), None, ".")
+
+            self.assertIsInstance(git_repo.repo.odb, git.GitCmdObjectDB)
+
     def test_diffs_empty_repo(self):
         with GitTemporaryDirectory():
             repo = git.Repo()


### PR DESCRIPTION
Fixes #5501

Aider forced GitPython’s pure-Python `GitDB` backend when opening the final `GitRepo`, which can report `BadObject` for repositories that Git itself and GitPython’s default `GitCmdObjectDB` backend read successfully. This removes that outdated override so the final repository handle uses the same default backend as Aider’s repository discovery path.

The old override referenced GitPython #427, a 2016 `BrokenPipeError` report that is now closed. The current dependency is GitPython 3.1.46.

Added a regression test that asserts `GitRepo` uses `GitCmdObjectDB`.

Validation:

- GitPython 3.1.46: verified the default is `GitCmdObjectDB`, while the old override selects `GitDB`.
- `env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL .venv/bin/python -m pytest tests/basic/test_repo.py -q` (22 passed)
- `.venv/bin/pre-commit run --files aider/repo.py tests/basic/test_repo.py`
- `git diff --check`