### PR TITLE
fix: correct o1-mini leaderboard well-formed rate

### DIFF
--- a/aider/website/_data/edit_leaderboard.yml
+++ b/aider/website/_data/edit_leaderboard.yml
@@ -1074,7 +1074,7 @@
   commit_hash: 36fa773-dirty, 291b456
   pass_rate_1: 49.6
   pass_rate_2: 70.7
-  percent_cases_well_formed: 90.0
+  percent_cases_well_formed: 100.0
   error_outputs: 0
   num_malformed_responses: 0
   num_with_malformed_responses: 0


### PR DESCRIPTION
Fixes #5508

Correct the `o1-mini (whole)` result to report `100.0` percent well-formed responses. The row has zero `num_with_malformed_responses` across 133 test cases, matching the calculation in `benchmark/benchmark.py`.

This deliberately leaves the incomplete-run `pass_rate_2` denominator question in #5508 unchanged because it needs a maintainer decision.

Validation:
- Parsed `aider/website/_data/edit_leaderboard.yml` with PyYAML and recomputed the target row from its stored fields.
- `git diff --check`

AI assistance: Codex assisted with implementing and validating this focused data correction.