### PR TITLE
Fix /drop command failing to match filenames containing [ ] brackets

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -946,14 +946,15 @@ class Commands:
                 self.coder.abs_read_only_fnames.remove(matched_file)
                 self.io.tool_output(f"Removed read-only file {matched_file} from the chat")
 
-            # For editable files, use glob if word contains glob chars, otherwise use substring
-            if any(c in expanded_word for c in "*?[]"):
-                matched_files = self.glob_filtered_to_repo(expanded_word)
+            # Try literal substring match first so filenames containing [ ] (e.g. Next.js
+            # dynamic routes like [id]/page.tsx) are matched without glob interpretation.
+            literal_matched = [
+                self.coder.get_rel_fname(f) for f in self.coder.abs_fnames if expanded_word in f
+            ]
+            if literal_matched or not any(c in expanded_word for c in "*?[]"):
+                matched_files = literal_matched
             else:
-                # Use substring matching like we do for read-only files
-                matched_files = [
-                    self.coder.get_rel_fname(f) for f in self.coder.abs_fnames if expanded_word in f
-                ]
+                matched_files = self.glob_filtered_to_repo(expanded_word)
 
             if not matched_files:
                 matched_files.append(expanded_word)


### PR DESCRIPTION
When a file path contains `[` or `]` characters (common in Next.js dynamic routes like `src/app/[id]/page.tsx`), the `/drop` command incorrectly treats the name as a glob pattern, causing `Path.glob()` to misinterpret `[id]` as a character class and fail to find the file. This fix tries a literal substring match first and only falls back to glob expansion when no literal match exists and the word genuinely contains glob metacharacters. Fixes #2616