### PR TITLE
Set AI_AGENT for subprocesses

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -40,6 +40,11 @@ from aider.watch import FileWatcher
 from .dump import dump  # noqa: F401
 
 
+def set_ai_agent_env():
+    if not os.environ.get("AI_AGENT", "").strip():
+        os.environ["AI_AGENT"] = "aider"
+
+
 def check_config_files_for_yes(config_files):
     found = False
     for config_file in config_files:
@@ -596,6 +601,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
                 io.tool_error(f"Invalid --set-env format: {env_setting}")
                 io.tool_output("Format should be: ENV_VAR_NAME=value")
                 return 1
+
+    set_ai_agent_env()
 
     # Process any API keys set via --api-key
     if args.api_key:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -15,6 +15,7 @@ from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import check_gitignore, load_dotenv_files, main, setup_git
+from aider.main import set_ai_agent_env
 from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory, make_repo
 
 
@@ -44,6 +45,20 @@ class TestMain(TestCase):
         os.environ.update(self.original_env)
         self.input_patcher.stop()
         self.webbrowser_patcher.stop()
+
+    def test_set_ai_agent_env_defaults_to_aider(self):
+        os.environ.pop("AI_AGENT", None)
+
+        set_ai_agent_env()
+
+        self.assertEqual(os.environ["AI_AGENT"], "aider")
+
+    def test_set_ai_agent_env_preserves_explicit_value(self):
+        os.environ["AI_AGENT"] = "wrapper"
+
+        set_ai_agent_env()
+
+        self.assertEqual(os.environ["AI_AGENT"], "wrapper")
 
     def test_main_with_empty_dir_no_files_on_command(self):
         main(["--no-git", "--exit", "--yes"], input=DummyInput(), output=DummyOutput())


### PR DESCRIPTION
## Summary

- Set `AI_AGENT=aider` after dotenv and `--set-env` processing so all later subprocesses inherit the marker.
- Preserve any explicit non-empty value supplied by a user or wrapper.
- Add focused tests for the default and override behavior.

## Why a universal marker

The process launching a tool knows its agent identity exactly. Without a common marker, every downstream CLI must maintain product-specific environment and parent-process heuristics just to select agent-friendly behavior such as JSON output, no pager, quiet progress, or no prompts. `AI_AGENT` turns that growing N-by-M integration problem into one stable convention: agents write a slug and tools read one variable.

This value is advisory metadata for user experience only, not an authorization, sandbox, policy, or trust signal. Preserving an existing non-empty value also lets orchestrators and nested agent wrappers retain the outer identity they intentionally selected.

## Verification

- `ruff check aider/main.py tests/basic/test_main.py`
- `python3 -m py_compile aider/main.py tests/basic/test_main.py`
- `git diff --check`
- Focused pytest collection was attempted, but this isolated checkout does not have the project's `GitPython` test dependency installed (`ModuleNotFoundError: git`).
