### PR TITLE
Don't double-bill cached tokens in the cost fallback

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -2074,27 +2074,26 @@ class Coder:
 
         input_cost_per_token = self.main_model.info.get("input_cost_per_token") or 0
         output_cost_per_token = self.main_model.info.get("output_cost_per_token") or 0
-        input_cost_per_token_cache_hit = (
-            self.main_model.info.get("input_cost_per_token_cache_hit") or 0
+        cache_write_cost_per_token = (
+            self.main_model.info.get("cache_creation_input_token_cost")
+            or input_cost_per_token * 1.25
+        )
+        cache_hit_cost_per_token = (
+            self.main_model.info.get("cache_read_input_token_cost")
+            or self.main_model.info.get("input_cost_per_token_cache_hit")
+            or input_cost_per_token * 0.10
         )
 
-        # deepseek
-        # prompt_cache_hit_tokens + prompt_cache_miss_tokens
-        #    == prompt_tokens == total tokens that were sent
-        #
-        # Anthropic
-        # cache_creation_input_tokens + cache_read_input_tokens + prompt
-        #    == total tokens that were
+        # prompt_tokens is the total input, with both cache classes included:
+        # deepseek reports prompt_cache_hit_tokens + prompt_cache_miss_tokens
+        #    == prompt_tokens, and litellm folds Anthropic's
+        # cache_creation_input_tokens and cache_read_input_tokens into
+        # prompt_tokens as well. Only the remainder is billed at the full rate.
+        uncached_tokens = max(0, prompt_tokens - cache_write_tokens - cache_hit_tokens)
 
-        if input_cost_per_token_cache_hit:
-            # must be deepseek
-            cost += input_cost_per_token_cache_hit * cache_hit_tokens
-            cost += (prompt_tokens - input_cost_per_token_cache_hit) * input_cost_per_token
-        else:
-            # hard code the anthropic adjustments, no-ops for other models since cache_x_tokens==0
-            cost += cache_write_tokens * input_cost_per_token * 1.25
-            cost += cache_hit_tokens * input_cost_per_token * 0.10
-            cost += prompt_tokens * input_cost_per_token
+        cost += cache_write_tokens * cache_write_cost_per_token
+        cost += cache_hit_tokens * cache_hit_cost_per_token
+        cost += uncached_tokens * input_cost_per_token
 
         cost += completion_tokens * output_cost_per_token
         return cost

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,89 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_compute_costs_from_tokens_uncached(self):
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+        }
+
+        cost = coder.compute_costs_from_tokens(1000, 100, 0, 0)
+        self.assertAlmostEqual(cost, 1000 * 1e-06 + 100 * 5e-06)
+
+    def test_compute_costs_from_tokens_anthropic_cache_hit(self):
+        # https://github.com/Aider-AI/aider/issues/5516
+        # litellm folds cache_read_input_tokens into prompt_tokens, so the
+        # cached tokens must not also be billed at the full input rate
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+            "cache_creation_input_token_cost": 1.25e-06,
+            "cache_read_input_token_cost": 1e-07,
+        }
+
+        cost = coder.compute_costs_from_tokens(17111, 0, 0, 17102)
+        self.assertAlmostEqual(cost, 17102 * 1e-07 + 9 * 1e-06)
+
+    def test_compute_costs_from_tokens_anthropic_cache_write(self):
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+            "cache_creation_input_token_cost": 1.25e-06,
+            "cache_read_input_token_cost": 1e-07,
+        }
+
+        cost = coder.compute_costs_from_tokens(17111, 0, 17102, 0)
+        self.assertAlmostEqual(cost, 17102 * 1.25e-06 + 9 * 1e-06)
+
+    def test_compute_costs_from_tokens_anthropic_multiplier_fallback(self):
+        # model info without explicit cache prices falls back to the
+        # 1.25x write and 0.10x read multipliers
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+        }
+
+        cost = coder.compute_costs_from_tokens(1000, 0, 600, 300)
+        self.assertAlmostEqual(cost, 600 * 1e-06 * 1.25 + 300 * 1e-06 * 0.10 + 100 * 1e-06)
+
+    def test_compute_costs_from_tokens_deepseek_cache_hit(self):
+        # deepseek reports prompt_cache_hit_tokens + prompt_cache_miss_tokens
+        # == prompt_tokens; the old code subtracted the cache-hit *price* from
+        # prompt_tokens instead of the cache-hit token count
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+            "input_cost_per_token_cache_hit": 1e-07,
+        }
+
+        cost = coder.compute_costs_from_tokens(10000, 0, 0, 9000)
+        self.assertAlmostEqual(cost, 9000 * 1e-07 + 1000 * 1e-06)
+
+    def test_compute_costs_from_tokens_never_negative(self):
+        # a provider reporting cache classes inconsistently must not
+        # produce a negative uncached remainder
+        io = InputOutput(yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        coder.main_model.info = {
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 5e-06,
+            "cache_creation_input_token_cost": 1.25e-06,
+            "cache_read_input_token_cost": 1e-07,
+        }
+
+        cost = coder.compute_costs_from_tokens(100, 0, 0, 500)
+        self.assertAlmostEqual(cost, 500 * 1e-07)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #5516

`compute_costs_from_tokens` is the fallback used when `litellm.completion_cost()` throws or returns nothing. Both of its branches overstate the cost of cached requests:

- The Anthropic branch charges the cache write and read tokens at their adjusted rates and then bills the full `prompt_tokens` on top. But litellm folds `cache_creation_input_tokens` and `cache_read_input_tokens` into `prompt_tokens`, so every cached token is billed twice — a fully cached call reports roughly 10.9x the real cost.
- The deepseek branch computes `prompt_tokens - input_cost_per_token_cache_hit`, subtracting a per-token price (~2.8e-08) from a token count. That's a no-op, so the whole prompt is billed at the full input rate on top of the cache-hit charge.

This replaces both branches with a single calculation: price the cache classes from the model info (`cache_creation_input_token_cost` / `cache_read_input_token_cost`, falling back to `input_cost_per_token_cache_hit` and then the old 1.25x / 0.10x multipliers) and bill only the uncached remainder at the full input rate. The remainder is clamped at zero so a provider reporting the cache classes inconsistently produces a slightly wrong number rather than a negative one.

Added tests for the uncached, Anthropic cache-read, cache-write, fallback-multiplier, deepseek and clamping cases. The cache-read and deepseek cases fail against the old code.