### PR TITLE
Detect unified diffs in whole-file mode

### DIFF
--- a/aider/coders/wholefile_coder.py
+++ b/aider/coders/wholefile_coder.py
@@ -7,6 +7,22 @@ from .base_coder import Coder
 from .wholefile_prompts import WholeFilePrompts
 
 
+def _looks_like_unified_diff(content):
+    saw_old_file = False
+    saw_new_file = False
+
+    for line in content.splitlines():
+        if line.startswith("--- a/") or line == "--- /dev/null":
+            saw_old_file = True
+            saw_new_file = False
+        elif saw_old_file and (line.startswith("+++ b/") or line == "+++ /dev/null"):
+            saw_new_file = True
+        elif saw_new_file and line.startswith("@@ -"):
+            return True
+
+    return False
+
+
 class WholeFileCoder(Coder):
     """A coder that operates on entire files for code modifications."""
 
@@ -118,6 +134,14 @@ class WholeFileCoder(Coder):
 
                 seen.add(fname)
                 refined_edits.append((fname, fname_source, new_lines))
+
+        if not refined_edits and _looks_like_unified_diff(content):
+            raise ValueError(
+                f"Expected whole-file edits from {self.main_model.name}, but received a unified "
+                "diff; no changes were applied. Retry with complete file contents. If this model "
+                "consistently returns diffs, use `--edit-format diff` or set `edit_format: diff` "
+                "in `.aider.model.settings.yml`."
+            )
 
         return refined_edits
 

--- a/tests/basic/test_wholefile.py
+++ b/tests/basic/test_wholefile.py
@@ -73,6 +73,53 @@ class TestWholeFileCoder(unittest.TestCase):
             updated_content = f.read()
         self.assertEqual(updated_content, "Updated content\n")
 
+    def test_reports_unified_diff_in_whole_mode(self):
+        sample_file = Path("sample.py")
+        sample_file.write_text('print("old")\n')
+
+        io = InputOutput(yes=True)
+        coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=[str(sample_file)])
+
+        coder.partial_response_content = """--- a/sample.py
++++ b/sample.py
+@@ -1 +1 @@
+-print("old")
++print("new")
+"""
+
+        coder.apply_updates()
+
+        self.assertEqual(sample_file.read_text(), 'print("old")\n')
+        self.assertEqual(coder.num_malformed_responses, 1)
+        reflected_message = coder.reflected_message.lower()
+        self.assertIn("gpt-3.5-turbo", reflected_message)
+        self.assertIn("expected whole-file edits", reflected_message)
+        self.assertIn("unified diff", reflected_message)
+        self.assertIn("no changes were applied", reflected_message)
+        self.assertIn("retry with complete file contents", reflected_message)
+        self.assertIn("--edit-format diff", reflected_message)
+        self.assertIn(".aider.model.settings.yml", reflected_message)
+
+    def test_get_edits_rejects_unified_diff(self):
+        io = InputOutput(yes=True)
+        coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=["sample.py"])
+        coder.partial_response_content = """--- a/sample.py
++++ b/sample.py
+@@ -1 +1 @@
+-print("old")
++print("new")
+"""
+
+        with self.assertRaisesRegex(ValueError, "received a unified diff"):
+            coder.get_edits()
+
+    def test_get_edits_allows_no_edit_response(self):
+        io = InputOutput(yes=True)
+        coder = WholeFileCoder(main_model=self.GPT35, io=io, fnames=["sample.py"])
+        coder.partial_response_content = "No changes are needed."
+
+        self.assertEqual(coder.get_edits(), [])
+
     def test_update_files_live_diff(self):
         # Create a sample file in the temporary directory
         sample_file = "sample.txt"


### PR DESCRIPTION
## Fixes #5486

## Summary
  - detect unified-diff-shaped responses when whole-file parsing produces no edits
  - report the mismatch through Aider's existing malformed-response path
  - avoid automatically applying an unexpected edit format
  - provide actionable retry and configuration guidance
  - add regression and no-change boundary tests

## Testing
  - `pytest tests/basic/test_wholefile.py -q`
  - `pytest tests/basic/test_coder.py -q`
  - `pre-commit run --all-files`